### PR TITLE
Add bootstrap memory eval runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+eval-runs/
+.env.local

--- a/evals/cases/bootstrap-current-repo-at-1872222/rubric.json
+++ b/evals/cases/bootstrap-current-repo-at-1872222/rubric.json
@@ -1,0 +1,365 @@
+{
+  "case_id": "bootstrap-current-repo-at-1872222",
+  "target_repo_url": "git@github.com:Autoloops/engineering-context.git",
+  "target_commit": "1872222671c85b347950462bc65ef3da3611ed6e",
+  "score": {
+    "pass_threshold": 80,
+    "node_coverage_points": 50,
+    "edge_coverage_points": 15,
+    "quality_points": 35,
+    "quality_penalties": {
+      "noisy_structure_node_points": 3,
+      "noisy_structure_node_max": 12,
+      "bad_claim_points": 4,
+      "bad_claim_max": 16,
+      "bad_anchor_points": 3,
+      "bad_anchor_max": 9,
+      "depth_violation_points": 8,
+      "weak_graph_linking_points": 8
+    }
+  },
+  "judge": {
+    "instructions": [
+      "Judge whether the proposal is a good shallow bootstrap memory graph for this exact repo commit.",
+      "Do not compute a numeric score. Only classify expected nodes, expected edges, and quality issues.",
+      "Judge semantic equivalence, not exact IDs or exact wording.",
+      "A node can satisfy an expected item if it clearly represents the same concept, even with a different ID.",
+      "An edge can satisfy an expected relation if the proposal connects the same semantic subjects through inline compact fields or canonical edges.",
+      "Compact relationship fields are graph edges: flow.touches creates Flow -> Component touches edges, claim.about creates Claim -> Component/Flow about edges, component.contains creates Component -> Component contains edges, and flow.contains creates Flow -> Flow contains edges.",
+      "When judging expected edges, inspect compact relationship arrays directly. Do not require a separate creates.edges entry.",
+      "Do not mark a real existing source file or source folder as a bad anchor merely because it is broad. Bad anchors are fake paths, generated/dependency paths, .git paths, or useless anchors like the repo root.",
+      "Do not mark a combined top-level component as noisy merely because a more detailed rubric has separate expected nodes. Missing specificity belongs in node coverage, not quality penalties.",
+      "Penalize depth only when the proposal is clearly doing a deep audit instead of top-level bootstrap.",
+      "The proposal should be useful to a future coding agent that needs to understand this repo quickly."
+    ],
+    "actual_repo_facts": [
+      "This repo is a small TypeScript project named context-graph-memory.",
+      "The package exposes an ec binary that points to dist/apps/cli/main.js.",
+      "The TypeScript build compiles apps/**/*.ts and libs/**/*.ts into dist using tsconfig.build.json.",
+      "apps/cli/main.ts is the CLI entrypoint.",
+      "apps/cli/main.ts imports createLocalKnowledgeGraphService from libs/knowledge-graph/service.ts.",
+      "apps/cli/main.ts imports detectRepoContext from apps/cli/repo-context.ts.",
+      "The CLI constructs a KnowledgeGraphService once at startup and dispatches commands based on argv.",
+      "The CLI supports ec init.",
+      "ec init detects the repo context, calls service.initRepo, and prints repo/default branch/database/scope information.",
+      "The CLI supports ec graph read.",
+      "ec graph read detects repo context, calls service.readGraph, and prints components, flows, claims, sources, and edges.",
+      "The CLI supports ec graph search <query>.",
+      "ec graph search detects repo context, calls service.searchGraph, and prints matching graph records.",
+      "The CLI supports ec proposal validate <file>.",
+      "ec proposal validate reads a proposal JSON file, calls service.validateProposal, and reports validation errors.",
+      "The CLI supports ec proposal apply <file>.",
+      "ec proposal apply reads a proposal JSON file, calls service.applyProposal, and prints the created object counts.",
+      "The CLI is intentionally a thin local client: argument routing, file reading, repo detection, and human text output live there.",
+      "apps/cli/repo-context.ts uses git commands to detect the repo root.",
+      "apps/cli/repo-context.ts reads remote.origin.url when available and falls back to local:<repoRoot>.",
+      "apps/cli/repo-context.ts derives repo_name from the remote URL or local root basename.",
+      "apps/cli/repo-context.ts derives default_branch from refs/remotes/origin/HEAD and falls back to main.",
+      "libs/knowledge-graph/service.ts defines the KnowledgeGraphService class.",
+      "KnowledgeGraphService is the boundary the CLI calls for graph operations.",
+      "KnowledgeGraphService.initRepo upserts a repo and ensures a main scope and a working scope.",
+      "The main scope is named with the repo default branch.",
+      "The working scope is named working and parented to the main scope.",
+      "KnowledgeGraphService.readGraph loads the repo by remote URL and asks the repository for the current graph view.",
+      "KnowledgeGraphService.searchGraph loads the repo by remote URL and asks the repository to search the current graph view.",
+      "KnowledgeGraphService.validateProposal normalizes compact proposal input before validating it.",
+      "KnowledgeGraphService.applyProposal normalizes the proposal, validates it, requires the working scope, creates a memory commit, and writes proposal records.",
+      "applyProposal always writes the proposal records to the working scope in this current implementation.",
+      "createLocalKnowledgeGraphService wires KnowledgeGraphService to SqliteRepository and openDatabase.",
+      "libs/knowledge-graph/proposal.ts defines the canonical MemoryCommitProposal shape.",
+      "A proposal can create components, flows, claims, sources, and edges.",
+      "proposal.ts also defines compact proposal types that allow relationships inline on components, flows, and claims.",
+      "Compact component relationship fields include contains and supersedes.",
+      "Compact flow relationship fields include contains, touches, and supersedes.",
+      "Compact claim relationship fields include about, evidenced_by, and supersedes.",
+      "normalizeProposal removes compact relationship fields from nodes and converts them into canonical Edge records.",
+      "normalizeProposal generates deterministic edge IDs from kind/from/to fields.",
+      "normalizeProposal deduplicates generated edges by edge ID.",
+      "Explicit compact edges can be supplied with kind/from/to and are resolved to endpoint types.",
+      "Explicit canonical edges can also be supplied in creates.edges.",
+      "libs/knowledge-graph/validate-proposal.ts validates proposal structure.",
+      "validateProposal requires a non-empty title and a creates object.",
+      "validateProposal validates component IDs, names, and optional code_anchor type.",
+      "validateProposal validates flow IDs and names.",
+      "validateProposal validates claim IDs, kind, text, truth, and intent.",
+      "Allowed claim kinds are fact, requirement, decision, task, question, and risk.",
+      "Allowed claim truth values are code_verified, source_verified, and unknown.",
+      "Allowed claim intent values are intended, accidental, and unknown.",
+      "validateProposal validates source IDs, source kind, ref, and optional title.",
+      "Allowed source kinds currently include session, prd, doc, issue, pr, artifact, and code.",
+      "validateProposal validates edge IDs, endpoint types, endpoint existence, edge kind, allowed direction, and optional metadata.",
+      "libs/knowledge-graph/edge.ts defines allowed edge kinds: about, contains, touches, supersedes, and evidenced_by.",
+      "An about edge must go from Claim to Component or Flow.",
+      "A contains edge must go from Component to Component or Flow to Flow.",
+      "A touches edge must go from Flow to Component.",
+      "A supersedes edge must connect same-kind Component, Flow, or Claim nodes.",
+      "An evidenced_by edge must go from Claim to Source.",
+      "libs/knowledge-graph/schema.ts defines graph IDs, Component, Flow, Source, GraphObjectType, and MembershipSubjectType.",
+      "Component has id, name, and optional code_anchor.",
+      "Flow has id and name.",
+      "Source has id, kind, ref, and optional title.",
+      "MembershipSubjectType excludes source; memberships are for component, flow, claim, and edge.",
+      "libs/knowledge-graph/claim.ts defines ClaimKind, ClaimTruth, ClaimIntent, and Claim.",
+      "libs/knowledge-graph/scope.ts defines GraphScopeKind, GraphScope, and GraphMembership.",
+      "GraphScopeKind includes main, working, branch, session, and source, though current CLI flow uses main and working.",
+      "GraphMembership includes scope_id, subject_type, subject_id, and memory_commit_id.",
+      "libs/knowledge-graph/commit.ts defines MemoryCommit.",
+      "MemoryCommit includes scope_id, parent_memory_commit_id, optional git_commit_sha, title, summary, and created_at.",
+      "libs/storage/sqlite/db.ts opens the local SQLite database.",
+      "The default SQLite database lives under ENGINEERING_CONTEXT_HOME when set.",
+      "If ENGINEERING_CONTEXT_HOME is not set, the default home is ~/.engineering-context.",
+      "libs/storage/sqlite/migrate.ts applies schemaSql to the SQLite database.",
+      "libs/storage/sqlite/schema.ts defines tables for repos, graph_scopes, memory_commits, components, flows, claims, sources, edges, and graph_memberships.",
+      "The repos table stores id, remote_url, repo_name, and default_branch.",
+      "The graph_scopes table stores repo_id, kind, name, parent_scope_id, ref, and created_at.",
+      "The memory_commits table stores scope_id, parent_memory_commit_id, git_commit_sha, title, summary, and created_at.",
+      "The graph_memberships table links scope_id, subject_type, subject_id, and memory_commit_id.",
+      "The graph_memberships primary key is scope_id, subject_type, subject_id.",
+      "SqliteRepository.upsertRepo creates deterministic repo IDs from the remote URL.",
+      "SqliteRepository.ensureScope creates deterministic scope IDs from repo, kind, and name.",
+      "SqliteRepository.requireWorkingScope finds the working scope for a repo.",
+      "SqliteRepository.createMemoryCommit creates a new memory commit and links it to the previous commit in the same scope.",
+      "SqliteRepository.createProposalRecords inserts graph objects and creates graph memberships for components, flows, claims, and edges.",
+      "SqliteRepository.createProposalRecords inserts sources globally without graph memberships.",
+      "SqliteRepository.readGraphView reads current main and working scopes.",
+      "readGraphView loads memberships for current scopes, loads edges, computes active subjects, and filters edges whose endpoints are inactive.",
+      "readGraphView excludes subjects superseded by active supersedes edges.",
+      "readGraphView returns sources only when active edges point to them.",
+      "SqliteRepository.searchGraphView searches the current graph view by simple lowercase substring matching.",
+      "Search checks component name/code_anchor, flow name, claim text/kind, and source ref/title/kind.",
+      "skills/engineering-memory/SKILL.md is a skill for bootstrapping or updating engineering memory using ec.",
+      "The skill instructs agents to run ec init and ec graph read, inspect the repo shallowly, create a proposal, validate it, and apply only when asked.",
+      "The skill says bootstrap memory should be shallow and high-signal, not exhaustive.",
+      "The skill says sources are external artifacts and should not be created just because code was inspected during bootstrap.",
+      "The skill prefers important subsystems over tiny helpers.",
+      "The skill suggests roughly 3-8 components for a small repo unless more are clearly needed.",
+      "The skill prefers human workflows over function-level traces."
+    ],
+    "expected_nodes": [
+      {
+        "id": "component.cli_app",
+        "kind": "component",
+        "description": "CLI app that exposes ec commands and delegates to the service."
+      },
+      {
+        "id": "component.repo_context",
+        "kind": "component",
+        "description": "Repo context detection from Git remote, repo name, and default branch."
+      },
+      {
+        "id": "component.knowledge_graph_service",
+        "kind": "component",
+        "description": "KnowledgeGraphService boundary for init, read, search, validate, and apply."
+      },
+      {
+        "id": "component.proposal_normalization",
+        "kind": "component",
+        "description": "Proposal normalization that converts compact relationship fields into canonical edges."
+      },
+      {
+        "id": "component.proposal_validation",
+        "kind": "component",
+        "description": "Proposal validation for graph object fields, allowed values, references, and edge directions."
+      },
+      {
+        "id": "component.graph_schema",
+        "kind": "component",
+        "description": "Knowledge graph schema/types for components, flows, claims, sources, scopes, memberships, commits, and edges."
+      },
+      {
+        "id": "component.sqlite_repository",
+        "kind": "component",
+        "description": "SQLite repository/storage implementation that persists and reads graph data."
+      },
+      {
+        "id": "component.sqlite_schema",
+        "kind": "component",
+        "description": "SQLite database schema and migration/opening layer."
+      },
+      {
+        "id": "component.engineering_memory_skill",
+        "kind": "component",
+        "description": "Engineering-memory skill that guides shallow bootstrap proposal creation."
+      },
+      {
+        "id": "flow.init_repo",
+        "kind": "flow",
+        "description": "Repo initialization detects repo context and creates main plus working scopes."
+      },
+      {
+        "id": "flow.validate_proposal",
+        "kind": "flow",
+        "description": "Proposal validation flow normalizes compact proposal input and validates graph shape."
+      },
+      {
+        "id": "flow.apply_proposal",
+        "kind": "flow",
+        "description": "Proposal apply flow validates, creates a memory commit, and writes graph records to working scope."
+      },
+      {
+        "id": "flow.read_search_graph",
+        "kind": "flow",
+        "description": "Graph read/search flow reads the composed main plus working graph view."
+      },
+      {
+        "id": "flow.compact_edges",
+        "kind": "flow",
+        "description": "Compact relationship fields become canonical graph edges."
+      },
+      {
+        "id": "flow.bootstrap_skill",
+        "kind": "flow",
+        "description": "Engineering-memory skill guides shallow repo inspection and proposal creation."
+      },
+      {
+        "id": "claim.cli_thin_wrapper",
+        "kind": "claim",
+        "description": "CLI is a thin local client over KnowledgeGraphService."
+      },
+      {
+        "id": "claim.repo_context_git",
+        "kind": "claim",
+        "description": "Repo context detection derives remote URL, repo name, and default branch from Git."
+      },
+      {
+        "id": "claim.service_boundary",
+        "kind": "claim",
+        "description": "KnowledgeGraphService owns repo init, graph read/search, proposal validation, and proposal apply operations."
+      },
+      {
+        "id": "claim.compact_normalization",
+        "kind": "claim",
+        "description": "Compact proposal fields normalize into canonical edges."
+      },
+      {
+        "id": "claim.validation_rules",
+        "kind": "claim",
+        "description": "Validation enforces allowed claim values, source kinds, edge kinds, endpoint existence, and allowed edge direction."
+      },
+      {
+        "id": "claim.apply_working_scope",
+        "kind": "claim",
+        "description": "Proposal apply writes to the working scope through a memory commit."
+      },
+      {
+        "id": "claim.sqlite_persistence",
+        "kind": "claim",
+        "description": "SQLite repository persists repos, scopes, memory commits, graph objects, edges, and memberships."
+      },
+      {
+        "id": "claim.active_graph_view",
+        "kind": "claim",
+        "description": "Graph read/search use active records from main plus working and remove superseded subjects from the active view."
+      },
+      {
+        "id": "claim.sources_global",
+        "kind": "claim",
+        "description": "Sources are global and graph memberships exclude sources."
+      },
+      {
+        "id": "claim.skill_shallow_bootstrap",
+        "kind": "claim",
+        "description": "Engineering-memory skill instructs agents to create shallow, high-signal bootstrap proposals and validate them."
+      }
+    ],
+    "expected_edges": [
+      {
+        "id": "edge.init_touches_cli",
+        "from": "repo initialization flow",
+        "to": "CLI app component",
+        "description": "Repo initialization flow touches the CLI app."
+      },
+      {
+        "id": "edge.init_touches_repo_context",
+        "from": "repo initialization flow",
+        "to": "repo context detection component",
+        "description": "Repo initialization flow touches repo context detection."
+      },
+      {
+        "id": "edge.init_touches_service",
+        "from": "repo initialization flow",
+        "to": "KnowledgeGraphService component",
+        "description": "Repo initialization flow touches KnowledgeGraphService."
+      },
+      {
+        "id": "edge.init_touches_sqlite",
+        "from": "repo initialization flow",
+        "to": "SQLite repository/storage or SQLite schema component",
+        "description": "Repo initialization flow touches SQLite repository/storage or schema."
+      },
+      {
+        "id": "edge.validate_touches_normalization",
+        "from": "proposal validation flow",
+        "to": "proposal normalization component",
+        "description": "Proposal validation flow touches proposal normalization."
+      },
+      {
+        "id": "edge.validate_touches_validation",
+        "from": "proposal validation flow",
+        "to": "proposal validation component",
+        "description": "Proposal validation flow touches proposal validation."
+      },
+      {
+        "id": "edge.apply_touches_service",
+        "from": "proposal apply flow",
+        "to": "KnowledgeGraphService component",
+        "description": "Proposal apply flow touches KnowledgeGraphService."
+      },
+      {
+        "id": "edge.apply_touches_sqlite",
+        "from": "proposal apply flow",
+        "to": "SQLite repository/storage component",
+        "description": "Proposal apply flow touches SQLite repository/storage."
+      },
+      {
+        "id": "edge.apply_touches_schema",
+        "from": "proposal apply flow",
+        "to": "memory commits or graph schema component",
+        "description": "Proposal apply flow touches memory commits or graph schema."
+      },
+      {
+        "id": "edge.read_search_touches_service",
+        "from": "graph read/search flow",
+        "to": "KnowledgeGraphService component",
+        "description": "Graph read/search flow touches KnowledgeGraphService."
+      },
+      {
+        "id": "edge.read_search_touches_sqlite",
+        "from": "graph read/search flow",
+        "to": "SQLite repository/storage component",
+        "description": "Graph read/search flow touches SQLite repository/storage."
+      },
+      {
+        "id": "edge.compact_touches_normalization",
+        "from": "compact relationship fields flow",
+        "to": "proposal normalization component",
+        "description": "Compact edge flow touches proposal normalization."
+      },
+      {
+        "id": "edge.compact_touches_graph_edges",
+        "from": "compact relationship fields flow",
+        "to": "graph edge/schema model component",
+        "description": "Compact edge flow touches the graph edge/schema model. A grouped graph_schema component satisfies this relation."
+      },
+      {
+        "id": "edge.skill_touches_skill",
+        "from": "bootstrap skill flow",
+        "to": "engineering-memory skill component",
+        "description": "Bootstrap skill flow touches the engineering-memory skill."
+      },
+      {
+        "id": "edge.claims_about_subjects",
+        "from": "important claims",
+        "to": "relevant components and/or flows",
+        "description": "Important claims are about the relevant components and/or flows rather than left disconnected."
+      }
+    ],
+    "quality_rules": {
+      "noisy_structure_nodes": "Components and flows that do not help top-level repo orientation, such as package-lock, tsconfig, every tiny type file, generic source-code component, or single-helper-function flow. Do not count a real top-level subsystem as noisy only because it combines two expected concepts.",
+      "bad_claims": "Claims that are wrong, unsupported, duplicated, vague, too low-level, or not useful for future engineering work.",
+      "bad_anchors": "Anchors that point to fake paths, generated output, dependency folders, .git, or a vague repo root without a strong reason. A real file or folder anchor is acceptable if it points to the code where the represented component lives.",
+      "depth_violation": "The proposal is clearly too deep for bootstrap, such as component-per-file graphing, function-level tracing, or a full code audit.",
+      "weak_graph_linking": "The proposal creates nodes but does not meaningfully connect flows to components and claims to components/flows."
+    }
+  }
+}

