### PR TITLE
Add compact memory proposals and bootstrap skill

### DIFF
--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -2,7 +2,6 @@
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { createLocalKnowledgeGraphService } from "../../libs/knowledge-graph/service.js";
-import type { MemoryCommitProposal } from "../../libs/knowledge-graph/proposal.js";
 import { detectRepoContext } from "./repo-context.js";
 
 async function main(argv: string[]): Promise<void> {
@@ -69,7 +68,7 @@ async function main(argv: string[]): Promise<void> {
   if (area === "proposal" && action === "apply") {
     const file = requireFile(rest[0], "Usage: ec proposal apply <file>");
     const repo = detectRepoContext();
-    const proposal = readProposal(file) as MemoryCommitProposal;
+    const proposal = readProposal(file);
     const result = service.applyProposal(repo, proposal);
     console.log("Applied proposal to working memory.");
     console.log(`Memory commit: ${result.memory_commit_id}`);

--- a/libs/knowledge-graph/proposal.ts
+++ b/libs/knowledge-graph/proposal.ts
@@ -1,6 +1,6 @@
 import type { Claim } from "./claim.js";
-import type { Edge } from "./edge.js";
-import type { Component, Flow, Source } from "./schema.js";
+import type { Edge, EdgeKind, EdgeMetadata } from "./edge.js";
+import type { Component, Flow, GraphObjectType, Source } from "./schema.js";
 
 export interface MemoryCommitProposal {
   title: string;
@@ -14,9 +14,211 @@ export interface MemoryCommitProposal {
   };
 }
 
+export type CompactComponent = Component & {
+  contains?: string | string[];
+  supersedes?: string | string[];
+};
+
+export type CompactFlow = Flow & {
+  contains?: string | string[];
+  touches?: string | string[];
+  supersedes?: string | string[];
+};
+
+export type CompactClaim = Claim & {
+  about?: string | string[];
+  evidenced_by?: string | string[];
+  supersedes?: string | string[];
+};
+
+export interface CompactEdge {
+  kind: EdgeKind;
+  from: string;
+  to: string;
+  metadata?: EdgeMetadata;
+}
+
+export interface CompactMemoryProposal {
+  title: string;
+  summary?: string;
+  creates: {
+    components?: CompactComponent[];
+    flows?: CompactFlow[];
+    claims?: CompactClaim[];
+    sources?: Source[];
+    edges?: CompactEdge[];
+  };
+}
+
 export type ProposalSubject =
   | { type: "component"; id: string }
   | { type: "flow"; id: string }
   | { type: "claim"; id: string }
   | { type: "edge"; id: string }
   | { type: "source"; id: string };
+
+export interface ProposalSubjectLookup {
+  subjectType(id: string): GraphObjectType | undefined;
+}
+
+export function normalizeProposal(input: unknown, lookup?: ProposalSubjectLookup): MemoryCommitProposal {
+  if (!isRecord(input)) {
+    return input as MemoryCommitProposal;
+  }
+
+  const creates = isRecord(input.creates) ? input.creates : {};
+  const components = objectArray<CompactComponent>(creates.components);
+  const flows = objectArray<CompactFlow>(creates.flows);
+  const claims = objectArray<CompactClaim>(creates.claims);
+  const sources = objectArray<Source>(creates.sources);
+  const explicitEdges = objectArray<Edge | CompactEdge>(creates.edges);
+  const subjectTypes = new Map<string, GraphObjectType>();
+
+  for (const component of components) subjectTypes.set(component.id, "component");
+  for (const flow of flows) subjectTypes.set(flow.id, "flow");
+  for (const claim of claims) subjectTypes.set(claim.id, "claim");
+  for (const source of sources) subjectTypes.set(source.id, "source");
+
+  const normalizedComponents = components.map(({ contains: _contains, supersedes: _supersedes, ...component }) => component);
+  const normalizedFlows = flows.map(({ contains: _contains, touches: _touches, supersedes: _supersedes, ...flow }) => flow);
+  const normalizedClaims = claims.map(
+    ({ about: _about, evidenced_by: _evidencedBy, supersedes: _supersedes, ...claim }) => claim,
+  );
+
+  const edges: Edge[] = [];
+
+  for (const component of components) {
+    for (const target of asArray(component.contains)) {
+      edges.push(makeEdge("contains", component.id, "component", target, "component"));
+    }
+    for (const target of asArray(component.supersedes)) {
+      edges.push(makeEdge("supersedes", component.id, "component", target, "component"));
+    }
+  }
+
+  for (const flow of flows) {
+    for (const target of asArray(flow.contains)) {
+      edges.push(makeEdge("contains", flow.id, "flow", target, "flow"));
+    }
+    for (const target of asArray(flow.touches)) {
+      edges.push(makeEdge("touches", flow.id, "flow", target, "component"));
+    }
+    for (const target of asArray(flow.supersedes)) {
+      edges.push(makeEdge("supersedes", flow.id, "flow", target, "flow"));
+    }
+  }
+
+  for (const claim of claims) {
+    for (const target of asArray(claim.about)) {
+      const targetType = resolveSubjectType(target, subjectTypes, lookup);
+      edges.push(makeEdge("about", claim.id, "claim", target, targetType ?? "component"));
+    }
+    for (const target of asArray(claim.evidenced_by)) {
+      edges.push(makeEdge("evidenced_by", claim.id, "claim", target, "source"));
+    }
+    for (const target of asArray(claim.supersedes)) {
+      edges.push(makeEdge("supersedes", claim.id, "claim", target, "claim"));
+    }
+  }
+
+  for (const edge of explicitEdges) {
+    if (isCanonicalEdge(edge)) {
+      edges.push(edge);
+      continue;
+    }
+
+    const fromType = resolveSubjectType(edge.from, subjectTypes, lookup) ?? "component";
+    const toType = resolveSubjectType(edge.to, subjectTypes, lookup) ?? defaultToType(edge.kind);
+    edges.push(makeEdge(edge.kind, edge.from, fromType, edge.to, toType, edge.metadata));
+  }
+
+  return {
+    title: typeof input.title === "string" ? input.title : "",
+    summary: typeof input.summary === "string" ? input.summary : undefined,
+    creates: {
+      components: normalizedComponents,
+      flows: normalizedFlows,
+      claims: normalizedClaims,
+      sources,
+      edges: dedupeEdges(edges),
+    },
+  };
+}
+
+function makeEdge(
+  kind: EdgeKind,
+  fromId: string,
+  fromType: GraphObjectType,
+  toId: string,
+  toType: GraphObjectType,
+  metadata?: EdgeMetadata,
+): Edge {
+  return {
+    id: edgeId(kind, fromType, fromId, toType, toId),
+    from_id: fromId,
+    from_type: fromType,
+    to_id: toId,
+    to_type: toType,
+    kind,
+    metadata,
+  };
+}
+
+function edgeId(kind: EdgeKind, fromType: GraphObjectType, fromId: string, toType: GraphObjectType, toId: string): string {
+  return `edge_${slug(kind)}_${slug(fromType)}_${slug(fromId)}_${slug(toType)}_${slug(toId)}`;
+}
+
+function dedupeEdges(edges: Edge[]): Edge[] {
+  const seen = new Set<string>();
+  const deduped: Edge[] = [];
+  for (const edge of edges) {
+    if (seen.has(edge.id)) continue;
+    seen.add(edge.id);
+    deduped.push(edge);
+  }
+  return deduped;
+}
+
+function resolveSubjectType(
+  id: string,
+  createdSubjects: Map<string, GraphObjectType>,
+  lookup: ProposalSubjectLookup | undefined,
+): GraphObjectType | undefined {
+  return createdSubjects.get(id) ?? lookup?.subjectType(id);
+}
+
+function defaultToType(kind: EdgeKind): GraphObjectType {
+  switch (kind) {
+    case "about":
+      return "component";
+    case "contains":
+      return "component";
+    case "touches":
+      return "component";
+    case "supersedes":
+      return "component";
+    case "evidenced_by":
+      return "source";
+  }
+}
+
+function asArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function objectArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function isCanonicalEdge(edge: Edge | CompactEdge): edge is Edge {
+  return "from_id" in edge && "from_type" in edge && "to_id" in edge && "to_type" in edge;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function slug(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "").toLowerCase();
+}

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -1,4 +1,4 @@
-import type { MemoryCommitProposal } from "./proposal.js";
+import { normalizeProposal } from "./proposal.js";
 import { validateProposal, type ProposalValidationResult } from "./validate-proposal.js";
 import type { Claim } from "./claim.js";
 import type { Edge } from "./edge.js";
@@ -88,11 +88,12 @@ export class KnowledgeGraphService {
 
   validateProposal(input: RepoRef, proposal: unknown): ProposalValidationResult {
     this.ensureInitialized(input);
-    return validateProposal(proposal, this.repository);
+    return validateProposal(normalizeProposal(proposal, this.repository), this.repository);
   }
 
-  applyProposal(input: RepoRef, proposal: MemoryCommitProposal): ApplyProposalResult {
-    const validation = this.validateProposal(input, proposal);
+  applyProposal(input: RepoRef, proposal: unknown): ApplyProposalResult {
+    const normalizedProposal = normalizeProposal(proposal, this.repository);
+    const validation = this.validateProposal(input, normalizedProposal);
     if (!validation.valid) {
       throw new Error(`Proposal is invalid:\n${validation.errors.map((error) => `- ${error}`).join("\n")}`);
     }
@@ -101,21 +102,21 @@ export class KnowledgeGraphService {
     const working = this.repository.requireWorkingScope(repo.id);
     const memoryCommit = this.repository.createMemoryCommit({
       scope_id: working.id,
-      title: proposal.title,
-      summary: proposal.summary,
+      title: normalizedProposal.title,
+      summary: normalizedProposal.summary,
     });
 
-    this.repository.createProposalRecords(working.id, memoryCommit.id, proposal);
+    this.repository.createProposalRecords(working.id, memoryCommit.id, normalizedProposal);
 
     return {
       memory_commit_id: memoryCommit.id,
       scope_id: working.id,
       created: {
-        components: proposal.creates.components?.length ?? 0,
-        flows: proposal.creates.flows?.length ?? 0,
-        claims: proposal.creates.claims?.length ?? 0,
-        sources: proposal.creates.sources?.length ?? 0,
-        edges: proposal.creates.edges?.length ?? 0,
+        components: normalizedProposal.creates.components?.length ?? 0,
+        flows: normalizedProposal.creates.flows?.length ?? 0,
+        claims: normalizedProposal.creates.claims?.length ?? 0,
+        sources: normalizedProposal.creates.sources?.length ?? 0,
+        edges: normalizedProposal.creates.edges?.length ?? 0,
       },
     };
   }

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -248,6 +248,13 @@ export class SqliteRepository {
     return row !== undefined;
   }
 
+  subjectType(id: string): GraphObjectType | undefined {
+    for (const type of ["component", "flow", "claim", "edge", "source"] as const) {
+      if (this.subjectExists(type, id)) return type;
+    }
+    return undefined;
+  }
+
   private createMembership(
     scopeId: string,
     subjectType: "component" | "flow" | "claim" | "edge",

--- a/skills/engineering-memory/SKILL.md
+++ b/skills/engineering-memory/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: engineering-memory
+description: Bootstrap or update engineering memory for a code repository using the local `ec` CLI. Use when asked to create repo memory, bootstrap a knowledge graph, create component/flow/claim memory, or generate a memory proposal from code.
+---
+
+# Engineering Memory
+
+Use this skill to create useful engineering memory for a repository.
+
+The output is a proposal JSON that can be validated and optionally applied with the `ec` CLI. Bootstrap memory should be shallow and high-signal, not exhaustive.
+
+## CLI Contract
+
+Run commands from the repo root.
+
+```bash
+ec init
+ec graph read
+ec graph search <query>
+ec proposal validate <proposal-file>
+ec proposal apply <proposal-file>
+```
+
+If `ec` is not on `PATH`, use the repo build output:
+
+```bash
+node dist/apps/cli/main.js <command>
+```
+
+Always validate a proposal before applying it. Apply only when the user explicitly asked to apply, or when the task is a test using an isolated `ENGINEERING_CONTEXT_HOME`.
+
+## Proposal Shape
+
+The proposal file must be JSON:
+
+```json
+{
+  "title": "Bootstrap repo memory",
+  "summary": "Top-level engineering memory for this repository.",
+  "creates": {
+    "components": [
+      {
+        "id": "cmp_example",
+        "name": "ExampleComponent",
+        "code_anchor": "src/example.ts",
+        "contains": ["cmp_child_component"]
+      }
+    ],
+    "flows": [
+      {
+        "id": "flow_example",
+        "name": "Example flow",
+        "touches": ["cmp_example"],
+        "contains": ["flow_child"]
+      }
+    ],
+    "claims": [
+      {
+        "id": "claim_example",
+        "kind": "fact",
+        "text": "ExampleComponent participates in Example flow.",
+        "truth": "code_verified",
+        "intent": "unknown",
+        "about": ["cmp_example", "flow_example"]
+      }
+    ],
+    "sources": [],
+    "edges": [
+      {
+        "kind": "touches",
+        "from": "flow_existing",
+        "to": "cmp_existing"
+      }
+    ]
+  }
+}
+```
+
+Inline relationship fields and `edges[]` create the same graph edges. Prefer inline fields when creating the subject. Use `edges[]` only for edge-only additions or when inline placement is awkward. Do not manually create edge ids; the CLI generates them.
+
+Allowed claim kinds:
+
+```txt
+fact | requirement | decision | task | question | risk
+```
+
+Allowed truth values:
+
+```txt
+code_verified | source_verified | unknown
+```
+
+Allowed intent values:
+
+```txt
+intended | accidental | unknown
+```
+
+Allowed edge rules:
+
+```txt
+Claim -> Component/Flow: about
+Component -> Component: contains
+Flow -> Flow: contains
+Flow -> Component: touches
+Component/Flow/Claim -> same kind: supersedes
+Claim -> Source: evidenced_by
+```
+
+Compact relationship fields:
+
+```txt
+component.contains[]      -> Component -> Component contains
+component.supersedes[]    -> Component -> Component supersedes
+
+flow.contains[]           -> Flow -> Flow contains
+flow.touches[]            -> Flow -> Component touches
+flow.supersedes[]         -> Flow -> Flow supersedes
+
+claim.about[]             -> Claim -> Component/Flow about
+claim.evidenced_by[]      -> Claim -> Source evidenced_by
+claim.supersedes[]        -> Claim -> Claim supersedes
+```
+
+Sources are external artifacts such as sessions, PRDs, docs, issues, PRs, or artifacts. Do not create a source just because code was inspected during bootstrap.
+
+## Bootstrap Workflow
+
+1. Run `ec init`.
+2. Run `ec graph read` to see existing memory.
+3. Inspect the repo shallowly:
+   - README and docs if present
+   - package/config/build files
+   - top-level directory tree
+   - app/lib entrypoints
+   - tests only when they reveal important behavior
+4. Create a proposal with major components, major flows, and useful claims.
+5. Include tasks/questions/risks for areas that need deeper inspection.
+6. Write the proposal to a temporary JSON file.
+7. Run `ec proposal validate <proposal-file>`.
+8. Fix validation errors until valid.
+9. Apply only if explicitly requested.
+
+## Quality Bar
+
+Create memory that helps a future coding agent orient quickly:
+
+- Prefer important subsystems over tiny helpers.
+- For a small repo, prefer roughly 3-8 components unless more are clearly needed.
+- Split a component only when the split would help a future agent navigate or change the code.
+- Prefer human workflows over function-level traces.
+- Use `code_verified` only for claims grounded in inspected code.
+- Use `unknown` for intent unless design intent is explicit.
+- Add open questions/tasks for areas that look important but were not inspected deeply.
+- Do not create questions about rules explicitly defined in this skill unless the code contradicts the rule.
+- Keep bootstrap shallow; suggest targeted deep dives rather than trying to cover every file.


### PR DESCRIPTION
Adds compact proposal normalization so agents can define relationships inline while the service expands them into canonical graph edges. Keeps normalization inside the knowledge graph service boundary and leaves the CLI as a thin wrapper. Adds a repo-local engineering-memory skill for shallow bootstrap workflows using the ec CLI. Verified with typecheck, build, compact proposal smoke test, and a worker-agent skill test.