### PR TITLE
Add Greplica coding eval and graph context outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ greplica-bootstrap
 greplica-update-working-memory
 ```
 
-After installing skills, verify:
+After installing skills, verify the install:
 
 ```bash
 greplica doctor
@@ -94,6 +94,8 @@ Use greplica-update-working-memory for this session.
 
 Run bootstrap once near the start of using Greplica in a repo. Run update working memory near the end of a coding session when the session contains durable decisions, changed flows, constraints, follow-up work, or useful implementation context.
 
+Do not run `greplica doctor` before normal Greplica commands. Use the intended command directly, such as `greplica graph context "<query>"`; if it fails, use the error message to decide whether `doctor` would help diagnose installation, repo detection, or OpenAI configuration.
+
 ## Configuration
 
 `greplica` looks for `OPENAI_API_KEY` in this order:
@@ -117,6 +119,8 @@ greplica proposal apply <proposal.json>
 ```
 
 `greplica` automatically prepares repo memory state when commands run, so users should not need a separate init step.
+
+`greplica doctor` is for install verification and diagnosing failures, not a required preflight before every Greplica command.
 
 ## Alpha Status
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ Memory is stored in `~/.greplica/graph.db` by default. Set `GREPLICA_HOME` only 
 ```bash
 greplica doctor [--check-openai]
 greplica graph read
-greplica graph context "<query>"
+greplica graph context "<query>" [--json|--debug]
 greplica proposal validate <proposal.json>
 greplica proposal apply <proposal.json>
 ```
+
+`greplica graph context "<query>"` prints concise Markdown for coding-agent use. Use `--json` for compact structured output, or `--debug` for the full retrieval payload with ranking signals and embedding status.
 
 `greplica` automatically prepares repo memory state when commands run, so users should not need a separate init step.
 

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
-import { basename } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { createLocalKnowledgeGraphService } from "../../libs/knowledge-graph/service.js";
 import type { KnowledgeGraphService, RepoRef } from "../../libs/knowledge-graph/service.js";
 import { envVarSource, loadRepoEnv, type LoadedRepoEnv } from "../../libs/env/load-local-env.js";
 import { graphContextConfig } from "../../libs/knowledge-graph/graph-context/config.js";
 import { OpenAIEmbedder } from "../../libs/knowledge-graph/graph-context/openai-embedder.js";
+import { buildGraphFolderExport } from "../../libs/knowledge-graph/folder-export.js";
 import { detectRepoContext } from "./repo-context.js";
 
 interface CommandContext {
@@ -53,6 +54,16 @@ async function main(argv: string[]): Promise<void> {
     const { repo, service } = createCommandContext();
     const result = await service.contextGraph(repo, query);
     console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (area === "graph" && action === "export") {
+    const outputDir = requireFile(rest[0], "Usage: greplica graph export <dir>");
+    const { repo, service } = createCommandContext();
+    const files = buildGraphFolderExport(service.readGraph(repo));
+    writeGraphFolderExport(outputDir, files);
+    console.log(`Exported current graph view to ${outputDir}`);
+    console.log(`Files: ${files.length}`);
     return;
   }
 
@@ -166,6 +177,15 @@ function requireFile(file: string | undefined, usage: string): string {
   return file;
 }
 
+function writeGraphFolderExport(outputDir: string, files: Array<{ path: string; content: string }>): void {
+  mkdirSync(outputDir, { recursive: true });
+  for (const file of files) {
+    const outputPath = join(outputDir, file.path);
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, file.content, "utf8");
+  }
+}
+
 function printSection<T extends { id: string }>(title: string, items: T[], format: (item: T) => string): void {
   console.log(`${title}: ${items.length}`);
   for (const item of items) {
@@ -193,6 +213,7 @@ function printHelp(): void {
   ${cli} doctor [--check-openai]
   ${cli} graph read
   ${cli} graph context <query>
+  ${cli} graph export <dir>
   ${cli} proposal validate <file>
   ${cli} proposal apply <file>`);
 }

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -6,6 +6,7 @@ import type { KnowledgeGraphService, RepoRef } from "../../libs/knowledge-graph/
 import { envVarSource, loadRepoEnv, type LoadedRepoEnv } from "../../libs/env/load-local-env.js";
 import { graphContextConfig } from "../../libs/knowledge-graph/graph-context/config.js";
 import { OpenAIEmbedder } from "../../libs/knowledge-graph/graph-context/openai-embedder.js";
+import { compactGraphContextResult, renderGraphContextMarkdown } from "../../libs/knowledge-graph/graph-context/render.js";
 import { buildGraphFolderExport } from "../../libs/knowledge-graph/folder-export.js";
 import { detectRepoContext } from "./repo-context.js";
 
@@ -49,11 +50,18 @@ async function main(argv: string[]): Promise<void> {
   }
 
   if (area === "graph" && action === "context") {
-    const query = rest.filter((arg) => arg !== "--json").join(" ").trim();
+    const output = parseGraphContextOutput(rest);
+    const query = rest.filter((arg) => arg !== "--json" && arg !== "--debug").join(" ").trim();
     if (query.length === 0) throw new Error(`Usage: greplica graph ${action} <query>`);
     const { repo, service } = createCommandContext();
     const result = await service.contextGraph(repo, query);
-    console.log(JSON.stringify(result, null, 2));
+    if (output === "debug") {
+      console.log(JSON.stringify(result, null, 2));
+    } else if (output === "json") {
+      console.log(JSON.stringify(compactGraphContextResult(result), null, 2));
+    } else {
+      console.log(renderGraphContextMarkdown(result));
+    }
     return;
   }
 
@@ -177,6 +185,15 @@ function requireFile(file: string | undefined, usage: string): string {
   return file;
 }
 
