### PR TITLE
Add knowledge graph CLI and SQLite storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { createLocalKnowledgeGraphService } from "../../libs/knowledge-graph/service.js";
+import type { MemoryCommitProposal } from "../../libs/knowledge-graph/proposal.js";
+import { detectRepoContext } from "./repo-context.js";
+
+async function main(argv: string[]): Promise<void> {
+  const [area, action, ...rest] = argv;
+  const service = createLocalKnowledgeGraphService();
+
+  if (area === "init" && action === undefined) {
+    const repo = detectRepoContext();
+    const result = service.initRepo(repo);
+    console.log(result.created ? "Initialized engineering context memory." : "Engineering context memory already initialized.");
+    console.log(`Repo: ${repo.repo_name}`);
+    console.log(`Remote: ${repo.remote_url}`);
+    console.log(`Default branch: ${repo.default_branch}`);
+    console.log(`Database: ${result.database_path}`);
+    console.log(`Main scope: ${result.main_scope_id}`);
+    console.log(`Working scope: ${result.working_scope_id}`);
+    return;
+  }
+
+  if (area === "graph" && action === "read") {
+    const repo = detectRepoContext();
+    const graph = service.readGraph(repo);
+    console.log("Current graph view: main + working");
+    printSection("Components", graph.components, (item) => `${named(item)} ${anchor(item)}`.trim());
+    printSection("Flows", graph.flows, named);
+    printSection("Claims", graph.claims, (item) => `${field(item, "kind")}: ${field(item, "text")}`);
+    printSection("Sources", graph.sources, (item) => `${field(item, "kind")}: ${field(item, "title") || field(item, "ref")}`);
+    printSection("Edges", graph.edges, (item) => `${field(item, "from_type")}:${field(item, "from_id")} -[${field(item, "kind")}]-> ${field(item, "to_type")}:${field(item, "to_id")}`);
+    return;
+  }
+
+  if (area === "graph" && action === "search") {
+    const query = rest.join(" ").trim();
+    if (query.length === 0) throw new Error("Usage: ec graph search <query>");
+    const repo = detectRepoContext();
+    const results = service.searchGraph(repo, query);
+    if (results.length === 0) {
+      console.log("No matching memory found.");
+      return;
+    }
+    console.log(`Found ${results.length} result(s):`);
+    for (const result of results) {
+      console.log(`- ${result.type}:${result.id} ${result.label}`);
+      if (result.text.length > 0) console.log(`  ${result.text}`);
+    }
+    return;
+  }
+
+  if (area === "proposal" && action === "validate") {
+    const file = requireFile(rest[0], "Usage: ec proposal validate <file>");
+    const repo = detectRepoContext();
+    const proposal = readProposal(file);
+    const result = service.validateProposal(repo, proposal);
+    if (result.valid) {
+      console.log("Proposal is valid.");
+      return;
+    }
+    console.log("Proposal is invalid:");
+    for (const error of result.errors) console.log(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (area === "proposal" && action === "apply") {
+    const file = requireFile(rest[0], "Usage: ec proposal apply <file>");
+    const repo = detectRepoContext();
+    const proposal = readProposal(file) as MemoryCommitProposal;
+    const result = service.applyProposal(repo, proposal);
+    console.log("Applied proposal to working memory.");
+    console.log(`Memory commit: ${result.memory_commit_id}`);
+    console.log(`Scope: ${result.scope_id}`);
+    console.log(`Components: ${result.created.components}`);
+    console.log(`Flows: ${result.created.flows}`);
+    console.log(`Claims: ${result.created.claims}`);
+    console.log(`Sources: ${result.created.sources}`);
+    console.log(`Edges: ${result.created.edges}`);
+    return;
+  }
+
+  printHelp();
+  process.exitCode = area === undefined ? 0 : 1;
+}
+
+function readProposal(file: string): unknown {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function requireFile(file: string | undefined, usage: string): string {
+  if (file === undefined || file.trim().length === 0) throw new Error(usage);
+  return file;
+}
+
+function printSection<T extends { id: string }>(title: string, items: T[], format: (item: T) => string): void {
+  console.log(`${title}: ${items.length}`);
+  for (const item of items) {
+    console.log(`- ${field(item, "id")} ${format(item)}`.trim());
+  }
+}
+
+function named(item: { id: string; name?: string }): string {
+  return item.name ?? item.id;
+}
+
+function anchor(item: object): string {
+  const record = item as Record<string, unknown>;
+  return typeof record.code_anchor === "string" ? `(${record.code_anchor})` : "";
+}
+
+function field(item: object, key: string): string {
+  const value = (item as Record<string, unknown>)[key];
+  return value === undefined || value === null ? "" : String(value);
+}
+
+function printHelp(): void {
+  const cli = basename(process.argv[1] ?? "ec");
+  console.log(`Usage:
+  ${cli} init
+  ${cli} graph read
+  ${cli} graph search <query>
+  ${cli} proposal validate <file>
+  ${cli} proposal apply <file>`);
+}
+
+main(process.argv.slice(2)).catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/cli/repo-context.ts
+++ b/apps/cli/repo-context.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from "node:child_process";
+import { basename } from "node:path";
+import type { RepoRef } from "../../libs/knowledge-graph/service.js";
+
+export function detectRepoContext(cwd = process.cwd()): RepoRef {
+  const repoRoot = git(cwd, ["rev-parse", "--show-toplevel"]);
+  const remoteUrl = gitOptional(repoRoot, ["config", "--get", "remote.origin.url"]) ?? `local:${repoRoot}`;
+
+  return {
+    remote_url: remoteUrl,
+    repo_name: repoName(remoteUrl, repoRoot),
+    default_branch: defaultBranch(repoRoot),
+  };
+}
+
+function defaultBranch(repoRoot: string): string {
+  const remoteHead = gitOptional(repoRoot, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"]);
+  if (remoteHead?.startsWith("origin/")) return remoteHead.slice("origin/".length);
+
+  return "main";
+}
+
+function repoName(remoteUrl: string, repoRoot: string): string {
+  if (remoteUrl.startsWith("local:")) return basename(repoRoot);
+  const withoutGit = remoteUrl.endsWith(".git") ? remoteUrl.slice(0, -4) : remoteUrl;
+  const lastPart = withoutGit.split(/[/:]/).filter(Boolean).at(-1);
+  return lastPart ?? basename(repoRoot);
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function gitOptional(cwd: string, args: string[]): string | undefined {
+  try {
+    const output = git(cwd, args);
+    return output.length > 0 ? output : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/libs/knowledge-graph/commit.ts
+++ b/libs/knowledge-graph/commit.ts
@@ -4,9 +4,8 @@ export interface MemoryCommit {
   id: MemoryCommitId;
   scope_id: GraphScopeId;
   parent_memory_commit_id?: MemoryCommitId;
-  git_commit_sha: string;
+  git_commit_sha?: string;
   title: string;
   summary?: string;
-  approved_by?: string;
   created_at: string;
 }

--- a/libs/knowledge-graph/edge.ts
+++ b/libs/knowledge-graph/edge.ts
@@ -1,4 +1,4 @@
-import type { EdgeId, SubjectType } from "./schema.js";
+import type { EdgeId, GraphObjectType } from "./schema.js";
 
 export type EdgeKind =
   | "about"
@@ -12,9 +12,9 @@ export type EdgeMetadata = Record<string, unknown>;
 export interface Edge {
   id: EdgeId;
   from_id: string;
-  from_type: SubjectType;
+  from_type: GraphObjectType;
   to_id: string;
-  to_type: SubjectType;
+  to_type: GraphObjectType;
   kind: EdgeKind;
   metadata?: EdgeMetadata;
 }

--- a/libs/knowledge-graph/proposal.ts
+++ b/libs/knowledge-graph/proposal.ts
@@ -1,0 +1,22 @@
+import type { Claim } from "./claim.js";
+import type { Edge } from "./edge.js";
+import type { Component, Flow, Source } from "./schema.js";
+
+export interface MemoryCommitProposal {
+  title: string;
+  summary?: string;
+  creates: {
+    components?: Component[];
+    flows?: Flow[];
+    claims?: Claim[];
+    sources?: Source[];
+    edges?: Edge[];
+  };
+}
+
+export type ProposalSubject =
+  | { type: "component"; id: string }
+  | { type: "flow"; id: string }
+  | { type: "claim"; id: string }
+  | { type: "edge"; id: string }
+  | { type: "source"; id: string };

--- a/libs/knowledge-graph/schema.ts
+++ b/libs/knowledge-graph/schema.ts
@@ -7,7 +7,9 @@ export type ClaimId = string;
 export type EdgeId = string;
 export type SourceId = string;
 
-export type SubjectType = "component" | "flow" | "claim" | "edge" | "source";
+export type GraphObjectType = "component" | "flow" | "claim" | "edge" | "source";
+
+export type MembershipSubjectType = "component" | "flow" | "claim" | "edge";
 
 export type SubjectIdByType = {
   component: ComponentId;

--- a/libs/knowledge-graph/scope.ts
+++ b/libs/knowledge-graph/scope.ts
@@ -1,6 +1,6 @@
-import type { GraphScopeId, MemoryCommitId, SubjectType } from "./schema.js";
+import type { GraphScopeId, MembershipSubjectType, MemoryCommitId } from "./schema.js";
 
-export type GraphScopeKind = "main" | "branch" | "session" | "source";
+export type GraphScopeKind = "main" | "working" | "branch" | "session" | "source";
 
 export interface GraphScope {
   id: GraphScopeId;
@@ -13,7 +13,7 @@ export interface GraphScope {
 
 export interface GraphMembership {
   scope_id: GraphScopeId;
-  subject_type: SubjectType;
+  subject_type: MembershipSubjectType;
   subject_id: string;
-  memory_commit_id?: MemoryCommitId;
+  memory_commit_id: MemoryCommitId;
 }

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -1,0 +1,130 @@
+import type { MemoryCommitProposal } from "./proposal.js";
+import { validateProposal, type ProposalValidationResult } from "./validate-proposal.js";
+import type { Claim } from "./claim.js";
+import type { Edge } from "./edge.js";
+import type { Component, Flow, Source } from "./schema.js";
+import { defaultDatabasePath, openDatabase } from "../storage/sqlite/db.js";
+import type { SqliteRepository } from "../storage/sqlite/repository.js";
+import { SqliteRepository as SqliteKnowledgeGraphRepository } from "../storage/sqlite/repository.js";
+
+export interface RepoRef {
+  remote_url: string;
+  repo_name: string;
+  default_branch: string;
+}
+
+export interface InitRepoResult {
+  repo_id: string;
+  main_scope_id: string;
+  working_scope_id: string;
+  database_path: string;
+  created: boolean;
+}
+
+export interface GraphReadResult {
+  components: Component[];
+  flows: Flow[];
+  claims: Claim[];
+  sources: Source[];
+  edges: Edge[];
+}
+
+export interface GraphSearchResult {
+  type: string;
+  id: string;
+  label: string;
+  text: string;
+}
+
+export interface ApplyProposalResult {
+  memory_commit_id: string;
+  scope_id: string;
+  created: {
+    components: number;
+    flows: number;
+    claims: number;
+    sources: number;
+    edges: number;
+  };
+}
+
+export class KnowledgeGraphService {
+  constructor(private readonly repository: SqliteRepository) {}
+
+  initRepo(input: RepoRef): InitRepoResult {
+    const { repo, created } = this.repository.upsertRepo(input);
+    const main = this.repository.ensureScope({
+      repo_id: repo.id,
+      kind: "main",
+      name: input.default_branch,
+      ref: input.default_branch,
+    });
+    const working = this.repository.ensureScope({
+      repo_id: repo.id,
+      kind: "working",
+      name: "working",
+      parent_scope_id: main.id,
+      ref: "working",
+    });
+
+    return {
+      repo_id: repo.id,
+      main_scope_id: main.id,
+      working_scope_id: working.id,
+      database_path: defaultDatabasePath(),
+      created,
+    };
+  }
+
+  readGraph(input: RepoRef): GraphReadResult {
+    const repo = this.repository.requireRepo(input.remote_url);
+    return this.repository.readGraphView(repo.id);
+  }
+
+  searchGraph(input: RepoRef, query: string): GraphSearchResult[] {
+    const repo = this.repository.requireRepo(input.remote_url);
+    return this.repository.searchGraphView(repo.id, query);
+  }
+
+  validateProposal(input: RepoRef, proposal: unknown): ProposalValidationResult {
+    this.ensureInitialized(input);
+    return validateProposal(proposal, this.repository);
+  }
+
+  applyProposal(input: RepoRef, proposal: MemoryCommitProposal): ApplyProposalResult {
+    const validation = this.validateProposal(input, proposal);
+    if (!validation.valid) {
+      throw new Error(`Proposal is invalid:\n${validation.errors.map((error) => `- ${error}`).join("\n")}`);
+    }
+
+    const repo = this.repository.requireRepo(input.remote_url);
+    const working = this.repository.requireWorkingScope(repo.id);
+    const memoryCommit = this.repository.createMemoryCommit({
+      scope_id: working.id,
+      title: proposal.title,
+      summary: proposal.summary,
+    });
+
+    this.repository.createProposalRecords(working.id, memoryCommit.id, proposal);
+
+    return {
+      memory_commit_id: memoryCommit.id,
+      scope_id: working.id,
+      created: {
+        components: proposal.creates.components?.length ?? 0,
+        flows: proposal.creates.flows?.length ?? 0,
+        claims: proposal.creates.claims?.length ?? 0,
+        sources: proposal.creates.sources?.length ?? 0,
+        edges: proposal.creates.edges?.length ?? 0,
+      },
+    };
+  }
+
+  private ensureInitialized(input: RepoRef): void {
+    this.repository.requireRepo(input.remote_url);
+  }
+}
+
+export function createLocalKnowledgeGraphService(): KnowledgeGraphService {
+  return new KnowledgeGraphService(new SqliteKnowledgeGraphRepository(openDatabase()));
+}

--- a/libs/knowledge-graph/validate-proposal.ts
+++ b/libs/knowledge-graph/validate-proposal.ts
@@ -1,0 +1,198 @@
+import { isAllowedEdge } from "./edge.js";
+import type { EdgeKind } from "./edge.js";
+import type { MemoryCommitProposal, ProposalSubject } from "./proposal.js";
+import type { GraphObjectType } from "./schema.js";
+
+const claimKinds = new Set(["fact", "requirement", "decision", "task", "question", "risk"]);
+const claimTruths = new Set(["code_verified", "source_verified", "unknown"]);
+const claimIntents = new Set(["intended", "accidental", "unknown"]);
+const sourceKinds = new Set(["session", "prd", "doc", "issue", "pr", "artifact", "code"]);
+const edgeKinds = new Set(["about", "contains", "touches", "supersedes", "evidenced_by"]);
+const graphObjectTypes = new Set(["component", "flow", "claim", "edge", "source"]);
+
+export interface ExistingSubjectLookup {
+  subjectExists(type: GraphObjectType, id: string): boolean;
+}
+
+export interface ProposalValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validateProposal(
+  proposal: unknown,
+  existingSubjects?: ExistingSubjectLookup,
+): ProposalValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(proposal)) {
+    return { valid: false, errors: ["Proposal must be an object."] };
+  }
+
+  if (!isNonEmptyString(proposal.title)) {
+    errors.push("Proposal title must be a non-empty string.");
+  }
+
+  if (proposal.summary !== undefined && typeof proposal.summary !== "string") {
+    errors.push("Proposal summary must be a string when present.");
+  }
+
+  if (!isRecord(proposal.creates)) {
+    errors.push("Proposal creates must be an object.");
+    return { valid: false, errors };
+  }
+
+  const typedProposal = proposal as Partial<MemoryCommitProposal>;
+  const creates = typedProposal.creates ?? {};
+  const ids = new Map<string, ProposalSubject>();
+  const components = arrayField(creates, "components", errors);
+  const flows = arrayField(creates, "flows", errors);
+  const claims = arrayField(creates, "claims", errors);
+  const sources = arrayField(creates, "sources", errors);
+  const edges = arrayField(creates, "edges", errors);
+
+  for (const component of components) {
+    if (!isRecord(component)) {
+      errors.push("Every component must be an object.");
+      continue;
+    }
+    validateSubjectBase("component", component.id, ids, existingSubjects, errors);
+    if (!isNonEmptyString(component.name)) errors.push(`Component ${stringId(component.id)} needs a name.`);
+    if (component.code_anchor !== undefined && typeof component.code_anchor !== "string") {
+      errors.push(`Component ${stringId(component.id)} code_anchor must be a string when present.`);
+    }
+  }
+
+  for (const flow of flows) {
+    if (!isRecord(flow)) {
+      errors.push("Every flow must be an object.");
+      continue;
+    }
+    validateSubjectBase("flow", flow.id, ids, existingSubjects, errors);
+    if (!isNonEmptyString(flow.name)) errors.push(`Flow ${stringId(flow.id)} needs a name.`);
+  }
+
+  for (const claim of claims) {
+    if (!isRecord(claim)) {
+      errors.push("Every claim must be an object.");
+      continue;
+    }
+    validateSubjectBase("claim", claim.id, ids, existingSubjects, errors);
+    if (!claimKinds.has(String(claim.kind))) errors.push(`Claim ${stringId(claim.id)} has invalid kind.`);
+    if (!isNonEmptyString(claim.text)) errors.push(`Claim ${stringId(claim.id)} needs text.`);
+    if (!claimTruths.has(String(claim.truth))) errors.push(`Claim ${stringId(claim.id)} has invalid truth.`);
+    if (!claimIntents.has(String(claim.intent))) errors.push(`Claim ${stringId(claim.id)} has invalid intent.`);
+  }
+
+  for (const source of sources) {
+    if (!isRecord(source)) {
+      errors.push("Every source must be an object.");
+      continue;
+    }
+    validateSubjectBase("source", source.id, ids, existingSubjects, errors);
+    if (!sourceKinds.has(String(source.kind))) errors.push(`Source ${stringId(source.id)} has invalid kind.`);
+    if (!isNonEmptyString(source.ref)) errors.push(`Source ${stringId(source.id)} needs ref.`);
+    if (source.title !== undefined && typeof source.title !== "string") {
+      errors.push(`Source ${stringId(source.id)} title must be a string when present.`);
+    }
+  }
+
+  for (const edge of edges) {
+    if (!isRecord(edge)) {
+      errors.push("Every edge must be an object.");
+      continue;
+    }
+
+    validateSubjectBase("edge", edge.id, ids, existingSubjects, errors);
+
+    const fromType = String(edge.from_type) as GraphObjectType;
+    const toType = String(edge.to_type) as GraphObjectType;
+    const kind = String(edge.kind) as EdgeKind;
+
+    if (!graphObjectTypes.has(fromType)) errors.push(`Edge ${stringId(edge.id)} has invalid from_type.`);
+    if (!graphObjectTypes.has(toType)) errors.push(`Edge ${stringId(edge.id)} has invalid to_type.`);
+    if (!edgeKinds.has(kind)) errors.push(`Edge ${stringId(edge.id)} has invalid kind.`);
+
+    if (graphObjectTypes.has(fromType) && !subjectRefExists(fromType, String(edge.from_id), ids, existingSubjects)) {
+      errors.push(`Edge ${stringId(edge.id)} references missing from subject ${fromType}:${String(edge.from_id)}.`);
+    }
+
+    if (graphObjectTypes.has(toType) && !subjectRefExists(toType, String(edge.to_id), ids, existingSubjects)) {
+      errors.push(`Edge ${stringId(edge.id)} references missing to subject ${toType}:${String(edge.to_id)}.`);
+    }
+
+    if (
+      graphObjectTypes.has(fromType) &&
+      graphObjectTypes.has(toType) &&
+      edgeKinds.has(kind) &&
+      !isAllowedEdge({ from_type: fromType, to_type: toType, kind })
+    ) {
+      errors.push(`Edge ${stringId(edge.id)} has invalid direction for ${kind}.`);
+    }
+
+    if (edge.metadata !== undefined && !isRecord(edge.metadata)) {
+      errors.push(`Edge ${stringId(edge.id)} metadata must be an object when present.`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+function validateSubjectBase(
+  type: GraphObjectType,
+  id: unknown,
+  ids: Map<string, ProposalSubject>,
+  existingSubjects: ExistingSubjectLookup | undefined,
+  errors: string[],
+): void {
+  if (!isNonEmptyString(id)) {
+    errors.push(`${type} must have a non-empty id.`);
+    return;
+  }
+
+  const key = subjectKey(type, id);
+  if (ids.has(key)) {
+    errors.push(`Duplicate id ${key} in proposal.`);
+  }
+
+  ids.set(key, { type, id });
+
+  if (existingSubjects?.subjectExists(type, id)) {
+    errors.push(`${key} already exists.`);
+  }
+}
+
+function subjectRefExists(
+  type: GraphObjectType,
+  id: string,
+  ids: Map<string, ProposalSubject>,
+  existingSubjects: ExistingSubjectLookup | undefined,
+): boolean {
+  return ids.has(subjectKey(type, id)) || existingSubjects?.subjectExists(type, id) === true;
+}
+
+function subjectKey(type: GraphObjectType, id: string): string {
+  return `${type}:${id}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function arrayField(source: object, key: string, errors: string[]): unknown[] {
+  const value = (source as Record<string, unknown>)[key];
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    errors.push(`creates.${key} must be an array when present.`);
+    return [];
+  }
+  return value;
+}
+
+function stringId(value: unknown): string {
+  return typeof value === "string" && value.length > 0 ? value : "<missing>";
+}

--- a/libs/storage/sqlite/db.ts
+++ b/libs/storage/sqlite/db.ts
@@ -1,0 +1,18 @@
+import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { migrate } from "./migrate.js";
+
+export function defaultDatabasePath(): string {
+  const home = process.env.ENGINEERING_CONTEXT_HOME ?? join(homedir(), ".engineering-context");
+  return join(home, "graph.db");
+}
+
+export function openDatabase(path = defaultDatabasePath()): Database.Database {
+  mkdirSync(dirname(path), { recursive: true });
+  const db = new Database(path);
+  db.pragma("foreign_keys = ON");
+  migrate(db);
+  return db;
+}

--- a/libs/storage/sqlite/migrate.ts
+++ b/libs/storage/sqlite/migrate.ts
@@ -1,0 +1,6 @@
+import type Database from "better-sqlite3";
+import { schemaSql } from "./schema.js";
+
+export function migrate(db: Database.Database): void {
+  db.exec(schemaSql);
+}

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -1,0 +1,369 @@
+import type Database from "better-sqlite3";
+import { createHash, randomUUID } from "node:crypto";
+import type { MemoryCommit } from "../../knowledge-graph/commit.js";
+import type { Edge } from "../../knowledge-graph/edge.js";
+import type { MemoryCommitProposal } from "../../knowledge-graph/proposal.js";
+import type { Component, Flow, GraphObjectType, Source } from "../../knowledge-graph/schema.js";
+import type { Claim } from "../../knowledge-graph/claim.js";
+import type { GraphScope, GraphScopeKind } from "../../knowledge-graph/scope.js";
+
+export interface RepoRecord {
+  id: string;
+  remote_url: string;
+  repo_name: string;
+  default_branch: string;
+}
+
+export interface UpsertRepoInput {
+  remote_url: string;
+  repo_name: string;
+  default_branch: string;
+}
+
+export interface CreateScopeInput {
+  repo_id: string;
+  kind: GraphScopeKind;
+  name: string;
+  parent_scope_id?: string;
+  ref?: string;
+}
+
+export interface CreateMemoryCommitInput {
+  scope_id: string;
+  git_commit_sha?: string;
+  title: string;
+  summary?: string;
+}
+
+type MembershipRow = {
+  subject_type: "component" | "flow" | "claim" | "edge";
+  subject_id: string;
+};
+
+type EdgeRow = Omit<Edge, "metadata"> & { metadata: string | null };
+
+export class SqliteRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  upsertRepo(input: UpsertRepoInput): { repo: RepoRecord; created: boolean } {
+    const existing = this.getRepoByRemote(input.remote_url);
+    if (existing) return { repo: existing, created: false };
+
+    const repo: RepoRecord = {
+      id: makeId("repo", input.remote_url),
+      remote_url: input.remote_url,
+      repo_name: input.repo_name,
+      default_branch: input.default_branch,
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO repos (id, remote_url, repo_name, default_branch)
+         VALUES (@id, @remote_url, @repo_name, @default_branch)`,
+      )
+      .run(repo);
+
+    return { repo, created: true };
+  }
+
+  getRepoByRemote(remoteUrl: string): RepoRecord | undefined {
+    return this.db.prepare("SELECT * FROM repos WHERE remote_url = ?").get(remoteUrl) as RepoRecord | undefined;
+  }
+
+  requireRepo(remoteUrl: string): RepoRecord {
+    const repo = this.getRepoByRemote(remoteUrl);
+    if (!repo) {
+      throw new Error(`Repo is not initialized. Run 'ec init' first for ${remoteUrl}.`);
+    }
+    return repo;
+  }
+
+  ensureScope(input: CreateScopeInput): GraphScope {
+    const existing = this.db
+      .prepare("SELECT * FROM graph_scopes WHERE repo_id = ? AND kind = ? AND name = ?")
+      .get(input.repo_id, input.kind, input.name) as GraphScope | undefined;
+
+    if (existing) return existing;
+
+    const scope: GraphScope = {
+      id: makeId("scope", `${input.repo_id}:${input.kind}:${input.name}`),
+      kind: input.kind,
+      name: input.name,
+      parent_scope_id: input.parent_scope_id,
+      ref: input.ref,
+      created_at: now(),
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO graph_scopes (id, repo_id, kind, name, parent_scope_id, ref, created_at)
+         VALUES (@id, @repo_id, @kind, @name, @parent_scope_id, @ref, @created_at)`,
+      )
+      .run({ ...scope, repo_id: input.repo_id });
+
+    return scope;
+  }
+
+  requireWorkingScope(repoId: string): GraphScope {
+    const scope = this.db
+      .prepare("SELECT * FROM graph_scopes WHERE repo_id = ? AND kind = 'working' AND name = 'working'")
+      .get(repoId) as GraphScope | undefined;
+    if (!scope) throw new Error("Working scope is missing. Run 'ec init' again.");
+    return scope;
+  }
+
+  readGraphView(repoId: string): {
+    components: Component[];
+    flows: Flow[];
+    claims: Claim[];
+    sources: Source[];
+    edges: Edge[];
+  } {
+    const scopeIds = this.currentScopeIds(repoId);
+    const memberships = this.membershipsForScopes(scopeIds);
+    const rawEdges = this.loadEdges(selectIds(memberships, "edge"));
+    const active = activeSubjectKeys(memberships, rawEdges);
+
+    const edges = rawEdges.filter(
+      (edge) =>
+        active.has(subjectKey("edge", edge.id)) &&
+        active.has(subjectKey(edge.from_type, edge.from_id)) &&
+        (edge.to_type === "source" || active.has(subjectKey(edge.to_type, edge.to_id))),
+    );
+
+    return {
+      components: this.loadComponents(selectActiveIds(memberships, active, "component")),
+      flows: this.loadFlows(selectActiveIds(memberships, active, "flow")),
+      claims: this.loadClaims(selectActiveIds(memberships, active, "claim")),
+      sources: this.loadSources([...new Set(edges.filter((edge) => edge.to_type === "source").map((edge) => edge.to_id))]),
+      edges,
+    };
+  }
+
+  searchGraphView(repoId: string, query: string): { type: string; id: string; label: string; text: string }[] {
+    const graph = this.readGraphView(repoId);
+    const normalized = query.trim().toLowerCase();
+    if (normalized.length === 0) return [];
+
+    const results: { type: string; id: string; label: string; text: string }[] = [];
+
+    for (const component of graph.components) {
+      if (matches(component.name, normalized) || matches(component.code_anchor, normalized)) {
+        results.push({ type: "component", id: component.id, label: component.name, text: component.code_anchor ?? "" });
+      }
+    }
+
+    for (const flow of graph.flows) {
+      if (matches(flow.name, normalized)) {
+        results.push({ type: "flow", id: flow.id, label: flow.name, text: "" });
+      }
+    }
+
+    for (const claim of graph.claims) {
+      if (matches(claim.text, normalized) || matches(claim.kind, normalized)) {
+        results.push({ type: "claim", id: claim.id, label: claim.kind, text: claim.text });
+      }
+    }
+
+    for (const source of graph.sources) {
+      if (matches(source.ref, normalized) || matches(source.title, normalized) || matches(source.kind, normalized)) {
+        results.push({ type: "source", id: source.id, label: source.title ?? source.ref, text: source.kind });
+      }
+    }
+
+    return results;
+  }
+
+  createMemoryCommit(input: CreateMemoryCommitInput): MemoryCommit {
+    const parent = this.db
+      .prepare("SELECT id FROM memory_commits WHERE scope_id = ? ORDER BY created_at DESC LIMIT 1")
+      .get(input.scope_id) as { id: string } | undefined;
+
+    const memoryCommit: MemoryCommit = {
+      id: `mc_${randomUUID()}`,
+      scope_id: input.scope_id,
+      parent_memory_commit_id: parent?.id,
+      git_commit_sha: input.git_commit_sha,
+      title: input.title,
+      summary: input.summary,
+      created_at: now(),
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO memory_commits
+          (id, scope_id, parent_memory_commit_id, git_commit_sha, title, summary, created_at)
+         VALUES
+          (@id, @scope_id, @parent_memory_commit_id, @git_commit_sha, @title, @summary, @created_at)`,
+      )
+      .run(memoryCommit);
+
+    return memoryCommit;
+  }
+
+  createProposalRecords(scopeId: string, memoryCommitId: string, proposal: MemoryCommitProposal): void {
+    const write = this.db.transaction(() => {
+      for (const component of proposal.creates.components ?? []) {
+        this.db
+          .prepare("INSERT INTO components (id, name, code_anchor) VALUES (@id, @name, @code_anchor)")
+          .run(component);
+        this.createMembership(scopeId, "component", component.id, memoryCommitId);
+      }
+
+      for (const flow of proposal.creates.flows ?? []) {
+        this.db.prepare("INSERT INTO flows (id, name) VALUES (@id, @name)").run(flow);
+        this.createMembership(scopeId, "flow", flow.id, memoryCommitId);
+      }
+
+      for (const claim of proposal.creates.claims ?? []) {
+        this.db
+          .prepare("INSERT INTO claims (id, kind, text, truth, intent) VALUES (@id, @kind, @text, @truth, @intent)")
+          .run(claim);
+        this.createMembership(scopeId, "claim", claim.id, memoryCommitId);
+      }
+
+      for (const source of proposal.creates.sources ?? []) {
+        this.db
+          .prepare("INSERT INTO sources (id, kind, ref, title) VALUES (@id, @kind, @ref, @title)")
+          .run(source);
+      }
+
+      for (const edge of proposal.creates.edges ?? []) {
+        this.db
+          .prepare(
+            `INSERT INTO edges (id, from_id, from_type, to_id, to_type, kind, metadata)
+             VALUES (@id, @from_id, @from_type, @to_id, @to_type, @kind, @metadata)`,
+          )
+          .run({ ...edge, metadata: edge.metadata === undefined ? null : JSON.stringify(edge.metadata) });
+        this.createMembership(scopeId, "edge", edge.id, memoryCommitId);
+      }
+    });
+
+    write();
+  }
+
+  subjectExists(type: GraphObjectType, id: string): boolean {
+    const table = tableForType(type);
+    const row = this.db.prepare(`SELECT id FROM ${table} WHERE id = ?`).get(id);
+    return row !== undefined;
+  }
+
+  private createMembership(
+    scopeId: string,
+    subjectType: "component" | "flow" | "claim" | "edge",
+    subjectId: string,
+    memoryCommitId: string,
+  ): void {
+    this.db
+      .prepare(
+        `INSERT INTO graph_memberships (scope_id, subject_type, subject_id, memory_commit_id)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(scopeId, subjectType, subjectId, memoryCommitId);
+  }
+
+  private currentScopeIds(repoId: string): string[] {
+    const rows = this.db
+      .prepare("SELECT id FROM graph_scopes WHERE repo_id = ? AND kind IN ('main', 'working') ORDER BY kind")
+      .all(repoId) as { id: string }[];
+    return rows.map((row) => row.id);
+  }
+
+  private membershipsForScopes(scopeIds: string[]): MembershipRow[] {
+    if (scopeIds.length === 0) return [];
+    return this.db
+      .prepare(`SELECT subject_type, subject_id FROM graph_memberships WHERE scope_id IN (${placeholders(scopeIds)})`)
+      .all(...scopeIds) as MembershipRow[];
+  }
+
+  private loadComponents(ids: string[]): Component[] {
+    return this.loadByIds<Component>("components", ids);
+  }
+
+  private loadFlows(ids: string[]): Flow[] {
+    return this.loadByIds<Flow>("flows", ids);
+  }
+
+  private loadClaims(ids: string[]): Claim[] {
+    return this.loadByIds<Claim>("claims", ids);
+  }
+
+  private loadSources(ids: string[]): Source[] {
+    return this.loadByIds<Source>("sources", ids);
+  }
+
+  private loadEdges(ids: string[]): Edge[] {
+    if (ids.length === 0) return [];
+    const rows = this.db
+      .prepare(`SELECT * FROM edges WHERE id IN (${placeholders(ids)})`)
+      .all(...ids) as EdgeRow[];
+    return rows.map((row) => ({
+      ...row,
+      metadata: row.metadata === null ? undefined : (JSON.parse(row.metadata) as Record<string, unknown>),
+    }));
+  }
+
+  private loadByIds<T>(table: string, ids: string[]): T[] {
+    if (ids.length === 0) return [];
+    return this.db.prepare(`SELECT * FROM ${table} WHERE id IN (${placeholders(ids)})`).all(...ids) as T[];
+  }
+}
+
+function activeSubjectKeys(memberships: MembershipRow[], edges: Edge[]): Set<string> {
+  const active = new Set(memberships.map((membership) => subjectKey(membership.subject_type, membership.subject_id)));
+  const superseded = new Set(
+    edges
+      .filter((edge) => edge.kind === "supersedes")
+      .map((edge) => subjectKey(edge.to_type, edge.to_id)),
+  );
+
+  for (const key of superseded) {
+    active.delete(key);
+  }
+
+  return active;
+}
+
+function selectIds(memberships: MembershipRow[], type: MembershipRow["subject_type"]): string[] {
+  return [...new Set(memberships.filter((membership) => membership.subject_type === type).map((membership) => membership.subject_id))];
+}
+
+function selectActiveIds(memberships: MembershipRow[], active: Set<string>, type: MembershipRow["subject_type"]): string[] {
+  return selectIds(memberships, type).filter((id) => active.has(subjectKey(type, id)));
+}
+
+function subjectKey(type: GraphObjectType, id: string): string {
+  return `${type}:${id}`;
+}
+
+function tableForType(type: GraphObjectType): string {
+  switch (type) {
+    case "component":
+      return "components";
+    case "flow":
+      return "flows";
+    case "claim":
+      return "claims";
+    case "edge":
+      return "edges";
+    case "source":
+      return "sources";
+  }
+}
+
+function makeId(prefix: string, value: string): string {
+  const hash = createHash("sha1").update(value).digest("hex").slice(0, 16);
+  return `${prefix}_${hash}`;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function placeholders(values: unknown[]): string {
+  return values.map(() => "?").join(", ");
+}
+
+function matches(value: string | undefined, query: string): boolean {
+  return value?.toLowerCase().includes(query) ?? false;
+}

--- a/libs/storage/sqlite/schema.ts
+++ b/libs/storage/sqlite/schema.ts
@@ -1,0 +1,78 @@
+export const schemaSql = `
+CREATE TABLE IF NOT EXISTS repos (
+  id TEXT PRIMARY KEY,
+  remote_url TEXT NOT NULL UNIQUE,
+  repo_name TEXT NOT NULL,
+  default_branch TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS graph_scopes (
+  id TEXT PRIMARY KEY,
+  repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  parent_scope_id TEXT REFERENCES graph_scopes(id) ON DELETE SET NULL,
+  ref TEXT,
+  created_at TEXT NOT NULL,
+  UNIQUE(repo_id, kind, name)
+);
+
+CREATE TABLE IF NOT EXISTS memory_commits (
+  id TEXT PRIMARY KEY,
+  scope_id TEXT NOT NULL REFERENCES graph_scopes(id) ON DELETE CASCADE,
+  parent_memory_commit_id TEXT REFERENCES memory_commits(id) ON DELETE SET NULL,
+  git_commit_sha TEXT,
+  title TEXT NOT NULL,
+  summary TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS components (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  code_anchor TEXT
+);
+
+CREATE TABLE IF NOT EXISTS flows (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS claims (
+  id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  text TEXT NOT NULL,
+  truth TEXT NOT NULL,
+  intent TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sources (
+  id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  ref TEXT NOT NULL,
+  title TEXT
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+  id TEXT PRIMARY KEY,
+  from_id TEXT NOT NULL,
+  from_type TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  to_type TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  metadata TEXT
+);
+
+CREATE TABLE IF NOT EXISTS graph_memberships (
+  scope_id TEXT NOT NULL REFERENCES graph_scopes(id) ON DELETE CASCADE,
+  subject_type TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  memory_commit_id TEXT NOT NULL REFERENCES memory_commits(id) ON DELETE CASCADE,
+  PRIMARY KEY(scope_id, subject_type, subject_id)
+);
+
+CREATE INDEX IF NOT EXISTS graph_scopes_repo_idx ON graph_scopes(repo_id);
+CREATE INDEX IF NOT EXISTS memory_commits_scope_idx ON memory_commits(scope_id);
+CREATE INDEX IF NOT EXISTS graph_memberships_scope_idx ON graph_memberships(scope_id);
+CREATE INDEX IF NOT EXISTS graph_memberships_subject_idx ON graph_memberships(subject_type, subject_id);
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,513 @@
+{
+  "name": "context-graph-memory",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "context-graph-memory",
+      "version": "0.0.0",
+      "dependencies": {
+        "better-sqlite3": "^11.9.1"
+      },
+      "bin": {
+        "ec": "dist/apps/cli/main.js"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/node": "^22.15.3",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,19 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "bin": {
+    "ec": "dist/apps/cli/main.js"
+  },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "better-sqlite3": "^11.9.1"
+  },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^22.15.3",
     "typescript": "^5.8.3"
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,9 @@
     "moduleResolution": "NodeNext",
     "strict": true,
     "noEmit": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["libs/**/*.ts"]
+  "include": ["apps/**/*.ts", "libs/**/*.ts"]
 }


### PR DESCRIPTION
Adds a minimal ec CLI for initializing repo memory, reading/searching graph memory, and validating/applying proposals. Introduces a SQLite-backed knowledge graph service with repo, scope, memory commit, membership, node, source, and edge tables. Updates the graph model so sources are global evidence nodes while memberships apply to components, flows, claims, and edges. Includes TypeScript build configuration and verification scripts.