--- a/evals/cases/bootstrap-current-repo-at-1872222/run.ts
+++ b/evals/cases/bootstrap-current-repo-at-1872222/run.ts
@@ -1,0 +1,555 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { runCodexAgent } from "../../../libs/agent-runner/codex.js";
+import type { AgentRunResult } from "../../../libs/agent-runner/types.js";
+
+const caseId = "bootstrap-current-repo-at-1872222";
+const targetRepoUrl = "git@github.com:Autoloops/engineering-context.git";
+const targetCommit = "1872222671c85b347950462bc65ef3da3611ed6e";
+
+interface CommandResult {
+  command: string[];
+  exit_code: number | null;
+  signal: string | null;
+}
+
+interface Args {
+  proposal?: string;
+  agent?: "codex";
+  agentModel?: string;
+  judge?: "openai";
+  judgeModel?: string;
+}
+
+interface RunContext {
+  repoRoot: string;
+  runDir: string;
+  targetRepoDir: string;
+  ecHomeDir: string;
+  proposalPath: string;
+  rubricPath: string;
+  ecCommand: string[];
+}
+
+interface EvalResult {
+  case_id: string;
+  target_repo_url: string;
+  target_commit: string;
+  run_dir: string;
+  target_repo_dir: string;
+  ec_home_dir: string;
+  proposal_path: string;
+  success: boolean;
+  commands: CommandResult[];
+  generation?: AgentRunResult;
+  judge?: {
+    model: string;
+    judge_input_path: string;
+    judge_output_path: string;
+    score: ScoreResult;
+  };
+}
+
+interface Rubric {
+  case_id: string;
+  target_repo_url: string;
+  target_commit: string;
+  score: {
+    pass_threshold: number;
+    node_coverage_points: number;
+    edge_coverage_points: number;
+    quality_points: number;
+    quality_penalties: {
+      noisy_structure_node_points: number;
+      noisy_structure_node_max: number;
+      bad_claim_points: number;
+      bad_claim_max: number;
+      bad_anchor_points: number;
+      bad_anchor_max: number;
+      depth_violation_points: number;
+      weak_graph_linking_points: number;
+    };
+  };
+  judge: JudgeRubric;
+}
+
+interface JudgeRubric {
+  instructions: string[];
+  actual_repo_facts: string[];
+  expected_nodes: Array<{ id: string; kind: string; description: string }>;
+  expected_edges: Array<{ id: string; description: string; from?: string; to?: string }>;
+  quality_rules: Record<string, string>;
+}
+
+interface JudgeInput {
+  task: string;
+  rubric: JudgeRubric;
+  repo_tree: string[];
+  proposal: unknown;
+}
+
+interface JudgeOutput {
+  nodes: Array<{
+    expected_id: string;
+    present: boolean;
+    matched_ids: string[];
+    reason: string;
+  }>;
+  edges: Array<{
+    expected_id: string;
+    present: boolean;
+    matched: string[];
+    reason: string;
+  }>;
+  quality: {
+    noisy_structure_nodes: Array<{ id: string; reason: string }>;
+    bad_claims: Array<{ id: string; reason: string }>;
+    bad_anchors: Array<{ id: string; anchor: string; reason: string }>;
+    depth_violation: { present: boolean; reason: string };
+    weak_graph_linking: { present: boolean; reason: string };
+  };
+}
+
+interface ScoreResult {
+  node_score: number;
+  edge_score: number;
+  quality_score: number;
+  final_score: number;
+  pass_threshold: number;
+  passed: boolean;
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const context = prepareRun();
+  prepareTargetRepo(context);
+  prepareEcHome(context);
+  const initCommand = runProductCommand(context, "init");
+  const generation = await getProposal(context, args);
+  const commands = [
+    initCommand,
+    ...runProductCommands(context),
+  ];
+  const commandsSucceeded = commands.every((command) => command.exit_code === 0);
+  const judge = commandsSucceeded && args.judge === "openai" ? await runOpenAiJudge(context, args) : undefined;
+  const success = commandsSucceeded && (judge === undefined || judge.score.passed);
+  writeResult(context, commands, success, generation, judge);
+
+  console.log(success ? "Eval run passed." : "Eval run failed.");
+  console.log(`Run directory: ${context.runDir}`);
+  if (judge) {
+    console.log(`Score: ${judge.score.final_score.toFixed(2)} / 100`);
+  }
+  process.exitCode = success ? 0 : 1;
+}
+
+function prepareRun(): RunContext {
+  const repoRoot = findRepoRoot();
+  const runDir = resolve(repoRoot, "eval-runs", timestamp(), caseId);
+  const targetRepoDir = resolve(runDir, "target-repo");
+  const ecHomeDir = resolve(runDir, "ec-home");
+  const proposalPath = resolve(runDir, "proposal.json");
+  const rubricPath = resolve(repoRoot, "evals/cases/bootstrap-current-repo-at-1872222/rubric.json");
+  const ecCommand = ["node", resolve(repoRoot, "dist/apps/cli/main.js")];
+
+  mkdirSync(runDir, { recursive: true });
+
+  return {
+    repoRoot,
+    runDir,
+    targetRepoDir,
+    ecHomeDir,
+    proposalPath,
+    rubricPath,
+    ecCommand,
+  };
+}
+
+function prepareTargetRepo(context: RunContext): void {
+  runOrThrow(["git", "clone", targetRepoUrl, context.targetRepoDir], context.repoRoot);
+  runOrThrow(["git", "checkout", targetCommit], context.targetRepoDir);
+}
+
+function prepareEcHome(context: RunContext): void {
+  mkdirSync(context.ecHomeDir, { recursive: true });
+}
+
+async function getProposal(context: RunContext, args: Args): Promise<AgentRunResult | undefined> {
+  if (args.proposal) {
+    copyFileSync(resolve(args.proposal), context.proposalPath);
+    return undefined;
+  }
+
+  if (args.agent === "codex") {
+    const model = args.agentModel ?? "gpt-5.4-mini";
+    const result = await runCodexAgent({
+      cwd: context.targetRepoDir,
+      env: { ...process.env, ENGINEERING_CONTEXT_HOME: context.ecHomeDir },
+      model,
+      prompt: codexBootstrapPrompt(context),
+      transcriptPath: resolve(context.runDir, "agent-events.jsonl"),
+      finalMessagePath: resolve(context.runDir, "agent-final-message.txt"),
+      proposalPath: context.proposalPath,
+    });
+    if (result.exit_code !== 0) {
+      throw new Error(`Codex agent failed with exit code ${String(result.exit_code)}.`);
+    }
+    if (!existsSync(context.proposalPath)) {
+      throw new Error(`Codex agent did not create proposal at ${context.proposalPath}.`);
+    }
+    return result;
+  }
+
+  throw new Error("Expected either --proposal <path> or --agent codex.");
+}
+
+function runProductCommands(context: RunContext): CommandResult[] {
+  const commands = [
+    [...context.ecCommand, "proposal", "validate", context.proposalPath],
+    [...context.ecCommand, "proposal", "apply", context.proposalPath],
+  ];
+
+  return commands.map((command) => runProductCommand(context, ...command.slice(context.ecCommand.length)));
+}
+
+function runProductCommand(context: RunContext, ...args: string[]): CommandResult {
+  const env = { ...process.env, ENGINEERING_CONTEXT_HOME: context.ecHomeDir };
+  return run([...context.ecCommand, ...args], context.targetRepoDir, env);
+}
+
+async function runOpenAiJudge(
+  context: RunContext,
+  args: Args,
+): Promise<NonNullable<EvalResult["judge"]>> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY is required when using --judge openai.");
+
+  const model = args.judgeModel ?? process.env.OPENAI_MODEL;
+  if (!model) throw new Error("Set OPENAI_MODEL or pass --judge-model when using --judge openai.");
+
+  const rubric = readJson<Rubric>(context.rubricPath);
+  const proposal = readJson<unknown>(context.proposalPath);
+  const judgeInput: JudgeInput = {
+    task: "Judge this bootstrap memory proposal for the pinned repo commit. Return JSON classification only; do not compute numeric scores.",
+    rubric: rubric.judge,
+    repo_tree: repoTree(context.targetRepoDir),
+    proposal,
+  };
+  const judgeInputPath = resolve(context.runDir, "judge-input.json");
+  const judgeOutputPath = resolve(context.runDir, "judge-output.json");
+  writeFileSync(judgeInputPath, `${JSON.stringify(judgeInput, null, 2)}\n`);
+
+  const judgeOutput = await requestJudge(apiKey, model, judgeInput);
+  writeFileSync(judgeOutputPath, `${JSON.stringify(judgeOutput, null, 2)}\n`);
+
+  return {
+    model,
+    judge_input_path: judgeInputPath,
+    judge_output_path: judgeOutputPath,
+    score: scoreJudgeOutput(rubric, judgeOutput),
+  };
+}
+
+function writeResult(
+  context: RunContext,
+  commands: CommandResult[],
+  success: boolean,
+  generation: AgentRunResult | undefined,
+  judge: EvalResult["judge"],
+): void {
+  const result: EvalResult = {
+    case_id: caseId,
+    target_repo_url: targetRepoUrl,
+    target_commit: targetCommit,
+    run_dir: context.runDir,
+    target_repo_dir: context.targetRepoDir,
+    ec_home_dir: context.ecHomeDir,
+    proposal_path: context.proposalPath,
+    success,
+    commands,
+    generation,
+    judge,
+  };
+
+  writeFileSync(resolve(context.runDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
+}
+
+function parseArgs(args: string[]): Args {
+  const proposal = valueAfter(args, "--proposal");
+  const agent = valueAfter(args, "--agent");
+  if ((proposal === undefined && agent === undefined) || (proposal !== undefined && agent !== undefined)) {
+    throw new Error("Usage: npm run eval:bootstrap-current -- (--proposal /path/to/proposal.json | --agent codex) [--agent-model model] [--judge openai] [--judge-model model]");
+  }
+  if (agent !== undefined && agent !== "codex") throw new Error("Only --agent codex is supported.");
+
+  const judge = valueAfter(args, "--judge");
+  if (judge !== undefined && judge !== "openai") {
+    throw new Error("Only --judge openai is supported.");
+  }
+
+  const agentModel = valueAfter(args, "--agent-model");
+  const judgeModel = valueAfter(args, "--judge-model");
+
+  return { proposal, agent, agentModel, judge, judgeModel };
+}
+
+function runOrThrow(command: string[], cwd: string): void {
+  const result = run(command, cwd, process.env);
+  if (result.exit_code !== 0) {
+    throw new Error(`Command failed: ${command.join(" ")}`);
+  }
+}
+
+function run(command: string[], cwd: string, env: NodeJS.ProcessEnv): CommandResult {
+  const result = spawnSync(command[0] ?? "", command.slice(1), {
+    cwd,
+    env,
+    stdio: "inherit",
+  });
+
+  return {
+    command,
+    exit_code: result.status,
+    signal: result.signal,
+  };
+}
+
+function codexBootstrapPrompt(context: RunContext): string {
+  const skill = readFileSync(resolve(context.repoRoot, "skills/engineering-memory/SKILL.md"), "utf8");
+  const ec = context.ecCommand.join(" ");
+
+  return `You are running an engineering-memory bootstrap workflow for this repository.
+
+Use this exact user-facing skill as the workflow contract:
+
+<engineering_memory_skill>
+${skill}
+</engineering_memory_skill>
+
+Runtime facts for this eval:
+- Current working directory is the target repository root.
+- ENGINEERING_CONTEXT_HOME is already set to an isolated eval directory.
+- Use this ec command exactly: ${ec}
+- Write the final proposal JSON exactly here: ${context.proposalPath}
+- If this repository contains skills/engineering-memory/SKILL.md, treat that file as part of the repository being bootstrapped. Do not ignore it just because the same skill content is included above as the workflow contract.
+- If this repository contains graph schema/type/model files that define components, flows, claims, edges, scopes, memberships, or commits, consider whether they are important top-level memory.
+
+Task:
+1. Run the skill workflow for bootstrap memory on this repo.
+2. Inspect the repo shallowly. Prefer top-level components, flows, and durable claims.
+3. Create a compact proposal JSON at ${context.proposalPath}.
+4. Validate it with: ${ec} proposal validate ${context.proposalPath}
+5. Fix validation errors until valid.
+6. Do not apply the proposal.
+
+The proposal should be useful to a future coding agent and should avoid deep implementation trivia.`;
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function repoTree(cwd: string): string[] {
+  const output = spawnSync("git", ["ls-tree", "-r", "--name-only", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if (output.status !== 0) throw new Error("Failed to read target repo tree.");
+  return output.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+}
+
+async function requestJudge(apiKey: string, model: string, input: JudgeInput): Promise<JudgeOutput> {
+  const response = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      input: [
+        {
+          role: "system",
+          content:
+            "You are an evaluator for engineering-memory bootstrap proposals. Return JSON only. Classify expected nodes, expected edges, and quality issues. Do not calculate numeric scores.",
+        },
+        {
+          role: "user",
+          content: JSON.stringify(input),
+        },
+      ],
+      text: {
+        format: {
+          type: "json_schema",
+          name: "bootstrap_eval_judge",
+          strict: true,
+          schema: judgeOutputSchema(),
+        },
+      },
+    }),
+  });
+
+  const body = await response.json() as Record<string, unknown>;
+  if (!response.ok) {
+    throw new Error(`OpenAI judge request failed: ${JSON.stringify(body)}`);
+  }
+
+  const outputText = extractOutputText(body);
+  return JSON.parse(outputText) as JudgeOutput;
+}
+
+function scoreJudgeOutput(rubric: Rubric, judge: JudgeOutput): ScoreResult {
+  const presentNodes = new Set(judge.nodes.filter((item) => item.present).map((item) => item.expected_id));
+  const presentEdges = new Set(judge.edges.filter((item) => item.present).map((item) => item.expected_id));
+  const nodeScore = (presentNodes.size / rubric.judge.expected_nodes.length) * rubric.score.node_coverage_points;
+  const edgeScore = (presentEdges.size / rubric.judge.expected_edges.length) * rubric.score.edge_coverage_points;
+  const penalties = rubric.score.quality_penalties;
+  const qualityPenalty =
+    Math.min(judge.quality.noisy_structure_nodes.length * penalties.noisy_structure_node_points, penalties.noisy_structure_node_max) +
+    Math.min(judge.quality.bad_claims.length * penalties.bad_claim_points, penalties.bad_claim_max) +
+    Math.min(judge.quality.bad_anchors.length * penalties.bad_anchor_points, penalties.bad_anchor_max) +
+    (judge.quality.depth_violation.present ? penalties.depth_violation_points : 0) +
+    (judge.quality.weak_graph_linking.present ? penalties.weak_graph_linking_points : 0);
+  const qualityScore = Math.max(0, rubric.score.quality_points - qualityPenalty);
+  const finalScore = nodeScore + edgeScore + qualityScore;
+
+  return {
+    node_score: round(nodeScore),
+    edge_score: round(edgeScore),
+    quality_score: round(qualityScore),
+    final_score: round(finalScore),
+    pass_threshold: rubric.score.pass_threshold,
+    passed: finalScore >= rubric.score.pass_threshold,
+  };
+}
+
+function extractOutputText(body: Record<string, unknown>): string {
+  if (typeof body.output_text === "string") return body.output_text;
+
+  const output = body.output;
+  if (!Array.isArray(output)) throw new Error("OpenAI response did not include output text.");
+
+  const texts: string[] = [];
+  for (const item of output) {
+    if (!isRecord(item) || !Array.isArray(item.content)) continue;
+    for (const content of item.content) {
+      if (isRecord(content) && typeof content.text === "string") texts.push(content.text);
+    }
+  }
+
+  const text = texts.join("");
+  if (text.length === 0) throw new Error("OpenAI response output text was empty.");
+  return text;
+}
+
+function judgeOutputSchema(): Record<string, unknown> {
+  const reasonedItem = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      expected_id: { type: "string" },
+      present: { type: "boolean" },
+      matched_ids: { type: "array", items: { type: "string" } },
+      reason: { type: "string" },
+    },
+    required: ["expected_id", "present", "matched_ids", "reason"],
+  };
+  const edgeItem = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      expected_id: { type: "string" },
+      present: { type: "boolean" },
+      matched: { type: "array", items: { type: "string" } },
+      reason: { type: "string" },
+    },
+    required: ["expected_id", "present", "matched", "reason"],
+  };
+  const issueItem = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      id: { type: "string" },
+      reason: { type: "string" },
+    },
+    required: ["id", "reason"],
+  };
+
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      nodes: { type: "array", items: reasonedItem },
+      edges: { type: "array", items: edgeItem },
+      quality: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          noisy_structure_nodes: { type: "array", items: issueItem },
+          bad_claims: { type: "array", items: issueItem },
+          bad_anchors: {
+            type: "array",
+            items: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                id: { type: "string" },
+                anchor: { type: "string" },
+                reason: { type: "string" },
+              },
+              required: ["id", "anchor", "reason"],
+            },
+          },
+          depth_violation: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              present: { type: "boolean" },
+              reason: { type: "string" },
+            },
+            required: ["present", "reason"],
+          },
+          weak_graph_linking: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              present: { type: "boolean" },
+              reason: { type: "string" },
+            },
+            required: ["present", "reason"],
+          },
+        },
+        required: ["noisy_structure_nodes", "bad_claims", "bad_anchors", "depth_violation", "weak_graph_linking"],
+      },
+    },
+    required: ["nodes", "edges", "quality"],
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function valueAfter(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function findRepoRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}