+function parseGraphContextOutput(args: string[]): "markdown" | "json" | "debug" {
+  const json = args.includes("--json");
+  const debug = args.includes("--debug");
+  if (json && debug) throw new Error("Use either --json or --debug, not both.");
+  if (debug) return "debug";
+  if (json) return "json";
+  return "markdown";
+}
+
 function writeGraphFolderExport(outputDir: string, files: Array<{ path: string; content: string }>): void {
   mkdirSync(outputDir, { recursive: true });
   for (const file of files) {
@@ -212,7 +229,7 @@ function printHelp(): void {
   console.log(`Usage:
   ${cli} doctor [--check-openai]
   ${cli} graph read
-  ${cli} graph context <query>
+  ${cli} graph context <query> [--json|--debug]
   ${cli} graph export <dir>
   ${cli} proposal validate <file>
   ${cli} proposal apply <file>`);

--- a/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/check-proposal-apply-atomicity.mjs
+++ b/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/check-proposal-apply-atomicity.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = findRepoRoot(scriptDir);
+const args = parseArgs(process.argv.slice(2));
+const ownsTempDir = args.keepTemp !== true;
+const tempDir = mkdtempSync(resolve(tmpdir(), "greplica-apply-atomicity-"));
+const dbPath = resolve(tempDir, "graph.db");
+const resultJson = args.resultJson;
+
+const marker = {
+  component: "component.atomicity_marker",
+  flow: "flow.atomicity_marker",
+  claim: "claim.atomicity_marker",
+  source: "source.atomicity_marker",
+  edges: [
+    "edge.atomicity_claim_component",
+    "edge.atomicity_claim_source",
+    "edge.atomicity_flow_component",
+  ],
+  title: "Atomicity failure fixture",
+};
+
+const repo = {
+  remote_url: "eval:proposal-apply-atomicity",
+  repo_name: "proposal-apply-atomicity",
+  default_branch: "main",
+};
+
+const proposal = {
+  title: marker.title,
+  summary: "This proposal must not leave rows behind when embedding generation fails.",
+  creates: {
+    components: [
+      {
+        id: marker.component,
+        name: "Atomicity Marker Component",
+        code_anchor: "libs/knowledge-graph/service.ts",
+      },
+    ],
+    flows: [
+      {
+        id: marker.flow,
+        name: "Atomicity Marker Flow",
+      },
+    ],
+    claims: [
+      {
+        id: marker.claim,
+        kind: "fact",
+        text: "This marker claim should only exist after a successful proposal apply.",
+        truth: "code_verified",
+        intent: "intended",
+      },
+    ],
+    sources: [
+      {
+        id: marker.source,
+        kind: "session",
+        ref: "eval:proposal-apply-atomicity",
+        title: "Proposal apply atomicity eval",
+      },
+    ],
+    edges: [
+      {
+        id: marker.edges[0],
+        from_type: "claim",
+        from_id: marker.claim,
+        to_type: "component",
+        to_id: marker.component,
+        kind: "about",
+      },
+      {
+        id: marker.edges[1],
+        from_type: "claim",
+        from_id: marker.claim,
+        to_type: "source",
+        to_id: marker.source,
+        kind: "evidenced_by",
+        metadata: {
+          reason: "Deterministic fixture evidence.",
+        },
+      },
+      {
+        id: marker.edges[2],
+        from_type: "flow",
+        from_id: marker.flow,
+        to_type: "component",
+        to_id: marker.component,
+        kind: "touches",
+      },
+    ],
+  },
+};
+
+let db;
+let checks = [];
+let commands = [];
+
+try {
+  const modules = await importBuiltModules();
+  db = modules.openDatabase(dbPath);
+  const repository = new modules.SqliteRepository(db);
+  const failingService = new modules.KnowledgeGraphService(repository, {
+    ensureForGraph: async () => {
+      throw new Error("synthetic embedding failure");
+    },
+  });
+
+  failingService.initRepo(repo);
+  const beforeGraph = failingService.readGraph(repo);
+
+  let failureError;
+  try {
+    await failingService.applyProposal(repo, proposal);
+  } catch (error) {
+    failureError = error;
+  }
+
+  const afterFailedGraph = failingService.readGraph(repo);
+  const afterFailedStorage = storageSnapshot(db);
+
+  const successfulService = new modules.KnowledgeGraphService(repository, {
+    ensureForGraph: async (_repoId, graph) => ({
+      checked_objects: graph.components.length + graph.flows.length + graph.claims.length,
+      created: 0,
+      reused: graph.components.length + graph.flows.length + graph.claims.length,
+    }),
+  });
+
+  let successError;
+  try {
+    await successfulService.applyProposal(repo, proposal);
+  } catch (error) {
+    successError = error;
+  }
+
+  const afterSuccessfulGraph = successfulService.readGraph(repo);
+
+  checks = [
+    checkFailedApplyRejected(failureError),
+    checkVisibleGraphUnchanged(beforeGraph, afterFailedGraph),
+    checkStorageRolledBack(afterFailedStorage),
+    checkSameProposalCanApplyAfterFailure(successError, afterSuccessfulGraph),
+  ];
+} catch (error) {
+  checks = [
+    {
+      id: "verification_script",
+      passed: false,
+      details: [error instanceof Error ? error.stack ?? error.message : String(error)],
+    },
+  ];
+} finally {
+  if (db !== undefined) db.close();
+
+  const passedChecks = checks.filter((check) => check.passed).length;
+  const result = {
+    success: passedChecks === checks.length,
+    correctness: {
+      passed_checks: passedChecks,
+      total_checks: checks.length,
+      ratio: checks.length === 0 ? 0 : passedChecks / checks.length,
+    },
+    db_path: dbPath,
+    commands,
+    checks,
+  };
+
+  const serialized = `${JSON.stringify(result, null, 2)}\n`;
+  if (resultJson !== undefined) writeFileSync(resultJson, serialized);
+  process.stdout.write(serialized);
+
+  if (ownsTempDir) rmSync(tempDir, { recursive: true, force: true });
+  process.exitCode = result.success ? 0 : 1;
+}
+
+async function importBuiltModules() {
+  const serviceModule = await import(toFileUrl("dist/libs/knowledge-graph/service.js"));
+  const dbModule = await import(toFileUrl("dist/libs/storage/sqlite/db.js"));
+  const repositoryModule = await import(toFileUrl("dist/libs/storage/sqlite/repository.js"));
+  return {
+    KnowledgeGraphService: serviceModule.KnowledgeGraphService,
+    openDatabase: dbModule.openDatabase,
+    SqliteRepository: repositoryModule.SqliteRepository,
+  };
+}
+
+function toFileUrl(path) {
+  return pathToFileURL(resolve(repoRoot, path)).href;
+}
+
+function findRepoRoot(startDir) {
+  let current = startDir;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (existsSync(resolve(current, "package.json")) && existsSync(resolve(current, "libs/knowledge-graph/service.ts"))) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Could not find repo root from ${startDir}`);
+}
+
+function checkFailedApplyRejected(error) {
+  const details = [];
+  if (error === undefined) {
+    details.push("applyProposal resolved even though embedding generation failed");
+  } else if (!String(error.message ?? error).includes("synthetic embedding failure")) {
+    details.push(`applyProposal failed with unexpected error: ${String(error.message ?? error)}`);
+  }
+
+  return {
+    id: "failed_apply_rejects",
+    passed: details.length === 0,
+    details,
+  };
+}
+
+function checkVisibleGraphUnchanged(beforeGraph, afterFailedGraph) {
+  const details = [];
+  for (const type of ["components", "flows", "claims", "sources", "edges"]) {
+    const beforeIds = ids(beforeGraph[type]);
+    const afterIds = ids(afterFailedGraph[type]);
+    if (beforeIds.join("\n") !== afterIds.join("\n")) {
+      details.push(`${type} changed after failed apply: before=[${beforeIds.join(", ")}] after=[${afterIds.join(", ")}]`);
+    }
+  }
+
+  return {
+    id: "visible_graph_unchanged",
+    passed: details.length === 0,
+    details,
+  };
+}
+
+function checkStorageRolledBack(snapshot) {
+  const details = [];
+  for (const [name, value] of Object.entries(snapshot)) {
+    if (value !== 0) details.push(`${name} has ${value} leaked row(s)`);
+  }
+
+  return {
+    id: "storage_rows_rolled_back",
+    passed: details.length === 0,
+    details,
+  };
+}
+
+function checkSameProposalCanApplyAfterFailure(error, graph) {
+  const details = [];
+  if (error !== undefined) {
+    details.push(`same proposal could not be applied after failed apply: ${String(error.message ?? error)}`);
+  }
+
+  const expected = [
+    ["components", marker.component],
+    ["flows", marker.flow],
+    ["claims", marker.claim],
+    ["sources", marker.source],
+    ...marker.edges.map((edgeId) => ["edges", edgeId]),
+  ];
+
+  for (const [type, id] of expected) {
+    if (!ids(graph[type]).includes(id)) details.push(`${type} missing ${id} after successful retry`);
+  }
+
+  return {
+    id: "same_proposal_can_apply_after_failure",
+    passed: details.length === 0,
+    details,
+  };
+}
+
+function storageSnapshot(dbHandle) {
+  return {
+    components: scalarCount(dbHandle, "SELECT COUNT(*) AS count FROM components WHERE id = ?", marker.component),
+    flows: scalarCount(dbHandle, "SELECT COUNT(*) AS count FROM flows WHERE id = ?", marker.flow),
+    claims: scalarCount(dbHandle, "SELECT COUNT(*) AS count FROM claims WHERE id = ?", marker.claim),
+    sources: scalarCount(dbHandle, "SELECT COUNT(*) AS count FROM sources WHERE id = ?", marker.source),
+    edges: scalarCount(
+      dbHandle,
+      `SELECT COUNT(*) AS count FROM edges WHERE id IN (${marker.edges.map(() => "?").join(", ")})`,
+      ...marker.edges,
+    ),
+    memberships: scalarCount(
+      dbHandle,
+      `SELECT COUNT(*) AS count
+       FROM graph_memberships
+       WHERE subject_id IN (${[marker.component, marker.flow, marker.claim, ...marker.edges].map(() => "?").join(", ")})`,
+      marker.component,
+      marker.flow,
+      marker.claim,
+      ...marker.edges,
+    ),
+    memory_commits: scalarCount(dbHandle, "SELECT COUNT(*) AS count FROM memory_commits WHERE title = ?", marker.title),
+    embeddings: scalarCount(
+      dbHandle,
+      `SELECT COUNT(*) AS count
+       FROM graph_object_embeddings
+       WHERE object_id IN (?, ?, ?)`,
+      marker.component,
+      marker.flow,
+      marker.claim,
+    ),
+  };
+}
+
+function scalarCount(dbHandle, sql, ...params) {
+  const row = dbHandle.prepare(sql).get(...params);
+  return Number(row?.count ?? 0);
+}
+
+function ids(items) {
+  return [...items.map((item) => item.id)].sort();
+}
+
+function parseArgs(values) {
+  const parsed = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (value === "--result-json") parsed.resultJson = requireValue(values, index += 1, value);
+    else if (value === "--keep-temp") parsed.keepTemp = true;
+    else throw new Error(`Unknown argument: ${value}`);
+  }
+  return parsed;
+}
+
+function requireValue(values, index, flag) {
+  const value = values[index];
+  if (value === undefined || value.startsWith("--")) throw new Error(`Expected value after ${flag}`);
+  return value;
+}

--- a/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/run.ts
+++ b/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/run.ts
@@ -1,0 +1,325 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  type CommandResult,
+  findRepoRoot,
+  run,
+  runOrThrow,
+  timestamp,
+  valueAfter,
+  writeJson,
+} from "../../lib/common.js";
+import { runCodexAgent } from "../../../libs/agent-runner/codex.js";
+import type { AgentRunResult } from "../../../libs/agent-runner/types.js";
+import { loadRepoEnv } from "../../../libs/env/load-local-env.js";
+
+const caseId = "coding-proposal-apply-atomicity-at-d6ebf80";
+const baseCommit = "d6ebf80298990fba01f94eb99804dd9e36a1606f";
+
+type Arm = "control" | "greplica";
+
+interface Args {
+  arm: Arm;
+  agent?: "codex";
+  agentModel?: string;
+}
+
+interface RunContext {
+  repoRoot: string;
+  fixtureDir: string;
+  runDir: string;
+  targetRepoDir: string;
+  targetRepoUrl: string;
+  agentGreplicaHomeDir: string;
+  verificationGreplicaHomeDir: string;
+  memorySeedPaths: string[];
+  verificationScriptPath: string;
+  verificationResultPath: string;
+  navigationGreplicaCommand: string[];
+}
+
+interface EvalResult {
+  case_id: string;
+  arm: Arm;
+  target_repo_url: string;
+  base_commit: string;
+  run_dir: string;
+  target_repo_dir: string;
+  agent_greplica_home_dir: string;
+  verification_greplica_home_dir: string;
+  memory_seed_paths: string[];
+  navigation_greplica_command: string[];
+  verification_result_path: string;
+  success: boolean;
+  correctness: {
+    passed_checks: number;
+    total_checks: number;
+    ratio: number;
+  };
+  setup_commands: CommandResult[];
+  generation?: AgentRunResult;
+  verification_commands: CommandResult[];
+  checks: CheckResult[];
+}
+
+interface CheckResult {
+  id: string;
+  passed: boolean;
+  details: string[];
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const context = prepareRun();
+
+  prepareTargetRepo(context);
+  prepareGreplicaHomes(context);
+
+  const setupCommands = [
+    runSetupCommand(["npm", "install"], context.targetRepoDir),
+    runSetupCommand(["npm", "run", "build"], context.targetRepoDir),
+  ];
+
+  const setupSucceeded = setupCommands.every((command) => command.exit_code === 0);
+  if (setupSucceeded && args.arm === "greplica") setupCommands.push(...seedAgentMemory(context));
+
+  const generation = setupCommands.every((command) => command.exit_code === 0)
+    ? await runCodingAgent(context, args)
+    : undefined;
+
+  const verificationCommands: CommandResult[] = [];
+  if (generation?.exit_code === 0) {
+    verificationCommands.push(runVerificationCommand(["npm", "run", "build"], context.targetRepoDir));
+    if (verificationCommands.every((command) => command.exit_code === 0)) {
+      verificationCommands.push(runCandidateVerificationScript(context));
+    }
+  }
+
+  const checks = runChecks(context, verificationCommands);
+  const passedChecks = checks.filter((check) => check.passed).length;
+  const success =
+    setupCommands.every((command) => command.exit_code === 0) &&
+    generation?.exit_code === 0 &&
+    verificationCommands.every((command) => command.exit_code === 0) &&
+    passedChecks === checks.length;
+
+  writeResult(context, args, setupCommands, generation, verificationCommands, checks, success);
+
+  console.log(success ? "Coding proposal apply atomicity eval passed." : "Coding proposal apply atomicity eval failed.");
+  console.log(`Run directory: ${context.runDir}`);
+  console.log(`Correctness: ${passedChecks}/${checks.length}`);
+  process.exitCode = success ? 0 : 1;
+}
+
+function prepareRun(): RunContext {
+  const repoRoot = findRepoRoot(import.meta.url);
+  loadRepoEnv(repoRoot);
+  const fixtureDir = resolve(repoRoot, "evals/cases/coding-proposal-apply-atomicity-at-d6ebf80");
+  const runDir = resolve(repoRoot, "eval-runs", timestamp(), caseId);
+  const targetRepoDir = resolve(runDir, "target-repo");
+  const targetRepoUrl = process.env.GREPLICA_EVAL_TARGET_REPO_URL ?? repoRoot;
+
+  mkdirSync(runDir, { recursive: true });
+
+  return {
+    repoRoot,
+    fixtureDir,
+    runDir,
+    targetRepoDir,
+    targetRepoUrl,
+    agentGreplicaHomeDir: resolve(runDir, "agent-greplica-home"),
+    verificationGreplicaHomeDir: resolve(runDir, "verification-greplica-home"),
+    memorySeedPaths: [
+      resolve(fixtureDir, "seed-01-bootstrap.proposal.json"),
+      resolve(fixtureDir, "seed-02-update-working-memory-2026-06-03.proposal.json"),
+      resolve(fixtureDir, "seed-03-eval-scoring.proposal.json"),
+      resolve(fixtureDir, "seed-04-eval-design.proposal.json"),
+    ],
+    verificationScriptPath: resolve(targetRepoDir, ".eval/check-proposal-apply-atomicity.mjs"),
+    verificationResultPath: resolve(runDir, "verification-result.json"),
+    navigationGreplicaCommand: ["node", resolve(repoRoot, "dist/apps/cli/main.js")],
+  };
+}
+
+function prepareTargetRepo(context: RunContext): void {
+  runOrThrow(["git", "clone", context.targetRepoUrl, context.targetRepoDir], context.repoRoot);
+  runOrThrow(["git", "checkout", baseCommit], context.targetRepoDir);
+  installVerificationScript(context);
+}
+
+function installVerificationScript(context: RunContext): void {
+  const evalDir = resolve(context.targetRepoDir, ".eval");
+  mkdirSync(evalDir, { recursive: true });
+  copyFileSync(resolve(context.fixtureDir, "check-proposal-apply-atomicity.mjs"), context.verificationScriptPath);
+}
+
+function prepareGreplicaHomes(context: RunContext): void {
+  mkdirSync(context.agentGreplicaHomeDir, { recursive: true });
+  mkdirSync(context.verificationGreplicaHomeDir, { recursive: true });
+}
+
+function seedAgentMemory(context: RunContext): CommandResult[] {
+  return context.memorySeedPaths.flatMap((seedPath) => [
+    runGreplicaCommand(context.navigationGreplicaCommand, context.targetRepoDir, context.agentGreplicaHomeDir, "proposal", "validate", seedPath),
+    runGreplicaCommand(context.navigationGreplicaCommand, context.targetRepoDir, context.agentGreplicaHomeDir, "proposal", "apply", seedPath),
+  ]);
+}
+
+async function runCodingAgent(context: RunContext, args: Args): Promise<AgentRunResult> {
+  if (args.agent !== "codex") throw new Error("Only --agent codex is supported.");
+
+  const model = args.agentModel ?? "gpt-5.4-mini";
+  return runCodexAgent({
+    cwd: context.targetRepoDir,
+    env: { ...process.env, GREPLICA_HOME: context.agentGreplicaHomeDir },
+    model,
+    prompt: buildPrompt(context, args.arm),
+    transcriptPath: resolve(context.runDir, "agent-events.jsonl"),
+    finalMessagePath: resolve(context.runDir, "agent-final-message.txt"),
+  });
+}
+
+function buildPrompt(context: RunContext, arm: Arm): string {
+  const taskPrompt = `Fix proposal apply atomicity.
+
+When graph-object embedding generation fails during proposal apply, the apply should fail and leave no partial proposal data behind.
+
+Required behavior:
+- surface the embedding failure to the caller instead of reporting a successful apply
+- leave no components, flows, claims, sources, edges, graph memberships, memory commits, or graph-object embeddings from the failed proposal
+- preserve the existing validation behavior
+- preserve successful proposal apply behavior
+
+The cloned repo includes a deterministic verifier at:
+
+.eval/check-proposal-apply-atomicity.mjs
+
+The verifier imports the built service, injects a failing graph-context builder, runs a proposal apply, and checks that failed proposal writes are rolled back.`;
+
+  if (arm === "control") {
+    return `Do not use Greplica navigation/context commands or Greplica skills in this run.
+You may run .eval/check-proposal-apply-atomicity.mjs because it is the deterministic verifier for the bug you are fixing.
+
+${taskPrompt}`;
+  }
+
+  return `Before broad manual exploration, use Greplica as an external navigation tool. Use this current-workspace Greplica command while working from the cloned target repository:
+
+${context.navigationGreplicaCommand.join(" ")} graph context "<natural-language question about the current task>"
+
+Treat Greplica output as navigation, not final truth. Verify implementation facts against current files before editing.
+
+${taskPrompt}`;
+}
+
+function runCandidateVerificationScript(context: RunContext): CommandResult {
+  return run(
+    [
+      "node",
+      context.verificationScriptPath,
+      "--result-json",
+      context.verificationResultPath,
+    ],
+    context.targetRepoDir,
+    { ...process.env, GREPLICA_HOME: context.verificationGreplicaHomeDir },
+  );
+}
+
+function runChecks(context: RunContext, verificationCommands: CommandResult[]): CheckResult[] {
+  const verificationCommand = verificationCommands[verificationCommands.length - 1];
+  if (verificationCommand?.exit_code !== 0 && !existsSync(context.verificationResultPath)) {
+    return [
+      {
+        id: "verification_script",
+        passed: false,
+        details: ["verification script failed before writing result json"],
+      },
+    ];
+  }
+
+  if (!existsSync(context.verificationResultPath)) {
+    return [
+      {
+        id: "verification_script",
+        passed: false,
+        details: ["verification script did not write result json"],
+      },
+    ];
+  }
+
+  const result = JSON.parse(readFileSync(context.verificationResultPath, "utf8")) as { checks?: CheckResult[] };
+  if (!Array.isArray(result.checks)) {
+    return [
+      {
+        id: "verification_script",
+        passed: false,
+        details: ["verification result json did not include checks"],
+      },
+    ];
+  }
+
+  return result.checks;
+}
+
+function runGreplicaCommand(command: string[], cwd: string, greplicaHomeDir: string, ...args: string[]): CommandResult {
+  return run([...command, ...args], cwd, { ...process.env, GREPLICA_HOME: greplicaHomeDir });
+}
+
+function runSetupCommand(command: string[], cwd: string): CommandResult {
+  return run(command, cwd, process.env, { stdio: "inherit" });
+}
+
+function runVerificationCommand(command: string[], cwd: string): CommandResult {
+  return run(command, cwd, process.env);
+}
+
+function writeResult(
+  context: RunContext,
+  args: Args,
+  setupCommands: CommandResult[],
+  generation: AgentRunResult | undefined,
+  verificationCommands: CommandResult[],
+  checks: CheckResult[],
+  success: boolean,
+): void {
+  const passedChecks = checks.filter((check) => check.passed).length;
+  const result: EvalResult = {
+    case_id: caseId,
+    arm: args.arm,
+    target_repo_url: context.targetRepoUrl,
+    base_commit: baseCommit,
+    run_dir: context.runDir,
+    target_repo_dir: context.targetRepoDir,
+    agent_greplica_home_dir: context.agentGreplicaHomeDir,
+    verification_greplica_home_dir: context.verificationGreplicaHomeDir,
+    memory_seed_paths: context.memorySeedPaths,
+    navigation_greplica_command: context.navigationGreplicaCommand,
+    verification_result_path: context.verificationResultPath,
+    success,
+    correctness: {
+      passed_checks: passedChecks,
+      total_checks: checks.length,
+      ratio: checks.length === 0 ? 0 : passedChecks / checks.length,
+    },
+    setup_commands: setupCommands,
+    generation,
+    verification_commands: verificationCommands,
+    checks,
+  };
+
+  writeJson(resolve(context.runDir, "result.json"), result);
+}
+
+function parseArgs(args: string[]): Args {
+  const arm = valueAfter(args, "--arm") ?? "control";
+  if (arm !== "control" && arm !== "greplica") throw new Error("Expected --arm control or --arm greplica.");
+  const agent = valueAfter(args, "--agent") ?? "codex";
+  if (agent !== "codex") throw new Error("Only --agent codex is supported.");
+  const agentModel = valueAfter(args, "--agent-model");
+  return { arm, agent, agentModel };
+}

--- a/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/seed-01-bootstrap.proposal.json
+++ b/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/seed-01-bootstrap.proposal.json
@@ -1,0 +1,362 @@
+{
+  "title": "Bootstrap repo memory",
+  "summary": "Top-level engineering memory for the Greplica CLI, graph model, proposal pipeline, storage, retrieval, skills, and eval harness.",
+  "creates": {
+    "components": [
+      {
+        "id": "component.cli_app",
+        "name": "Greplica CLI command surface",
+        "code_anchor": "apps/cli/main.ts",
+        "contains": [
+          "component.repo_env_context"
+        ]
+      },
+      {
+        "id": "component.repo_env_context",
+        "name": "Repo detection and repo-local env loading",
+        "code_anchor": "apps/cli/repo-context.ts, libs/env/load-local-env.ts"
+      },
+      {
+        "id": "component.knowledge_graph_service",
+        "name": "KnowledgeGraphService boundary",
+        "code_anchor": "libs/knowledge-graph/service.ts"
+      },
+      {
+        "id": "component.graph_schema",
+        "name": "Knowledge graph object and edge model",
+        "code_anchor": "libs/knowledge-graph/schema.ts, libs/knowledge-graph/claim.ts, libs/knowledge-graph/edge.ts, libs/knowledge-graph/scope.ts, libs/knowledge-graph/commit.ts"
+      },
+      {
+        "id": "component.proposal_model",
+        "name": "Proposal model and compact normalization",
+        "code_anchor": "libs/knowledge-graph/proposal.ts"
+      },
+      {
+        "id": "component.proposal_validation",
+        "name": "Proposal validation",
+        "code_anchor": "libs/knowledge-graph/validate-proposal.ts"
+      },
+      {
+        "id": "component.sqlite_database_schema",
+        "name": "SQLite database path, open, schema, and migration",
+        "code_anchor": "libs/storage/sqlite/db.ts, libs/storage/sqlite/schema.ts, libs/storage/sqlite/migrate.ts"
+      },
+      {
+        "id": "component.sqlite_repository",
+        "name": "SQLite repository operations and active graph view",
+        "code_anchor": "libs/storage/sqlite/repository.ts"
+      },
+      {
+        "id": "component.graph_context_retrieval",
+        "name": "Graph context retrieval and embeddings",
+        "code_anchor": "libs/knowledge-graph/graph-context"
+      },
+      {
+        "id": "component.greplica_skills",
+        "name": "Bundled Greplica agent skills",
+        "code_anchor": "skills/greplica-bootstrap/SKILL.md, skills/greplica-update-working-memory/SKILL.md"
+      },
+      {
+        "id": "component.evals_agent_runner",
+        "name": "Eval harness and Codex agent runner",
+        "code_anchor": "evals, libs/agent-runner"
+      }
+    ],
+    "flows": [
+      {
+        "id": "flow.doctor_and_init",
+        "name": "Doctor and init prepare repo memory and report setup readiness",
+        "touches": [
+          "component.cli_app",
+          "component.repo_env_context",
+          "component.knowledge_graph_service",
+          "component.sqlite_database_schema",
+          "component.sqlite_repository",
+          "component.graph_context_retrieval"
+        ]
+      },
+      {
+        "id": "flow.graph_read_and_context",
+        "name": "Graph read and context return current memory and ranked query results",
+        "touches": [
+          "component.cli_app",
+          "component.knowledge_graph_service",
+          "component.sqlite_repository",
+          "component.graph_context_retrieval"
+        ]
+      },
+      {
+        "id": "flow.proposal_validation",
+        "name": "Proposal validation normalizes compact input and validates graph shape",
+        "touches": [
+          "component.cli_app",
+          "component.knowledge_graph_service",
+          "component.proposal_model",
+          "component.proposal_validation",
+          "component.graph_schema"
+        ]
+      },
+      {
+        "id": "flow.proposal_apply",
+        "name": "Proposal apply writes working-scope graph records and ensures embeddings",
+        "touches": [
+          "component.cli_app",
+          "component.knowledge_graph_service",
+          "component.proposal_model",
+          "component.proposal_validation",
+          "component.sqlite_repository",
+          "component.graph_context_retrieval"
+        ]
+      },
+      {
+        "id": "flow.compact_relationships_to_edges",
+        "name": "Compact relationship fields become canonical graph edges",
+        "touches": [
+          "component.proposal_model",
+          "component.graph_schema",
+          "component.proposal_validation"
+        ]
+      },
+      {
+        "id": "flow.greplica_skill_workflows",
+        "name": "Bundled skills guide bootstrap and session working-memory updates",
+        "touches": [
+          "component.greplica_skills",
+          "component.cli_app",
+          "component.proposal_model",
+          "component.proposal_validation",
+          "component.graph_context_retrieval"
+        ]
+      },
+      {
+        "id": "flow.eval_workflows",
+        "name": "Eval runs create isolated repos and Greplica homes to score bootstrap, search, and update behavior",
+        "touches": [
+          "component.evals_agent_runner",
+          "component.cli_app",
+          "component.greplica_skills",
+          "component.graph_context_retrieval"
+        ]
+      }
+    ],
+    "claims": [
+      {
+        "id": "claim.readme_cli_primitives_skills",
+        "kind": "fact",
+        "text": "The README describes Greplica as a CLI that stores lightweight codebase memory with small graph-memory primitives, while agent workflows are supplied by bundled skills.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.cli_app",
+          "component.greplica_skills"
+        ]
+      },
+      {
+        "id": "claim.cli_thin_dispatcher",
+        "kind": "fact",
+        "text": "The CLI parses argv, reads JSON proposal files, prints command output, and delegates graph behavior to KnowledgeGraphService after detecting repo context and loading repo env.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.cli_app",
+          "component.knowledge_graph_service",
+          "component.repo_env_context"
+        ]
+      },
+      {
+        "id": "claim.repo_context_git_detection",
+        "kind": "fact",
+        "text": "Repo context detection shells out to Git for the repo root, origin remote URL, and origin HEAD default branch, with local:<repoRoot> and main fallbacks when remote metadata is absent.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.repo_env_context",
+          "flow.doctor_and_init"
+        ]
+      },
+      {
+        "id": "claim.env_loading_openai_key_precedence",
+        "kind": "fact",
+        "text": "Repo env loading only imports allowed repo-local keys such as OPENAI_API_KEY from .env.local and .env, without overriding a key that was already present in the process environment.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.repo_env_context",
+          "flow.doctor_and_init"
+        ]
+      },
+      {
+        "id": "claim.doctor_initializes_and_checks_openai",
+        "kind": "fact",
+        "text": "The doctor command initializes repo memory state, reports the database and main/working scopes, reports whether OPENAI_API_KEY is available, and optionally checks OpenAI embeddings with --check-openai.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "flow.doctor_and_init",
+          "component.cli_app",
+          "component.graph_context_retrieval"
+        ]
+      },
+      {
+        "id": "claim.database_home_precedence",
+        "kind": "fact",
+        "text": "The SQLite database path prefers GREPLICA_HOME, then ENGINEERING_CONTEXT_HOME, and otherwise defaults to ~/.greplica/graph.db; opening the database enables foreign keys and runs the schema migration.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.sqlite_database_schema",
+          "flow.doctor_and_init"
+        ]
+      },
+      {
+        "id": "claim.service_boundary_operations",
+        "kind": "fact",
+        "text": "KnowledgeGraphService is the local service boundary for repo initialization, graph reads, graph context search, proposal validation, and proposal apply.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.knowledge_graph_service",
+          "component.cli_app"
+        ]
+      },
+      {
+        "id": "claim.graph_model_types_and_edges",
+        "kind": "fact",
+        "text": "The graph model has components, flows, claims, sources, edges, scopes, memberships, and memory commits; allowed edges include about, contains, touches, supersedes, and evidenced_by with direction rules in edge.ts.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.graph_schema",
+          "component.proposal_validation"
+        ]
+      },
+      {
+        "id": "claim.sqlite_repository_graph_view",
+        "kind": "fact",
+        "text": "The SQLite repository persists graph objects, memberships, memory commits, and embeddings, and readGraphView composes the current main plus working graph while hiding superseded subjects and inactive edges.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.sqlite_repository",
+          "component.sqlite_database_schema",
+          "flow.graph_read_and_context"
+        ]
+      },
+      {
+        "id": "claim.sources_are_edge_referenced",
+        "kind": "fact",
+        "text": "Source records are inserted separately from graph memberships and become visible in graph reads when active evidenced_by edges reference them.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.sqlite_repository",
+          "component.graph_schema"
+        ]
+      },
+      {
+        "id": "claim.compact_relationship_normalization",
+        "kind": "fact",
+        "text": "Proposal normalization strips compact relationship fields from created components, flows, and claims and expands contains, touches, about, evidenced_by, and supersedes into canonical edge records.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.proposal_model",
+          "flow.compact_relationships_to_edges"
+        ]
+      },
+      {
+        "id": "claim.proposal_validation_rules",
+        "kind": "fact",
+        "text": "Proposal validation checks top-level shape, duplicate and pre-existing IDs, claim/source enum values, referenced subjects, allowed edge directions, metadata shape, and evidenced_by metadata.reason.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.proposal_validation",
+          "component.graph_schema",
+          "flow.proposal_validation"
+        ]
+      },
+      {
+        "id": "claim.apply_creates_working_commit_and_embeddings",
+        "kind": "fact",
+        "text": "Applying a proposal normalizes and validates it, creates a memory commit in the working scope, writes proposal records through the repository, and ensures embeddings for the resulting graph objects.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "flow.proposal_apply",
+          "component.knowledge_graph_service",
+          "component.sqlite_repository",
+          "component.graph_context_retrieval"
+        ]
+      },
+      {
+        "id": "claim.graph_context_ranking",
+        "kind": "fact",
+        "text": "Graph context retrieval builds documents for claims, components, and flows, embeds them with text-embedding-3-small, combines semantic, BM25, and exact scores, and applies graph boosts and claim support when selecting results.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.graph_context_retrieval",
+          "flow.graph_read_and_context"
+        ]
+      },
+      {
+        "id": "claim.openai_embeddings_required_for_context",
+        "kind": "requirement",
+        "text": "Graph context search and proposal apply require OPENAI_API_KEY because the OpenAI embedder throws when no API key is available and stores graph-object embeddings for retrieval.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.graph_context_retrieval",
+          "flow.graph_read_and_context",
+          "flow.proposal_apply"
+        ]
+      },
+      {
+        "id": "claim.skills_bootstrap_and_update_guidance",
+        "kind": "fact",
+        "text": "The bootstrap skill requires greplica doctor, shallow repository inspection, existing graph reading, compact proposal validation, and apply; the update skill requires git/session evidence and source-backed memory for durable session decisions.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.greplica_skills",
+          "flow.greplica_skill_workflows"
+        ]
+      },
+      {
+        "id": "claim.evals_isolated_runs",
+        "kind": "fact",
+        "text": "Eval cases clone target repos into per-run directories, use isolated GREPLICA_HOME locations, run product CLI commands, and score bootstrap, search, and update-working-memory behavior against rubrics.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "flow.eval_workflows"
+        ]
+      },
+      {
+        "id": "claim.codex_runner_boundary",
+        "kind": "fact",
+        "text": "The Codex agent runner launches codex exec with approval never and danger-full-access, streams JSON transcript output, writes the final message path, and collects coarse tool-call and token metrics from the transcript.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "flow.eval_workflows"
+        ]
+      },
+      {
+        "id": "claim.schema_migration_strategy_risk",
+        "kind": "risk",
+        "text": "SQLite migration currently executes a CREATE TABLE IF NOT EXISTS schema; incompatible future schema changes will need an explicit migration strategy beyond the current bootstrap-style migration.",
+        "truth": "code_verified",
+        "intent": "unknown",
+        "about": [
+          "component.sqlite_database_schema"
+        ]
+      }
+    ],
+    "sources": [],
+    "edges": []
+  }
+}

--- a/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/seed-02-update-working-memory-2026-06-03.proposal.json
+++ b/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/seed-02-update-working-memory-2026-06-03.proposal.json
@@ -1,0 +1,80 @@
+{
+  "title": "Update working memory from session transcript replay eval",
+  "summary": "Capture durable context from the session that improved the update-working-memory transcript replay eval and skill guidance.",
+  "creates": {
+    "claims": [
+      {
+        "id": "claim.update_memory_eval_uses_filtered_markdown_transcript",
+        "kind": "fact",
+        "text": "The update-working-memory source-evidence eval now projects the raw Codex JSONL fixture into a filtered Markdown transcript containing whitelisted session metadata plus human and agent messages, strips historical system/developer instruction blocks, and passes that Markdown transcript to the replay agent instead of the raw JSONL.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "flow.eval_workflows"
+        ]
+      },
+      {
+        "id": "claim.update_memory_skill_requires_full_transcript_scan",
+        "kind": "fact",
+        "text": "The update-working-memory skill now tells agents with a transcript file to get the transcript line count, read every line in chunks, keep distinct durable memories separate, preserve explicit negative or deferred decisions, and avoid broad code-verified workflow claims unless each part is patch-verified.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.greplica_skills",
+          "flow.greplica_skill_workflows"
+        ]
+      },
+      {
+        "id": "claim.transcript_replay_eval_keeps_only_replay_specific_prompting",
+        "kind": "decision",
+        "text": "General update-working-memory extraction behavior belongs in the reusable skill, while the replay eval prompt should only carry eval-specific differences such as filtered transcript paths, proposal output path, historical replay constraints, and not applying the proposal.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "component.greplica_skills",
+          "flow.eval_workflows",
+          "flow.greplica_skill_workflows"
+        ]
+      },
+      {
+        "id": "claim.update_memory_candidate_inventory_followup",
+        "kind": "task",
+        "text": "Improve the update-working-memory skill with a staged transcript extraction workflow that builds a candidate inventory across buckets such as code facts, constraints, rationale, trade-offs, negative decisions, deferred work, drift, eval/process constraints, and a dropped-candidate audit before writing proposal JSON.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.greplica_skills",
+          "flow.greplica_skill_workflows"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "id": "source.codex_session.2026_06_03_transcript_replay_eval",
+        "kind": "session",
+        "ref": "codex-session:2026-06-03-transcript-replay-eval",
+        "title": "Codex session on update-working-memory transcript replay eval"
+      }
+    ],
+    "edges": [
+      {
+        "kind": "evidenced_by",
+        "from": "claim.transcript_replay_eval_keeps_only_replay_specific_prompting",
+        "to": "source.codex_session.2026_06_03_transcript_replay_eval",
+        "metadata": {
+          "reason": "The user corrected the implementation layering: general behavior should live in the reusable skill, while only replay-specific differences should remain in the eval prompt."
+        }
+      },
+      {
+        "kind": "evidenced_by",
+        "from": "claim.update_memory_candidate_inventory_followup",
+        "to": "source.codex_session.2026_06_03_transcript_replay_eval",
+        "metadata": {
+          "reason": "The user asked for suggestions such as a workflow that first extracts many candidates, buckets transcript evidence, and audits omissions before writing memory."
+        }
+      }
+    ]
+  }
+}

--- a/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/seed-03-eval-scoring.proposal.json
+++ b/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/seed-03-eval-scoring.proposal.json
@@ -1,0 +1,89 @@
+{
+  "title": "Update working memory from transcript eval scoring session",
+  "summary": "Durable context from improving the update-working-memory transcript ingestion eval and committing PR #9.",
+  "creates": {
+    "components": [],
+    "flows": [],
+    "claims": [
+      {
+        "id": "claim.update_memory_eval_scores_supersedes_structurally",
+        "kind": "fact",
+        "text": "The update-working-memory source-evidence eval now scores supersedes deterministically from the generated proposal structure, requiring either compact `supersedes[]` or an explicit supersedes edge instead of trusting the judge to infer supersession from wording.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "flow.eval_workflows"
+        ],
+        "supersedes": [
+          "claim.transcript_replay_eval_keeps_only_replay_specific_prompting"
+        ]
+      },
+      {
+        "id": "claim.update_memory_skill_has_transcript_inventory_and_supersedes_workflow",
+        "kind": "fact",
+        "text": "The update-working-memory skill now requires transcript line counting, chunked full-transcript reading, a bucketed candidate inventory, dropped-candidate review, distinct focused claims, and an explicit final supersedes pass for older broad memory that is narrowed or corrected by new session claims.",
+        "truth": "code_verified",
+        "intent": "intended",
+        "about": [
+          "component.greplica_skills",
+          "flow.greplica_skill_workflows"
+        ],
+        "supersedes": [
+          "claim.update_memory_skill_requires_full_transcript_scan",
+          "claim.update_memory_candidate_inventory_followup"
+        ]
+      },
+      {
+        "id": "claim.update_memory_transcript_eval_remains_prompt_sensitive",
+        "kind": "risk",
+        "text": "The prompt-only update-memory transcript workflow remains sensitive to agent model and exploration path: GPT-5.5 generated a more complete proposal than GPT-5.4-mini, while repeated GPT-5.4-mini runs over-pruned transcript memories and missed session-only constraints, future work, or eval-process constraints.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "component.greplica_skills",
+          "flow.eval_workflows",
+          "flow.greplica_skill_workflows"
+        ]
+      },
+      {
+        "id": "claim.code_based_memory_update_workflow_followup",
+        "kind": "task",
+        "text": "Replace the prompt-only update-memory extraction workflow with a more code-driven workflow for memory updates so transcript candidate extraction, candidate dropping, and supersedes decisions are guided by deterministic steps rather than relying only on prompt compliance.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.greplica_skills",
+          "flow.greplica_skill_workflows"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "id": "source.codex_session.2026_06_03_eval_scoring_pr",
+        "kind": "session",
+        "ref": "codex-session:2026-06-03-eval-scoring-pr",
+        "title": "Codex session on transcript eval scoring and PR #9"
+      }
+    ],
+    "edges": [
+      {
+        "kind": "evidenced_by",
+        "from": "claim.update_memory_transcript_eval_remains_prompt_sensitive",
+        "to": "source.codex_session.2026_06_03_eval_scoring_pr",
+        "metadata": {
+          "reason": "The session compared GPT-5.5 and GPT-5.4-mini eval runs and found the prompt-only workflow produced materially different proposal quality across models and runs."
+        }
+      },
+      {
+        "kind": "evidenced_by",
+        "from": "claim.code_based_memory_update_workflow_followup",
+        "to": "source.codex_session.2026_06_03_eval_scoring_pr",
+        "metadata": {
+          "reason": "The user decided to defer further prompt tuning and later build a code-based workflow for updating memories."
+        }
+      }
+    ]
+  }
+}

--- a/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/seed-04-eval-design.proposal.json
+++ b/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/seed-04-eval-design.proposal.json
@@ -1,0 +1,135 @@
+{
+  "title": "Update working memory from eval-design session",
+  "summary": "Durable decisions from the June 4 eval-design discussion.",
+  "creates": {
+    "claims": [
+      {
+        "id": "claim.eval_benchmark_primary_metric_correctness_per_cost",
+        "kind": "decision",
+        "text": "The planned Greplica coding-task benchmark should use correctness-per-cost as its primary metric, measuring final correctness together with token spend and elapsed time.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "flow.eval_workflows"
+        ]
+      },
+      {
+        "id": "claim.eval_compare_real_greplica_experience_to_control",
+        "kind": "decision",
+        "text": "The first correctness-per-cost eval should compare the real Greplica user experience against no Greplica: the Greplica arm gets memory plus the normal workflow and skills, while the control arm keeps the same model, repo state, task, sandbox, and normal code-inspection tools without Greplica.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "component.greplica_skills",
+          "flow.eval_workflows",
+          "flow.greplica_skill_workflows"
+        ]
+      },
+      {
+        "id": "claim.eval_first_family_should_be_coding_tasks",
+        "kind": "decision",
+        "text": "The first Greplica correctness-per-cost eval family should use coding tasks rather than repo QA, retrieval-only tasks, or memory-update tasks; those other task families can be added separately later.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "flow.eval_workflows"
+        ]
+      },
+      {
+        "id": "claim.eval_coding_task_must_be_real_work",
+        "kind": "requirement",
+        "text": "Coding tasks for the benchmark should come from real intended repo work or bug fixes with settled desired behavior, not invented speculative features created only to make the eval task larger.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "flow.eval_workflows"
+        ]
+      },
+      {
+        "id": "claim.eval_task_selection_deferred_until_real_commits",
+        "kind": "task",
+        "text": "Defer choosing the first concrete Greplica correctness-per-cost coding task until more real product work has landed; then use a parent commit as the base, the issue or implementation intent as the prompt, and the final commit plus hidden checks as the oracle.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.evals_agent_runner",
+          "flow.eval_workflows"
+        ]
+      },
+      {
+        "id": "claim.greplica_graph_context_current_value_standard",
+        "kind": "decision",
+        "text": "The user accepted Greplica graph context as useful when it accelerates repo orientation and surfaces historical session context, while still requiring normal code inspection before implementation.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.graph_context_retrieval",
+          "component.greplica_skills",
+          "flow.graph_read_and_context"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "id": "source.codex_session.2026_06_04_eval_design_grilling",
+        "kind": "session",
+        "ref": "codex-session:2026-06-04-eval-design-grilling",
+        "title": "Codex session on Greplica correctness-per-cost eval design"
+      }
+    ],
+    "edges": [
+      {
+        "kind": "evidenced_by",
+        "from": "claim.eval_benchmark_primary_metric_correctness_per_cost",
+        "to": "source.codex_session.2026_06_04_eval_design_grilling",
+        "metadata": {
+          "reason": "The user confirmed that correctness-per-cost, including tokens and time, is the primary metric for the proposed eval."
+        }
+      },
+      {
+        "kind": "evidenced_by",
+        "from": "claim.eval_compare_real_greplica_experience_to_control",
+        "to": "source.codex_session.2026_06_04_eval_design_grilling",
+        "metadata": {
+          "reason": "The user confirmed the eval should compare the real Greplica user experience against no Greplica, with everything else held constant and no ablation for the first version."
+        }
+      },
+      {
+        "kind": "evidenced_by",
+        "from": "claim.eval_first_family_should_be_coding_tasks",
+        "to": "source.codex_session.2026_06_04_eval_design_grilling",
+        "metadata": {
+          "reason": "The user agreed the first eval should be a coding task rather than repo QA or other task families."
+        }
+      },
+      {
+        "kind": "evidenced_by",
+        "from": "claim.eval_coding_task_must_be_real_work",
+        "to": "source.codex_session.2026_06_04_eval_design_grilling",
+        "metadata": {
+          "reason": "The user rejected invented task ideas and said the benchmark task should be real work such as a future repo task or bug fix with decided behavior."
+        }
+      },
+      {
+        "kind": "evidenced_by",
+        "from": "claim.eval_task_selection_deferred_until_real_commits",
+        "to": "source.codex_session.2026_06_04_eval_design_grilling",
+        "metadata": {
+          "reason": "The user decided to defer choosing the exact eval task until after more real product work and commits create a suitable task candidate."
+        }
+      },
+      {
+        "kind": "evidenced_by",
+        "from": "claim.greplica_graph_context_current_value_standard",
+        "to": "source.codex_session.2026_06_04_eval_design_grilling",
+        "metadata": {
+          "reason": "The user accepted the assessment that Greplica graph context is doing its job when it saves orientation time and surfaces prior context, while not replacing code inspection."
+        }
+      }
+    ]
+  }
+}

--- a/evals/cases/search-current-repo-at-8038fe8/run.ts
+++ b/evals/cases/search-current-repo-at-8038fe8/run.ts
@@ -174,7 +174,7 @@ function prepareTargetRepo(context: RunContext): void {
 }
 
 function runQuery(context: RunContext, rubric: SearchRubric, queryCase: SearchQueryCase): QueryScore {
-  const command = runProductCommand(context, "graph", "context", queryCase.query);
+  const command = runProductCommand(context, "graph", "context", queryCase.query, "--debug");
   const returnedIds = command.exit_code === 0 ? parseReturnedIds(command.stdout ?? "") : [];
   const qrels = qrelsFor(queryCase);
   const metrics = scoreQuery(qrels, returnedIds, rubric.k);

--- a/libs/knowledge-graph/folder-export.ts
+++ b/libs/knowledge-graph/folder-export.ts
@@ -1,0 +1,447 @@
+import { createHash } from "node:crypto";
+import { posix as path } from "node:path";
+import type { Claim, ClaimKind } from "./claim.js";
+import type { Edge } from "./edge.js";
+import type { GraphReadResult } from "./service.js";
+import type { Component, Flow, Source } from "./schema.js";
+
+export interface ExportedGraphFile {
+  path: string;
+  content: string;
+}
+
+type EntityType = "component" | "flow";
+type Entity = Component | Flow;
+
+interface EntityIndex<T extends Entity> {
+  byId: Map<string, T>;
+  childrenByParentId: Map<string, string[]>;
+  parentByChildId: Map<string, string>;
+  pathsById: Map<string, string>;
+  roots: string[];
+}
+
+export function buildGraphFolderExport(graph: GraphReadResult): ExportedGraphFile[] {
+  const components = buildEntityIndex("component", graph.components, graph.edges);
+  const flows = buildEntityIndex("flow", graph.flows, graph.edges);
+  const claimsBySubjectId = buildClaimsBySubjectId(graph.claims, graph.edges);
+  const touchedComponentIdsByFlowId = buildTouchedComponentIdsByFlowId(graph.edges);
+  const flowIdsByTouchedComponentId = invertMap(touchedComponentIdsByFlowId);
+  const evidenceByClaimId = buildEvidenceByClaimId(graph.edges);
+  const sourceById = new Map(graph.sources.map((source) => [source.id, source]));
+
+  const files: ExportedGraphFile[] = [
+    {
+      path: "index.md",
+      content: renderRootIndex(graph, components, flows),
+    },
+    {
+      path: "sources.md",
+      content: renderSources(graph.sources, graph.claims, evidenceByClaimId),
+    },
+  ];
+
+  for (const component of sortByName(graph.components)) {
+    files.push({
+      path: `${components.pathsById.get(component.id) ?? `components/${segmentForId(component.id, "component")}`}/index.md`,
+      content: renderComponentIndex({
+        component,
+        components,
+        flows,
+        claims: claimsBySubjectId.get(component.id) ?? [],
+        relatedFlowIds: flowIdsByTouchedComponentId.get(component.id) ?? [],
+        evidenceByClaimId,
+        sourceById,
+      }),
+    });
+  }
+
+  for (const flow of sortByName(graph.flows)) {
+    files.push({
+      path: `${flows.pathsById.get(flow.id) ?? `flows/${segmentForId(flow.id, "flow")}`}/index.md`,
+      content: renderFlowIndex({
+        flow,
+        flows,
+        components,
+        claims: claimsBySubjectId.get(flow.id) ?? [],
+        touchedComponentIds: touchedComponentIdsByFlowId.get(flow.id) ?? [],
+        evidenceByClaimId,
+        sourceById,
+      }),
+    });
+  }
+
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function buildEntityIndex<T extends Entity>(type: EntityType, entities: T[], edges: Edge[]): EntityIndex<T> {
+  const byId = new Map(entities.map((entity) => [entity.id, entity] as const));
+  const childrenByParentId = new Map<string, string[]>();
+  const parentCandidatesByChildId = new Map<string, string[]>();
+
+  for (const edge of edges) {
+    if (edge.kind !== "contains" || edge.from_type !== type || edge.to_type !== type) continue;
+    if (!byId.has(edge.from_id) || !byId.has(edge.to_id)) continue;
+    appendToMap(childrenByParentId, edge.from_id, edge.to_id);
+    appendToMap(parentCandidatesByChildId, edge.to_id, edge.from_id);
+  }
+
+  sortMapValues(childrenByParentId, byId);
+  sortMapValues(parentCandidatesByChildId, byId);
+
+  const parentByChildId = new Map<string, string>();
+  for (const [childId, parentIds] of parentCandidatesByChildId) {
+    const parentId = parentIds[0];
+    if (parentId !== undefined) parentByChildId.set(childId, parentId);
+  }
+
+  const roots = sortByName(entities)
+    .map((entity) => entity.id)
+    .filter((id) => !parentByChildId.has(id));
+  const pathsById = new Map<string, string>();
+
+  for (const entity of entities) {
+    pathsById.set(entity.id, entityPath(type, entity.id, byId, parentByChildId, new Set()));
+  }
+
+  return { byId, childrenByParentId, parentByChildId, pathsById, roots };
+}
+
+function entityPath<T extends Entity>(
+  type: EntityType,
+  id: string,
+  byId: Map<string, T>,
+  parentByChildId: Map<string, string>,
+  visiting: Set<string>,
+): string {
+  const entity = byId.get(id);
+  const segment = segmentForId(id, type);
+  const root = `${type}s`;
+  if (entity === undefined || visiting.has(id)) return `${root}/${segment}`;
+
+  const parentId = parentByChildId.get(id);
+  if (parentId === undefined || !byId.has(parentId)) return `${root}/${segment}`;
+
+  visiting.add(id);
+  const parentPath = entityPath(type, parentId, byId, parentByChildId, visiting);
+  visiting.delete(id);
+  return `${parentPath}/${segment}`;
+}
+
+function renderRootIndex(graph: GraphReadResult, components: EntityIndex<Component>, flows: EntityIndex<Flow>): string {
+  return lines(
+    "# Graph View",
+    "",
+    "Current graph view: main + working.",
+    "",
+    `Components: ${graph.components.length}`,
+    `Flows: ${graph.flows.length}`,
+    `Claims: ${graph.claims.length}`,
+    `Sources: ${graph.sources.length}`,
+    "",
+    "## Components",
+    "",
+    ...renderEntityTree("index.md", components.roots, components),
+    "",
+    "## Flows",
+    "",
+    ...renderEntityTree("index.md", flows.roots, flows),
+    "",
+    "## Sources",
+    "",
+    "- [sources](sources.md)",
+  );
+}
+
+function renderComponentIndex(input: {
+  component: Component;
+  components: EntityIndex<Component>;
+  flows: EntityIndex<Flow>;
+  claims: Claim[];
+  relatedFlowIds: string[];
+  evidenceByClaimId: Map<string, Evidence[]>;
+  sourceById: Map<string, Source>;
+}): string {
+  const content = [`# ${input.component.name}`, "", `ID: \`${input.component.id}\``];
+  const currentPath = `${input.components.pathsById.get(input.component.id) ?? ""}/index.md`;
+  const parentId = input.components.parentByChildId.get(input.component.id);
+  const childIds = input.components.childrenByParentId.get(input.component.id) ?? [];
+
+  if (input.component.code_anchor !== undefined) content.push(`Code anchor: \`${input.component.code_anchor}\``);
+  if (parentId !== undefined) {
+    content.push(`Parent component: ${linkToEntity(currentPath, parentId, input.components) ?? `\`${parentId}\``}`);
+  }
+
+  pushEntitySection(content, "Child Components", currentPath, childIds, input.components);
+  pushEntitySection(content, "Related Flows", currentPath, input.relatedFlowIds, input.flows);
+  pushClaimSection(content, input.claims, input.evidenceByClaimId, input.sourceById);
+
+  return lines(...content);
+}
+
+function renderFlowIndex(input: {
+  flow: Flow;
+  flows: EntityIndex<Flow>;
+  components: EntityIndex<Component>;
+  claims: Claim[];
+  touchedComponentIds: string[];
+  evidenceByClaimId: Map<string, Evidence[]>;
+  sourceById: Map<string, Source>;
+}): string {
+  const content = [`# ${input.flow.name}`, "", `ID: \`${input.flow.id}\``];
+  const currentPath = `${input.flows.pathsById.get(input.flow.id) ?? ""}/index.md`;
+  const parentId = input.flows.parentByChildId.get(input.flow.id);
+  const childIds = input.flows.childrenByParentId.get(input.flow.id) ?? [];
+
+  if (parentId !== undefined) content.push(`Parent flow: ${linkToEntity(currentPath, parentId, input.flows) ?? `\`${parentId}\``}`);
+
+  pushEntitySection(content, "Child Flows", currentPath, childIds, input.flows);
+  pushEntitySection(content, "Touched Components", currentPath, input.touchedComponentIds, input.components);
+  pushClaimSection(content, input.claims, input.evidenceByClaimId, input.sourceById);
+
+  return lines(...content);
+}
+
+function renderSources(sources: Source[], claims: Claim[], evidenceByClaimId: Map<string, Evidence[]>): string {
+  const claimById = new Map(claims.map((claim) => [claim.id, claim]));
+  const claimIdsBySourceId = new Map<string, string[]>();
+
+  for (const [claimId, evidence] of evidenceByClaimId) {
+    for (const item of evidence) appendToMap(claimIdsBySourceId, item.sourceId, claimId);
+  }
+
+  const content = ["# Sources", ""];
+  for (const source of sortByTitle(sources)) {
+    content.push(`## ${source.title ?? source.ref}`, "", `\`${source.id}\` | \`${source.kind}\` | \`${source.ref}\``, "");
+    const claimIds = claimIdsBySourceId.get(source.id) ?? [];
+    if (claimIds.length === 0) {
+      content.push("- No claims reference this source.");
+    } else {
+      for (const claimId of claimIds.sort()) {
+        const claim = claimById.get(claimId);
+        content.push(`- \`${claimId}\`${claim === undefined ? "" : ` ${claim.text}`}`);
+      }
+    }
+    content.push("");
+  }
+
+  if (sources.length === 0) content.push("No sources.");
+  return lines(...content);
+}
+
+function renderClaims(claims: Claim[], evidenceByClaimId: Map<string, Evidence[]>, sourceById: Map<string, Source>): string[] {
+  if (claims.length === 0) return [];
+
+  const content: string[] = [];
+
+  for (const [kind, kindClaims] of groupedClaims(claims)) {
+    content.push(`### ${claimKindTitle(kind)}`, "");
+    for (const claim of kindClaims) {
+      const evidence = evidenceByClaimId.get(claim.id) ?? [];
+      const evidenceText = evidence.length === 0 ? "" : ` Evidence: ${renderEvidence(evidence, sourceById)}.`;
+      content.push(`- \`${claim.id}\`${claimMetadata(claim)}: ${claim.text}${evidenceText}`);
+    }
+    content.push("");
+  }
+  return content;
+}
+
+function pushEntitySection<T extends Entity>(
+  content: string[],
+  title: string,
+  currentPath: string,
+  ids: string[],
+  index: EntityIndex<T>,
+): void {
+  if (ids.length === 0) return;
+  content.push("", `## ${title}`, "", ...renderEntityLinks(currentPath, ids, index));
+}
+
+function pushClaimSection(
+  content: string[],
+  claims: Claim[],
+  evidenceByClaimId: Map<string, Evidence[]>,
+  sourceById: Map<string, Source>,
+): void {
+  const renderedClaims = renderClaims(claims, evidenceByClaimId, sourceById);
+  if (renderedClaims.length === 0) return;
+  content.push("", "## Claims", "", ...renderedClaims);
+}
+
+function renderEntityTree<T extends Entity>(currentPath: string, ids: string[], index: EntityIndex<T>, depth = 0): string[] {
+  if (ids.length === 0 && depth === 0) return ["- None."];
+  const content: string[] = [];
+  for (const id of ids) {
+    const entity = index.byId.get(id);
+    if (entity === undefined) continue;
+    const indent = "  ".repeat(depth);
+    content.push(`${indent}- ${linkToEntity(currentPath, id, index) ?? entity.name}`);
+    content.push(...renderEntityTree(currentPath, index.childrenByParentId.get(id) ?? [], index, depth + 1));
+  }
+  return content;
+}
+
+function renderEntityLinks<T extends Entity>(currentPath: string, ids: string[], index: EntityIndex<T>): string[] {
+  return ids
+    .map((id) => linkToEntity(currentPath, id, index))
+    .filter((link): link is string => link !== undefined)
+    .map((link) => `- ${link}`);
+}
+
+function linkToEntity<T extends Entity>(currentPath: string, id: string, index: EntityIndex<T>): string | undefined {
+  const entity = index.byId.get(id);
+  const entityPath = index.pathsById.get(id);
+  if (entity === undefined || entityPath === undefined) return undefined;
+  const target = relativeFolderLink(currentPath, `${entityPath}/index.md`);
+  return `[${entity.name}](${target})`;
+}
+
+function relativeFolderLink(fromIndexPath: string, toIndexPath: string): string {
+  const fromDirectory = path.dirname(fromIndexPath);
+  const toDirectory = path.dirname(toIndexPath);
+  const relative = path.relative(fromDirectory, toDirectory);
+  return relative.length === 0 ? "./" : `${relative}/`;
+}
+
+function buildClaimsBySubjectId(claims: Claim[], edges: Edge[]): Map<string, Claim[]> {
+  const claimById = new Map(claims.map((claim) => [claim.id, claim]));
+  const claimsBySubjectId = new Map<string, Claim[]>();
+
+  for (const edge of edges) {
+    if (edge.kind !== "about" || edge.from_type !== "claim") continue;
+    const claim = claimById.get(edge.from_id);
+    if (claim === undefined) continue;
+    appendToMap(claimsBySubjectId, edge.to_id, claim);
+  }
+
+  for (const [subjectId, subjectClaims] of claimsBySubjectId) {
+    claimsBySubjectId.set(subjectId, sortByClaimKind(subjectClaims));
+  }
+
+  return claimsBySubjectId;
+}
+
+function groupedClaims(claims: Claim[]): Array<[ClaimKind, Claim[]]> {
+  const groups = new Map<ClaimKind, Claim[]>();
+  for (const claim of sortByClaimKind(claims)) appendToMap(groups, claim.kind, claim);
+  return [...groups.entries()];
+}
+
+function claimKindTitle(kind: ClaimKind): string {
+  switch (kind) {
+    case "decision":
+      return "Decisions";
+    case "fact":
+      return "Facts";
+    case "question":
+      return "Questions";
+    case "requirement":
+      return "Requirements";
+    case "risk":
+      return "Risks";
+    case "task":
+      return "Tasks";
+  }
+}
+
+function claimMetadata(claim: Claim): string {
+  const metadata = [];
+  if (claim.truth !== "code_verified") metadata.push(claim.truth);
+  if (claim.intent !== "intended") metadata.push(`${claim.intent} intent`);
+  return metadata.length === 0 ? "" : ` (${metadata.join(", ")})`;
+}
+
+function renderEvidence(evidence: Evidence[], sourceById: Map<string, Source>): string {
+  return evidence
+    .map((item) => {
+      const source = sourceById.get(item.sourceId);
+      return source?.title ?? source?.ref ?? item.sourceId;
+    })
+    .join("; ");
+}
+
+function buildTouchedComponentIdsByFlowId(edges: Edge[]): Map<string, string[]> {
+  const touchedComponentIdsByFlowId = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (edge.kind !== "touches" || edge.from_type !== "flow" || edge.to_type !== "component") continue;
+    appendToMap(touchedComponentIdsByFlowId, edge.from_id, edge.to_id);
+  }
+  for (const [flowId, componentIds] of touchedComponentIdsByFlowId) touchedComponentIdsByFlowId.set(flowId, componentIds.sort());
+  return touchedComponentIdsByFlowId;
+}
+
+interface Evidence {
+  sourceId: string;
+  reason?: string;
+}
+
+function buildEvidenceByClaimId(edges: Edge[]): Map<string, Evidence[]> {
+  const evidenceByClaimId = new Map<string, Evidence[]>();
+  for (const edge of edges) {
+    if (edge.kind !== "evidenced_by" || edge.from_type !== "claim" || edge.to_type !== "source") continue;
+    const reason = typeof edge.metadata?.reason === "string" ? edge.metadata.reason : undefined;
+    appendToMap(evidenceByClaimId, edge.from_id, { sourceId: edge.to_id, reason });
+  }
+  return evidenceByClaimId;
+}
+
+function invertMap(input: Map<string, string[]>): Map<string, string[]> {
+  const output = new Map<string, string[]>();
+  for (const [fromId, toIds] of input) {
+    for (const toId of toIds) appendToMap(output, toId, fromId);
+  }
+  for (const [id, values] of output) output.set(id, values.sort());
+  return output;
+}
+
+function appendToMap<T>(map: Map<string, T[]>, key: string, value: T): void {
+  const values = map.get(key);
+  if (values === undefined) {
+    map.set(key, [value]);
+    return;
+  }
+  values.push(value);
+}
+
+function sortMapValues<T extends Entity>(map: Map<string, string[]>, byId: Map<string, T>): void {
+  for (const [key, ids] of map) {
+    map.set(
+      key,
+      ids.sort((left, right) => {
+        const leftEntity = byId.get(left);
+        const rightEntity = byId.get(right);
+        return (leftEntity?.name ?? left).localeCompare(rightEntity?.name ?? right);
+      }),
+    );
+  }
+}
+
+function sortByName<T extends Entity>(items: T[]): T[] {
+  return [...items].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function sortByTitle(items: Source[]): Source[] {
+  return [...items].sort((left, right) => (left.title ?? left.ref).localeCompare(right.title ?? right.ref));
+}
+
+function sortByClaimKind(claims: Claim[]): Claim[] {
+  return [...claims].sort((left, right) => {
+    const kind = left.kind.localeCompare(right.kind);
+    if (kind !== 0) return kind;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function segmentForId(id: string, type: EntityType): string {
+  const withoutPrefix = id.startsWith(`${type}.`) ? id.slice(type.length + 1) : id;
+  const slugged = withoutPrefix.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "").toLowerCase();
+  return slugged.length > 0 ? slugged : `${type}-${shortHash(id)}`;
+}
+
+function shortHash(value: string): string {
+  return createHash("sha1").update(value).digest("hex").slice(0, 8);
+}
+
+function lines(...values: Array<string | undefined>): string {
+  return `${values.filter((value): value is string => value !== undefined).join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`;
+}

--- a/libs/knowledge-graph/graph-context/render.ts
+++ b/libs/knowledge-graph/graph-context/render.ts
@@ -1,0 +1,166 @@
+import type { Claim } from "../claim.js";
+import type { Source } from "../schema.js";
+import type {
+  ClaimContextResult,
+  ComponentContextResult,
+  FlowContextResult,
+  GraphContextResult,
+} from "./types.js";
+
+interface CompactGraphContextResult {
+  query: string;
+  components: CompactComponentResult[];
+  flows: CompactFlowResult[];
+  claims: CompactClaimResult[];
+  sources: Source[];
+}
+
+interface CompactComponentResult {
+  id: string;
+  name: string;
+  code_anchor?: string;
+  matched_claim_ids: string[];
+}
+
+interface CompactFlowResult {
+  id: string;
+  name: string;
+  matched_claim_ids: string[];
+}
+
+interface CompactClaimResult {
+  id: string;
+  kind: Claim["kind"];
+  text: string;
+  truth: Claim["truth"];
+  intent: Claim["intent"];
+  about: ClaimContextResult["about"];
+  evidence: Array<{
+    source_id: string;
+    title?: string;
+    ref: string;
+    reason?: string;
+  }>;
+}
+
+export function renderGraphContextMarkdown(result: GraphContextResult): string {
+  const claimById = new Map(result.claims.map((claim) => [claim.object.id, claim]));
+  const shownClaimIds = new Set<string>();
+  const content = [
+    "# Graph Context",
+    "",
+    `Query: ${result.query}`,
+    "",
+    "## Components",
+    "",
+    ...renderComponents(result.components),
+    "",
+    "## Flows",
+    "",
+    ...renderFlows(result.flows, claimById, shownClaimIds),
+  ];
+  const remainingClaims = result.claims.filter((claim) => !shownClaimIds.has(claim.object.id));
+  if (remainingClaims.length > 0) {
+    content.push("", "## Other Relevant Claims", "", ...renderClaimItems(remainingClaims));
+  }
+  if (result.sources.length > 0) {
+    content.push("", "## Sources", "", ...renderSources(result.sources));
+  }
+
+  return lines(...content);
+}
+
+export function compactGraphContextResult(result: GraphContextResult): CompactGraphContextResult {
+  return {
+    query: result.query,
+    components: result.components.map((component) => ({
+      id: component.object.id,
+      name: component.object.name,
+      code_anchor: component.object.code_anchor,
+      matched_claim_ids: component.matched_claim_ids,
+    })),
+    flows: result.flows.map((flow) => ({
+      id: flow.object.id,
+      name: flow.object.name,
+      matched_claim_ids: flow.matched_claim_ids,
+    })),
+    claims: result.claims.map((claim) => ({
+      id: claim.object.id,
+      kind: claim.object.kind,
+      text: claim.object.text,
+      truth: claim.object.truth,
+      intent: claim.object.intent,
+      about: claim.about,
+      evidence: claim.evidence.map((evidence) => ({
+        source_id: evidence.source.id,
+        title: evidence.source.title,
+        ref: evidence.source.ref,
+        reason: evidence.reason.length > 0 ? evidence.reason : undefined,
+      })),
+    })),
+    sources: result.sources,
+  };
+}
+
+function renderComponents(components: ComponentContextResult[]): string[] {
+  if (components.length === 0) return ["- None."];
+  return components.map((component) => {
+    const anchor = component.object.code_anchor === undefined ? "" : `\n  Anchor: \`${component.object.code_anchor}\``;
+    return `- \`${component.object.id}\` ${component.object.name}${anchor}`;
+  });
+}
+
+function renderFlows(
+  flows: FlowContextResult[],
+  claimById: Map<string, ClaimContextResult>,
+  shownClaimIds: Set<string>,
+): string[] {
+  if (flows.length === 0) return ["- None."];
+  return flows.flatMap((flow) => {
+    const claims = claimsForFlow(flow, claimById);
+    for (const claim of claims) shownClaimIds.add(claim.object.id);
+    return [
+      `### ${flow.object.name}`,
+      "",
+      `ID: \`${flow.object.id}\``,
+      "",
+      "Claims:",
+      ...renderClaimItems(claims),
+      "",
+    ];
+  });
+}
+
+function claimsForFlow(flow: FlowContextResult, claimById: Map<string, ClaimContextResult>): ClaimContextResult[] {
+  const claims = new Map<string, ClaimContextResult>();
+  for (const claimId of flow.matched_claim_ids) {
+    const claim = claimById.get(claimId);
+    if (claim !== undefined) claims.set(claim.object.id, claim);
+  }
+  for (const claim of claimById.values()) {
+    if (claim.about.some((subject) => subject.type === "flow" && subject.id === flow.object.id)) {
+      claims.set(claim.object.id, claim);
+    }
+  }
+  return [...claims.values()].sort((left, right) => left.object.kind.localeCompare(right.object.kind) || left.object.id.localeCompare(right.object.id));
+}
+
+function renderClaimItems(claims: ClaimContextResult[]): string[] {
+  if (claims.length === 0) return ["- None."];
+  return claims.map((claim) => {
+    const evidence = claim.evidence.length === 0 ? "" : ` Source: ${claim.evidence.map(evidenceLabel).join("; ")}.`;
+    return `- \`${claim.object.id}\` (${claim.object.kind}, ${claim.object.truth}): ${claim.object.text}${evidence}`;
+  });
+}
+
+function evidenceLabel(evidence: ClaimContextResult["evidence"][number]): string {
+  return evidence.source.title ?? evidence.source.ref ?? evidence.source.id;
+}
+
+function renderSources(sources: Source[]): string[] {
+  return sources.map((source) => `- \`${source.id}\` ${source.title ?? source.ref}`);
+}
+
+function lines(...values: string[]): string {
+  return `${values.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`;
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",
+    "eval:coding-proposal-apply-atomicity": "npm run build && node dist/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/run.js",
     "eval:search-current": "npm run build && node dist/evals/cases/search-current-repo-at-8038fe8/run.js",
     "eval:update-working-memory-source-evidence": "npm run build && node dist/evals/cases/update-working-memory-source-evidence-at-0438915/run.js"
   },

--- a/skills/greplica-bootstrap/SKILL.md
+++ b/skills/greplica-bootstrap/SKILL.md
@@ -12,9 +12,11 @@ Create shallow, high-signal Greplica memory for the current repository.
 
 Run from the target repository root or any subdirectory inside it.
 
-1. Run `greplica doctor`.
-2. If `greplica` is missing, tell the user to run the Greplica setup prompt from the README.
-3. If `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in repo-root `.env.local`.
+Do not run `greplica doctor` as a routine preflight. Run the needed Greplica commands directly; if one fails, use the error to decide whether `greplica doctor` would help diagnose installation, repo detection, or OpenAI configuration.
+
+If `greplica` is missing, tell the user to run the Greplica setup prompt from the README.
+
+If a Greplica command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in repo-root `.env.local`.
 
 `greplica` automatically prepares repo memory state; do not ask the user to run a separate initialization command.
 

--- a/skills/greplica-update-working-memory/SKILL.md
+++ b/skills/greplica-update-working-memory/SKILL.md
@@ -12,9 +12,11 @@ Update working memory with durable information learned during this coding sessio
 
 Run from the target repository root or any subdirectory inside it.
 
-1. Run `greplica doctor`.
-2. If `greplica` is missing, tell the user to run the Greplica setup prompt from the README.
-3. If `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in repo-root `.env.local`.
+Do not run `greplica doctor` as a routine preflight. Run the needed Greplica commands directly; if one fails, use the error to decide whether `greplica doctor` would help diagnose installation, repo detection, or OpenAI configuration.
+
+If `greplica` is missing, tell the user to run the Greplica setup prompt from the README.
+
+If a Greplica command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in repo-root `.env.local`.
 
 `greplica` automatically prepares repo memory state; do not ask the user to run a separate initialization command.
 


### PR DESCRIPTION
## Summary
- add `greplica graph export <dir>` for Markdown folder exports of the current graph view
- add concise Markdown, compact `--json`, and full `--debug` output modes for `graph context`
- add a deterministic coding eval for the real `proposal apply` atomicity bug, reusing the existing seed memory profile
- update the search eval to consume `graph context --debug`

## Verification
- `npm run build`
- `npm run typecheck`
- direct atomicity verifier baseline on current buggy service: `1/4`
- control arm with `gpt-5.5`: `4/4`, 141.7s, 559,873 tokens
- Greplica arm with `gpt-5.5`: `4/4`, 119.3s, 364,134 tokens