--- a/evals/cases/bootstrap-current-repo-at-1872222/sample-good.proposal.json
+++ b/evals/cases/bootstrap-current-repo-at-1872222/sample-good.proposal.json
@@ -1,0 +1,228 @@
+{
+  "title": "Bootstrap engineering-context memory",
+  "summary": "Top-level memory for the CLI, knowledge graph service, proposal pipeline, SQLite storage, graph schema, and engineering-memory skill.",
+  "creates": {
+    "components": [
+      {
+        "id": "component.cli_app",
+        "name": "Engineering Context CLI",
+        "code_anchor": "apps/cli"
+      },
+      {
+        "id": "component.repo_context_detection",
+        "name": "Repo Context Detection",
+        "code_anchor": "apps/cli/repo-context.ts"
+      },
+      {
+        "id": "component.knowledge_graph_service",
+        "name": "Knowledge Graph Service",
+        "code_anchor": "libs/knowledge-graph/service.ts"
+      },
+      {
+        "id": "component.proposal_normalization",
+        "name": "Proposal Normalization",
+        "code_anchor": "libs/knowledge-graph/proposal.ts"
+      },
+      {
+        "id": "component.proposal_validation",
+        "name": "Proposal Validation",
+        "code_anchor": "libs/knowledge-graph/validate-proposal.ts"
+      },
+      {
+        "id": "component.graph_schema",
+        "name": "Graph Schema and Types",
+        "code_anchor": "libs/knowledge-graph/schema.ts, libs/knowledge-graph/claim.ts, libs/knowledge-graph/edge.ts, libs/knowledge-graph/scope.ts, libs/knowledge-graph/commit.ts"
+      },
+      {
+        "id": "component.sqlite_repository",
+        "name": "SQLite Repository",
+        "code_anchor": "libs/storage/sqlite/repository.ts"
+      },
+      {
+        "id": "component.sqlite_schema",
+        "name": "SQLite Schema and Database Setup",
+        "code_anchor": "libs/storage/sqlite/schema.ts, libs/storage/sqlite/db.ts, libs/storage/sqlite/migrate.ts"
+      },
+      {
+        "id": "component.engineering_memory_skill",
+        "name": "Engineering Memory Skill",
+        "code_anchor": "skills/engineering-memory/SKILL.md"
+      }
+    ],
+    "flows": [
+      {
+        "id": "flow.repo_initialization",
+        "name": "Repo initialization creates main and working scopes",
+        "touches": [
+          "component.cli_app",
+          "component.repo_context_detection",
+          "component.knowledge_graph_service",
+          "component.sqlite_repository",
+          "component.sqlite_schema",
+          "component.graph_schema"
+        ]
+      },
+      {
+        "id": "flow.proposal_validation",
+        "name": "Proposal validation normalizes compact input and validates graph shape",
+        "touches": [
+          "component.cli_app",
+          "component.knowledge_graph_service",
+          "component.proposal_normalization",
+          "component.proposal_validation"
+        ]
+      },
+      {
+        "id": "flow.proposal_apply",
+        "name": "Proposal apply creates a memory commit and writes records to working scope",
+        "touches": [
+          "component.cli_app",
+          "component.knowledge_graph_service",
+          "component.proposal_normalization",
+          "component.proposal_validation",
+          "component.sqlite_repository",
+          "component.graph_schema"
+        ]
+      },
+      {
+        "id": "flow.graph_read_search",
+        "name": "Graph read and search use main plus working graph view",
+        "touches": [
+          "component.cli_app",
+          "component.knowledge_graph_service",
+          "component.sqlite_repository"
+        ]
+      },
+      {
+        "id": "flow.compact_relationships",
+        "name": "Compact relationship fields become canonical graph edges",
+        "touches": [
+          "component.proposal_normalization",
+          "component.graph_schema"
+        ]
+      },
+      {
+        "id": "flow.skill_bootstrap",
+        "name": "Engineering memory skill guides shallow bootstrap proposal creation",
+        "touches": [
+          "component.engineering_memory_skill",
+          "component.cli_app"
+        ]
+      }
+    ],
+    "claims": [
+      {
+        "id": "claim.cli_thin_client",
+        "kind": "fact",
+        "text": "The CLI is a thin local client that routes commands, reads proposal files, detects repo context, prints human output, and delegates graph behavior to KnowledgeGraphService.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.cli_app",
+          "component.knowledge_graph_service"
+        ]
+      },
+      {
+        "id": "claim.repo_context_from_git",
+        "kind": "fact",
+        "text": "Repo context detection derives the repo root, remote URL, repo name, and default branch from Git, with local and main fallbacks.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.repo_context_detection",
+          "flow.repo_initialization"
+        ]
+      },
+      {
+        "id": "claim.service_is_graph_boundary",
+        "kind": "fact",
+        "text": "KnowledgeGraphService is the boundary used by the CLI for repo initialization, graph read/search, proposal validation, and proposal apply.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.knowledge_graph_service"
+        ]
+      },
+      {
+        "id": "claim.compact_fields_normalize_to_edges",
+        "kind": "fact",
+        "text": "Compact proposal fields such as contains, touches, about, evidenced_by, and supersedes are normalized into canonical graph edges before validation and apply.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.proposal_normalization",
+          "flow.compact_relationships"
+        ]
+      },
+      {
+        "id": "claim.validation_enforces_graph_rules",
+        "kind": "fact",
+        "text": "Proposal validation enforces allowed claim kinds, truth and intent values, source kinds, edge kinds, endpoint existence, metadata shape, and edge direction rules.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.proposal_validation",
+          "component.graph_schema",
+          "flow.proposal_validation"
+        ]
+      },
+      {
+        "id": "claim.apply_writes_working_commit",
+        "kind": "fact",
+        "text": "Applying a proposal normalizes and validates it, creates a memory commit, and writes new graph records into the working scope.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "flow.proposal_apply",
+          "component.knowledge_graph_service",
+          "component.sqlite_repository",
+          "component.graph_schema"
+        ]
+      },
+      {
+        "id": "claim.sqlite_persists_graph_records",
+        "kind": "fact",
+        "text": "The SQLite repository persists repos, graph scopes, memory commits, components, flows, claims, sources, edges, and graph memberships.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.sqlite_repository",
+          "component.sqlite_schema"
+        ]
+      },
+      {
+        "id": "claim.read_search_active_main_working",
+        "kind": "fact",
+        "text": "Graph read and search operate on active graph records from main plus working scopes and exclude superseded subjects from the active view.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "flow.graph_read_search",
+          "component.sqlite_repository"
+        ]
+      },
+      {
+        "id": "claim.sources_global_memberships_exclude_sources",
+        "kind": "fact",
+        "text": "Sources are stored globally, while graph memberships are created for components, flows, claims, and edges rather than sources.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.graph_schema",
+          "component.sqlite_repository"
+        ]
+      },
+      {
+        "id": "claim.skill_requires_shallow_validated_bootstrap",
+        "kind": "fact",
+        "text": "The engineering-memory skill tells agents to inspect a repo shallowly, create high-signal component/flow/claim memory, validate proposals, and avoid applying unless requested.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.engineering_memory_skill",
+          "flow.skill_bootstrap"
+        ]
+      }
+    ]
+  }
+}

--- a/libs/agent-runner/codex.ts
+++ b/libs/agent-runner/codex.ts
@@ -1,0 +1,65 @@
+import { createWriteStream } from "node:fs";
+import { spawn } from "node:child_process";
+import { collectAgentMetrics } from "./metrics.js";
+import type { AgentRunInput, AgentRunResult } from "./types.js";
+
+export async function runCodexAgent(input: AgentRunInput): Promise<AgentRunResult> {
+  const startedAt = Date.now();
+  const transcript = createWriteStream(input.transcriptPath, { flags: "w" });
+  const result = await runCodexProcess(input, transcript);
+  transcript.end();
+
+  const elapsedMs = Date.now() - startedAt;
+  const metrics = collectAgentMetrics({
+    transcriptPath: input.transcriptPath,
+  });
+
+  return {
+    agent: "codex",
+    model: input.model,
+    elapsed_ms: elapsedMs,
+    transcript_path: input.transcriptPath,
+    final_message_path: input.finalMessagePath,
+    exit_code: result.exitCode,
+    signal: result.signal,
+    ...metrics,
+  };
+}
+
+function runCodexProcess(
+  input: AgentRunInput,
+  transcript: NodeJS.WritableStream,
+): Promise<{ exitCode: number | null; signal: string | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "codex",
+      [
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--json",
+        "--model",
+        input.model,
+        "--cd",
+        input.cwd,
+        "--sandbox",
+        "danger-full-access",
+        "--output-last-message",
+        input.finalMessagePath,
+        "-",
+      ],
+      {
+        cwd: input.cwd,
+        env: input.env,
+        stdio: ["pipe", "pipe", "inherit"],
+      },
+    );
+
+    child.once("error", reject);
+    child.stdout.pipe(transcript);
+    child.stdin.end(input.prompt);
+    child.once("close", (exitCode, signal) => {
+      resolve({ exitCode, signal });
+    });
+  });
+}

--- a/libs/agent-runner/metrics.ts
+++ b/libs/agent-runner/metrics.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync } from "node:fs";
+
+export interface AgentMetricInput {
+  transcriptPath: string;
+}
+
+export interface AgentMetrics {
+  tool_calls: number;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+}
+
+export function collectAgentMetrics(input: AgentMetricInput): AgentMetrics {
+  const transcript = readOptional(input.transcriptPath);
+  const toolCalls = countToolCalls(transcript);
+  const usage = usageFromTranscript(transcript);
+  const inputTokens = usage?.input_tokens ?? null;
+  const outputTokens = usage?.output_tokens ?? null;
+
+  return {
+    tool_calls: toolCalls,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: inputTokens === null || outputTokens === null ? null : inputTokens + outputTokens,
+  };
+}
+
+function countToolCalls(jsonl: string): number {
+  if (jsonl.trim().length === 0) return 0;
+
+  let count = 0;
+  for (const line of jsonl.split("\n")) {
+    const event = parseJsonLine(line);
+    if (!event) continue;
+    if (isRecord(event) && event.type === "item.started" && isRecord(event.item) && event.item.type === "command_execution") {
+      count += 1;
+      continue;
+    }
+    const text = JSON.stringify(event).toLowerCase();
+    if (
+      text.includes("exec_command") ||
+      text.includes("command_begin") ||
+      text.includes("command_start") ||
+      text.includes("\"type\":\"tool_call\"") ||
+      text.includes("\"type\":\"function_call\"")
+    ) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function usageFromTranscript(jsonl: string): { input_tokens: number; output_tokens: number } | undefined {
+  let latest: { input_tokens: number; output_tokens: number } | undefined;
+
+  for (const line of jsonl.split("\n")) {
+    const event = parseJsonLine(line);
+    if (!isRecord(event) || !isRecord(event.usage)) continue;
+    const inputTokens = event.usage.input_tokens;
+    const outputTokens = event.usage.output_tokens;
+    if (typeof inputTokens === "number" && typeof outputTokens === "number") {
+      latest = {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+      };
+    }
+  }
+
+  return latest;
+}
+
+function parseJsonLine(line: string): unknown | undefined {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return undefined;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function readOptional(path: string): string {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/libs/agent-runner/types.ts
+++ b/libs/agent-runner/types.ts
@@ -1,0 +1,25 @@
+export type AgentKind = "codex";
+
+export interface AgentRunInput {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  model: string;
+  prompt: string;
+  transcriptPath: string;
+  finalMessagePath: string;
+  proposalPath?: string;
+}
+
+export interface AgentRunResult {
+  agent: AgentKind;
+  model: string;
+  elapsed_ms: number;
+  tool_calls: number;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+  transcript_path: string;
+  final_message_path: string;
+  exit_code: number | null;
+  signal: string | null;
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-1872222/run.js"
   },
   "dependencies": {
     "better-sqlite3": "^11.9.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["apps/**/*.ts", "libs/**/*.ts"]
+  "include": ["apps/**/*.ts", "libs/**/*.ts", "evals/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add a bootstrap-current-repo eval case pinned to commit 1872222
- add a shared Codex agent runner with real token/tool/time metrics
- add an OpenAI judge path plus sample proposal and rubric

## Verification
- npm run typecheck
- npm run build
- gpt-5.4-mini Codex eval: 65/100, failed, 102.7s, 20 tool calls, 189,737 total tokens
- gpt-5.5 Codex eval: 100/100, passed, 141.8s, 24 tool calls, 243,958 total tokens
