### PR TITLE
Add configurable local embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Greplica (`greplica`) stores lightweight codebase memory for coding agents. The 
 
 - Node.js and npm.
 - Build tools needed by native npm packages such as `better-sqlite3`.
-- An OpenAI API key for graph context search and proposal application.
+- An embedding provider for graph context search and proposal application. Local embeddings run in-process by default; OpenAI embeddings require `OPENAI_API_KEY` when configured.
 
 ## Agent Setup
 
@@ -18,7 +18,7 @@ Install Greplica for this repo.
 Goal:
 - Install the `greplica` CLI from the Greplica GitHub repo.
 - Install the bundled Greplica skills into this coding agent's user-level skills directory.
-- Verify the CLI can see this repo and can access OpenAI embeddings when configured.
+- Ask me whether to use local or OpenAI embeddings, then initialize Greplica with that choice.
 
 Use this repo unless I provide a different URL or branch:
 
@@ -60,14 +60,23 @@ greplica-bootstrap
 greplica-update-working-memory
 ```
 
-After installing skills, verify the install:
+Before running Greplica init, ask me whether to use local embeddings or OpenAI embeddings.
+
+Local is the default recommendation: it runs on this laptop without an API key and downloads the local embedding model into `~/.greplica/models`. OpenAI may be faster or higher quality, but requires `OPENAI_API_KEY`.
+
+If I choose local, run:
 
 ```bash
-greplica doctor
-greplica doctor --check-openai
+greplica init --local
 ```
 
-If `greplica doctor --check-openai` reports that `OPENAI_API_KEY` is missing or invalid, stop and ask me to set it. Do not ask me to paste the key into chat. I can set it either in my shell before starting the coding agent, or in this repo's `.env.local` file:
+If I choose OpenAI, verify `OPENAI_API_KEY` is available in the environment, this repo's `.env.local`, or this repo's `.env`, then run:
+
+```bash
+greplica init --openai
+```
+
+If OpenAI is selected and `OPENAI_API_KEY` is missing or invalid, stop and ask me to set it. Do not ask me to paste the key into chat. I can set it either in my shell before starting the coding agent, or in this repo's `.env.local` file:
 
 ```txt
 OPENAI_API_KEY=...
@@ -76,6 +85,8 @@ OPENAI_API_KEY=...
 After setup, tell me:
 - where the CLI was installed
 - where the two skills were installed
+- which embedding mode was selected
+- where the Greplica config file is
 - whether I need to restart the coding agent for skills to appear
 - how to invoke `greplica-bootstrap` and `greplica-update-working-memory`
 ````
@@ -98,6 +109,51 @@ Do not run `greplica doctor` before normal Greplica commands. Use the intended c
 
 ## Configuration
 
+`greplica` stores default CLI config at `~/.greplica/config.json`:
+
+```json
+{
+  "version": 1,
+  "embedding": {
+    "provider": "local",
+    "model": "all-mpnet-base-v2",
+    "dimensions": 768,
+    "batchSize": 16
+  }
+}
+```
+
+Print the config path, current JSON, allowed providers, and common examples:
+
+```bash
+greplica config
+```
+
+Edit the printed JSON file directly to change the selected embedding provider, model, dimensions, or batch size. For example:
+
+```json
+{
+  "version": 1,
+  "embedding": {
+    "provider": "openai",
+    "model": "text-embedding-3-small",
+    "dimensions": 1536,
+    "batchSize": 100
+  }
+}
+```
+
+Allowed `embedding.provider` values are `local` and `openai`.
+
+`greplica init --local` and `greplica init --openai` also update the same config file to provider defaults while initializing repo memory and checking that the selected embedding provider is ready.
+
+Local embeddings run in-process with a quantized Hugging Face Transformers model and cache model files under `~/.greplica/models`. The first `greplica init --local` or local embedding check downloads the configured model; subsequent runs reuse the cache.
+
+Useful local model choices:
+
+- `all-mpnet-base-v2`, 768 dimensions, default local model.
+- `all-MiniLM-L6-v2`, 384 dimensions, smaller local option.
+
 `greplica` looks for `OPENAI_API_KEY` in this order:
 
 1. the process environment
@@ -111,7 +167,9 @@ Memory is stored in `~/.greplica/graph.db` by default. Set `GREPLICA_HOME` only 
 ## Commands
 
 ```bash
-greplica doctor [--check-openai]
+greplica init [--local|--openai]
+greplica config
+greplica doctor [--check-embeddings]
 greplica graph read
 greplica graph context "<query>" [--json|--debug]
 greplica proposal validate <proposal.json>

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { createLocalKnowledgeGraphService } from "../../libs/knowledge-graph/service.js";
 import type { KnowledgeGraphService, RepoRef } from "../../libs/knowledge-graph/service.js";
 import { envVarSource, loadRepoEnv, type LoadedRepoEnv } from "../../libs/env/load-local-env.js";
-import { graphContextConfig } from "../../libs/knowledge-graph/graph-context/config.js";
-import { OpenAIEmbedder } from "../../libs/knowledge-graph/graph-context/openai-embedder.js";
+import {
+  ensureGreplicaConfig,
+  greplicaConfigPath,
+  updateEmbeddingConfig,
+  type EmbeddingConfig,
+  type EmbeddingProvider,
+  type GreplicaConfig,
+} from "../../libs/config/greplica-config.js";
+import { graphContextConfigFromGreplicaConfig } from "../../libs/knowledge-graph/graph-context/config.js";
+import { createEmbedder } from "../../libs/knowledge-graph/graph-context/embedder.js";
 import { compactGraphContextResult, renderGraphContextMarkdown } from "../../libs/knowledge-graph/graph-context/render.js";
 import { buildGraphFolderExport } from "../../libs/knowledge-graph/folder-export.js";
 import { detectRepoContext } from "./repo-context.js";
@@ -13,13 +21,24 @@ import { detectRepoContext } from "./repo-context.js";
 interface CommandContext {
   repo: RepoRef;
   env: LoadedRepoEnv;
+  config: GreplicaConfig;
   service: KnowledgeGraphService;
 }
 
 async function main(argv: string[]): Promise<void> {
   const [area, action, ...rest] = argv;
 
-  if (area === "init" && action === undefined) {
+  if (area === "init") {
+    const initArgs = [action, ...rest].filter((arg): arg is string => arg !== undefined);
+    const provider = parseOptionalEmbeddingSelection(initArgs);
+    let configuredEmbedding: EmbeddingConfig | undefined;
+    if (provider !== undefined) {
+      const config = updateEmbeddingConfig({ provider });
+      configuredEmbedding = config.embedding;
+      console.log(`Config: ${displayConfigPath()}`);
+      printEmbeddingConfig(config.embedding);
+    }
+
     const { repo, service } = createCommandContext();
     const result = service.initRepo(repo);
     console.log(result.created ? "Initialized Greplica memory." : "Greplica memory already initialized.");
@@ -29,6 +48,14 @@ async function main(argv: string[]): Promise<void> {
     console.log(`Database: ${result.database_path}`);
     console.log(`Main scope: ${result.main_scope_id}`);
     console.log(`Working scope: ${result.working_scope_id}`);
+    if (configuredEmbedding !== undefined) {
+      if (!(await checkEmbeddings(configuredEmbedding))) process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (area === "config") {
+    runConfigCommand([action, ...rest].filter((arg): arg is string => arg !== undefined));
     return;
   }
 
@@ -116,8 +143,9 @@ async function main(argv: string[]): Promise<void> {
 function createCommandContext(): CommandContext {
   const repo = detectRepoContext();
   const env = loadRepoEnv(repo.repo_root ?? process.cwd());
-  const service = createLocalKnowledgeGraphService();
-  return { repo, env, service };
+  const config = ensureGreplicaConfig();
+  const service = createLocalKnowledgeGraphService(graphContextConfigFromGreplicaConfig(config));
+  return { repo, env, config, service };
 }
 
 async function runDoctor(args: string[]): Promise<void> {
@@ -150,30 +178,84 @@ async function runDoctor(args: string[]): Promise<void> {
     console.log(error instanceof Error ? error.message : String(error));
   }
 
-  const source = envVarSource("OPENAI_API_KEY", context.env);
-  if (source === undefined) {
-    ready = false;
-    console.log("OPENAI_API_KEY: missing");
-    console.log("Set OPENAI_API_KEY in the shell, repo-root .env.local, or repo-root .env.");
-  } else if (source.kind === "environment") {
-    console.log("OPENAI_API_KEY: found in environment");
-  } else {
-    console.log(`OPENAI_API_KEY: found in ${source.path}`);
-  }
+  console.log(`Config: ${displayConfigPath()}`);
+  printEmbeddingConfig(context.config.embedding);
 
-  if (source !== undefined && args.includes("--check-openai")) {
-    try {
-      const embedder = new OpenAIEmbedder(graphContextConfig.embedding);
-      await embedder.embed("greplica doctor");
-      console.log("OpenAI embeddings: ok");
-    } catch (error: unknown) {
+  if (context.config.embedding.provider === "openai") {
+    const source = envVarSource("OPENAI_API_KEY", context.env);
+    if (source === undefined) {
       ready = false;
-      console.log("OpenAI embeddings: failed");
-      console.log(error instanceof Error ? error.message : String(error));
+      console.log("OPENAI_API_KEY: missing");
+      console.log("Set OPENAI_API_KEY in the shell, repo-root .env.local, or repo-root .env.");
+    } else if (source.kind === "environment") {
+      console.log("OPENAI_API_KEY: found in environment");
+    } else {
+      console.log(`OPENAI_API_KEY: found in ${source.path}`);
     }
   }
 
+  if (args.includes("--check-embeddings") || args.includes("--check-openai")) {
+    ready = (await checkEmbeddings(context.config.embedding)) && ready;
+  }
+
   process.exitCode = ready ? 0 : 1;
+}
+
+async function checkEmbeddings(config: EmbeddingConfig): Promise<boolean> {
+  try {
+    console.log(`Checking ${config.provider} embeddings...`);
+    const embedder = createEmbedder(config);
+    await embedder.embed("greplica embeddings check");
+    console.log(`${config.provider} embeddings: ok`);
+    return true;
+  } catch (error: unknown) {
+    console.log(`${config.provider} embeddings: failed`);
+    console.log(error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function runConfigCommand(args: string[]): void {
+  if (args.length > 0) throw new Error("Usage: greplica config");
+
+  const config = ensureGreplicaConfig();
+  console.log("Greplica config");
+  console.log(`Path: ${displayConfigPath()}`);
+  console.log("");
+  console.log("Edit this JSON to change Greplica defaults:");
+  console.log(JSON.stringify(config, null, 2));
+  console.log("");
+  console.log("Allowed embedding.provider values:");
+  console.log("- local");
+  console.log("- openai");
+  console.log("");
+  console.log("Common embedding examples:");
+  console.log("- local MPNet base: provider=local, model=all-mpnet-base-v2, dimensions=768, batchSize=16");
+  console.log("- local MiniLM: provider=local, model=all-MiniLM-L6-v2, dimensions=384, batchSize=32");
+  console.log("- OpenAI small: provider=openai, model=text-embedding-3-small, dimensions=1536, batchSize=100");
+}
+
+function parseOptionalEmbeddingSelection(args: string[]): EmbeddingProvider | undefined {
+  const local = args.includes("--local");
+  const openai = args.includes("--openai");
+  if (local && openai) throw new Error("Use either --local or --openai, not both.");
+  if (!local && !openai) {
+    if (args.length === 0) return undefined;
+    throw new Error("Usage: greplica init [--local|--openai]");
+  }
+  if (args.length !== 1) throw new Error("Usage: greplica init [--local|--openai]");
+  return local ? "local" : "openai";
+}
+
+function printEmbeddingConfig(config: EmbeddingConfig): void {
+  console.log(`Embedding provider: ${config.provider}`);
+  console.log(`Embedding model: ${config.model}`);
+  console.log(`Embedding dimensions: ${config.dimensions}`);
+  console.log(`Embedding batch size: ${config.batchSize}`);
+}
+
+function displayConfigPath(): string {
+  return resolve(greplicaConfigPath());
 }
 
 function readProposal(file: string): unknown {
@@ -227,7 +309,9 @@ function field(item: object, key: string): string {
 function printHelp(): void {
   const cli = basename(process.argv[1] ?? "greplica");
   console.log(`Usage:
-  ${cli} doctor [--check-openai]
+  ${cli} init [--local|--openai]
+  ${cli} config
+  ${cli} doctor [--check-embeddings]
   ${cli} graph read
   ${cli} graph context <query> [--json|--debug]
   ${cli} graph export <dir>

--- a/evals/cases/search-current-repo-at-8038fe8/run.ts
+++ b/evals/cases/search-current-repo-at-8038fe8/run.ts
@@ -24,6 +24,10 @@ interface RunContext {
   targetRepoDir: string;
   targetRepoUrl: string;
   greplicaHomeDir: string;
+  embeddingProvider: "local" | "openai" | undefined;
+  embeddingModel: string | undefined;
+  embeddingDimensions: number | undefined;
+  embeddingBatchSize: number | undefined;
   proposalPath: string;
   rubricPath: string;
   greplicaCommand: string[];
@@ -123,7 +127,7 @@ function main(): void {
   validateRubric(rubric);
 
   const setupCommands = [
-    runProductCommand(context, "init"),
+    runInitCommand(context),
     runProductCommand(context, "proposal", "validate", context.proposalPath),
     runProductCommand(context, "proposal", "apply", context.proposalPath),
   ];
@@ -152,6 +156,10 @@ function prepareRun(): RunContext {
   const targetRepoDir = resolve(runDir, "target-repo");
   const targetRepoUrl = process.env.GREPLICA_EVAL_TARGET_REPO_URL ?? repoRoot;
   const greplicaHomeDir = resolve(runDir, "greplica-home");
+  const embeddingProvider = parseEmbeddingProvider(process.env.GREPLICA_EVAL_EMBEDDING_PROVIDER);
+  const embeddingModel = parseOptionalString(process.env.GREPLICA_EVAL_EMBEDDING_MODEL, "GREPLICA_EVAL_EMBEDDING_MODEL");
+  const embeddingDimensions = parseOptionalPositiveInteger(process.env.GREPLICA_EVAL_EMBEDDING_DIMENSIONS, "GREPLICA_EVAL_EMBEDDING_DIMENSIONS");
+  const embeddingBatchSize = parseOptionalPositiveInteger(process.env.GREPLICA_EVAL_EMBEDDING_BATCH_SIZE, "GREPLICA_EVAL_EMBEDDING_BATCH_SIZE");
 
   mkdirSync(runDir, { recursive: true });
   mkdirSync(greplicaHomeDir, { recursive: true });
@@ -162,10 +170,34 @@ function prepareRun(): RunContext {
     targetRepoDir,
     targetRepoUrl,
     greplicaHomeDir,
+    embeddingProvider,
+    embeddingModel,
+    embeddingDimensions,
+    embeddingBatchSize,
     proposalPath: resolve(repoRoot, "evals/cases/search-current-repo-at-8038fe8/proposal.json"),
     rubricPath: resolve(repoRoot, "evals/cases/search-current-repo-at-8038fe8/rubric.json"),
     greplicaCommand: ["node", resolve(repoRoot, "dist/apps/cli/main.js")],
   };
+}
+
+function parseEmbeddingProvider(value: string | undefined): "local" | "openai" | undefined {
+  if (value === undefined || value.trim().length === 0) return undefined;
+  if (value === "local" || value === "openai") return value;
+  throw new Error("GREPLICA_EVAL_EMBEDDING_PROVIDER must be local or openai.");
+}
+
+function parseOptionalString(value: string | undefined, name: string): string | undefined {
+  if (value === undefined || value.trim().length === 0) return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) throw new Error(`${name} must be a non-empty string.`);
+  return trimmed;
+}
+
+function parseOptionalPositiveInteger(value: string | undefined, name: string): number | undefined {
+  if (value === undefined || value.trim().length === 0) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer.`);
+  return parsed;
 }
 
 function prepareTargetRepo(context: RunContext): void {
@@ -362,6 +394,38 @@ function runProductCommand(context: RunContext, ...args: string[]): CommandResul
   return run([...context.greplicaCommand, ...args], context.targetRepoDir, {
     ...process.env,
     GREPLICA_HOME: context.greplicaHomeDir,
+  });
+}
+
+function runInitCommand(context: RunContext): CommandResult {
+  const result = context.embeddingProvider === undefined
+    ? runProductCommand(context, "init")
+    : runProductCommand(context, "init", `--${context.embeddingProvider}`);
+  if (result.exit_code === 0) writeEvalEmbeddingOverride(context);
+  return result;
+}
+
+function writeEvalEmbeddingOverride(context: RunContext): void {
+  if (
+    context.embeddingModel === undefined &&
+    context.embeddingDimensions === undefined &&
+    context.embeddingBatchSize === undefined
+  ) {
+    return;
+  }
+
+  const configPath = resolve(context.greplicaHomeDir, "config.json");
+  const config = readJson<Record<string, unknown>>(configPath);
+  const embedding = isRecord(config.embedding) ? config.embedding : {};
+
+  writeJson(configPath, {
+    ...config,
+    embedding: {
+      ...embedding,
+      ...(context.embeddingModel === undefined ? {} : { model: context.embeddingModel }),
+      ...(context.embeddingDimensions === undefined ? {} : { dimensions: context.embeddingDimensions }),
+      ...(context.embeddingBatchSize === undefined ? {} : { batchSize: context.embeddingBatchSize }),
+    },
   });
 }
 

--- a/libs/config/greplica-config.ts
+++ b/libs/config/greplica-config.ts
@@ -1,0 +1,150 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { greplicaHome } from "./greplica-home.js";
+
+export type EmbeddingProvider = "local" | "openai";
+
+export interface EmbeddingConfig {
+  provider: EmbeddingProvider;
+  model: string;
+  dimensions: number;
+  batchSize: number;
+}
+
+export interface GreplicaConfig {
+  version: 1;
+  embedding: EmbeddingConfig;
+}
+
+export interface EmbeddingConfigInput {
+  provider: EmbeddingProvider;
+  model?: string;
+  dimensions?: number;
+  batchSize?: number;
+}
+
+const embeddingDefaults: Record<EmbeddingProvider, EmbeddingConfig> = {
+  local: {
+    provider: "local",
+    model: "all-mpnet-base-v2",
+    dimensions: 768,
+    batchSize: 16,
+  },
+  openai: {
+    provider: "openai",
+    model: "text-embedding-3-small",
+    dimensions: 1536,
+    batchSize: 100,
+  },
+};
+
+export const defaultGreplicaConfig: GreplicaConfig = {
+  version: 1,
+  embedding: { ...embeddingDefaults.local },
+};
+
+export function defaultEmbeddingConfig(provider: EmbeddingProvider): EmbeddingConfig {
+  return { ...embeddingDefaults[provider] };
+}
+
+export function greplicaConfigPath(): string {
+  return join(greplicaHome(), "config.json");
+}
+
+export function ensureGreplicaConfig(path = greplicaConfigPath()): GreplicaConfig {
+  if (!existsSync(path)) {
+    writeGreplicaConfig(defaultGreplicaConfig, path);
+    return cloneConfig(defaultGreplicaConfig);
+  }
+  return readGreplicaConfig(path);
+}
+
+export function readGreplicaConfig(path = greplicaConfigPath()): GreplicaConfig {
+  if (!existsSync(path)) return cloneConfig(defaultGreplicaConfig);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid Greplica config at ${path}: ${message}`);
+  }
+
+  return normalizeConfig(parsed, path);
+}
+
+export function writeGreplicaConfig(config: GreplicaConfig, path = greplicaConfigPath()): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+}
+
+export function updateEmbeddingConfig(input: EmbeddingConfigInput, path = greplicaConfigPath()): GreplicaConfig {
+  const base = defaultEmbeddingConfig(input.provider);
+  const config: GreplicaConfig = {
+    version: 1,
+    embedding: {
+      ...base,
+      model: input.model ?? base.model,
+      dimensions: input.dimensions ?? base.dimensions,
+      batchSize: input.batchSize ?? base.batchSize,
+    },
+  };
+  writeGreplicaConfig(config, path);
+  return config;
+}
+
+function normalizeConfig(value: unknown, path: string): GreplicaConfig {
+  if (!isRecord(value)) throw new Error(`Invalid Greplica config at ${path}: expected an object.`);
+  const version = value.version === undefined ? 1 : value.version;
+  if (version !== 1) throw new Error(`Invalid Greplica config at ${path}: unsupported version ${String(version)}.`);
+
+  const embeddingValue = value.embedding;
+  if (!isRecord(embeddingValue)) {
+    return cloneConfig(defaultGreplicaConfig);
+  }
+
+  const provider = parseProvider(embeddingValue.provider, path);
+  const defaults = defaultEmbeddingConfig(provider);
+  const model = parseString(embeddingValue.model, defaults.model, "embedding.model", path);
+  const dimensions = parsePositiveInteger(embeddingValue.dimensions, defaults.dimensions, "embedding.dimensions", path);
+  const batchSize = parsePositiveInteger(embeddingValue.batchSize, defaults.batchSize, "embedding.batchSize", path);
+
+  return {
+    version: 1,
+    embedding: {
+      provider,
+      model,
+      dimensions,
+      batchSize,
+    },
+  };
+}
+
+function parseProvider(value: unknown, path: string): EmbeddingProvider {
+  if (value === "local" || value === "openai") return value;
+  if (value === undefined) return defaultGreplicaConfig.embedding.provider;
+  throw new Error(`Invalid Greplica config at ${path}: embedding.provider must be local or openai.`);
+}
+
+function parseString(value: unknown, fallback: string, field: string, path: string): string {
+  if (value === undefined) return fallback;
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  throw new Error(`Invalid Greplica config at ${path}: ${field} must be a non-empty string.`);
+}
+
+function parsePositiveInteger(value: unknown, fallback: number, field: string, path: string): number {
+  if (value === undefined) return fallback;
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
+  throw new Error(`Invalid Greplica config at ${path}: ${field} must be a positive integer.`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneConfig(config: GreplicaConfig): GreplicaConfig {
+  return {
+    version: config.version,
+    embedding: { ...config.embedding },
+  };
+}

--- a/libs/config/greplica-home.ts
+++ b/libs/config/greplica-home.ts
@@ -1,0 +1,6 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function greplicaHome(): string {
+  return process.env.GREPLICA_HOME ?? process.env.ENGINEERING_CONTEXT_HOME ?? join(homedir(), ".greplica");
+}

--- a/libs/knowledge-graph/graph-context/config.ts
+++ b/libs/knowledge-graph/graph-context/config.ts
@@ -1,41 +1,57 @@
-export const graphContextConfig = {
-  version: "graph-context-v3-graph-boost",
-  embedding: {
-    provider: "openai",
-    model: "text-embedding-3-small",
-    dimensions: 1536,
-    batchSize: 100,
+import type { GreplicaConfig, EmbeddingConfig } from "../../config/greplica-config.js";
+
+const rankingConfig = {
+  semanticThreshold: 0.1,
+  selectionThreshold: 0.72,
+  minimumSelectedClaims: 3,
+  weights: {
+    semantic: 1,
+    bm25: 0.075,
+    exact: 0,
   },
-  ranking: {
-    semanticThreshold: 0.1,
-    selectionThreshold: 0.72,
-    minimumSelectedClaims: 3,
-    weights: {
-      semantic: 1,
-      bm25: 0.075,
-      exact: 0,
-    },
-    bm25: {
-      k1: 1.5,
-      b: 0.75,
-    },
-    claimSupport: {
-      weight: 1,
-      countBoost: 0.03,
-    },
-    directObject: {
-      weight: 0.85,
-    },
-    graphBoost: {
-      containsParentToChild: 0.85,
-      containsChildToParent: 0.85,
-      aboutClaimToObject: 0,
-      aboutObjectToClaim: 0,
-      touchesFlowToComponent: 0,
-      touchesComponentToFlow: 0,
-      maxSources: 3,
-    },
+  bm25: {
+    k1: 1.5,
+    b: 0.75,
+  },
+  claimSupport: {
+    weight: 1,
+    countBoost: 0.03,
+  },
+  directObject: {
+    weight: 0.85,
+  },
+  graphBoost: {
+    containsParentToChild: 0.85,
+    containsChildToParent: 0.85,
+    aboutClaimToObject: 0,
+    aboutObjectToClaim: 0,
+    touchesFlowToComponent: 0,
+    touchesComponentToFlow: 0,
+    maxSources: 3,
   },
 } as const;
 
-export type GraphContextConfig = typeof graphContextConfig;
+export interface GraphContextConfig {
+  version: string;
+  embedding: EmbeddingConfig;
+  ranking: typeof rankingConfig;
+}
+
+export const graphContextConfig: GraphContextConfig = {
+  version: "graph-context-v3-graph-boost",
+  embedding: {
+    provider: "local",
+    model: "all-mpnet-base-v2",
+    dimensions: 768,
+    batchSize: 16,
+  },
+  ranking: rankingConfig,
+};
+
+export function graphContextConfigFromGreplicaConfig(config: GreplicaConfig): GraphContextConfig {
+  return {
+    ...graphContextConfig,
+    version: `${graphContextConfig.version}:${config.embedding.provider}:${config.embedding.model}:${config.embedding.dimensions}`,
+    embedding: { ...config.embedding },
+  };
+}

--- a/libs/knowledge-graph/graph-context/context-builder.ts
+++ b/libs/knowledge-graph/graph-context/context-builder.ts
@@ -10,7 +10,7 @@ import {
   contextDocumentKey,
   type ContextDocument,
 } from "./documents.js";
-import { OpenAIEmbedder } from "./openai-embedder.js";
+import { createEmbedder, type Embedder } from "./embedder.js";
 import { float32ArrayToBuffer, bufferToFloat32Array, cosineSimilarity } from "./vector.js";
 import { scoreBm25 } from "./bm25.js";
 import { scoreExact } from "./exact.js";
@@ -37,7 +37,7 @@ export class GraphContextBuilder {
     const flowDocuments = buildFlowDocuments(graph);
     const evidenceByClaim = buildEvidenceByClaim(graph);
     const documents = [...claimDocuments, ...componentDocuments, ...flowDocuments];
-    const embedder = new OpenAIEmbedder(config.embedding);
+    const embedder = createEmbedder(config.embedding);
     const embeddingStatus = await this.ensureEmbeddings(repoId, documents, embedder, config);
     if (options.warnOnCreatedEmbeddings && embeddingStatus.created > 0) {
       console.warn(`graph context created ${embeddingStatus.created} missing embedding(s); proposal apply should normally pre-create them.`);
@@ -86,14 +86,14 @@ export class GraphContextBuilder {
       ...buildComponentDocuments(graph),
       ...buildFlowDocuments(graph),
     ];
-    const embedder = new OpenAIEmbedder(config.embedding);
+    const embedder = createEmbedder(config.embedding);
     return this.ensureEmbeddings(repoId, documents, embedder, config);
   }
 
   private async ensureEmbeddings(
     repoId: string,
     documents: ContextDocument[],
-    embedder: OpenAIEmbedder,
+    embedder: Embedder,
     config: GraphContextConfig,
   ): Promise<EmbeddingStatus> {
     const existing = new Set(

--- a/libs/knowledge-graph/graph-context/embedder.ts
+++ b/libs/knowledge-graph/graph-context/embedder.ts
@@ -1,0 +1,13 @@
+import type { EmbeddingConfig } from "../../config/greplica-config.js";
+import { LocalEmbedder } from "./local-embedder.js";
+import { OpenAIEmbedder } from "./openai-embedder.js";
+
+export interface Embedder {
+  embed(text: string): Promise<number[]>;
+  embedBatch(texts: string[]): Promise<number[][]>;
+}
+
+export function createEmbedder(config: EmbeddingConfig): Embedder {
+  if (config.provider === "openai") return new OpenAIEmbedder(config);
+  return new LocalEmbedder(config);
+}

--- a/libs/knowledge-graph/graph-context/local-embedder.ts
+++ b/libs/knowledge-graph/graph-context/local-embedder.ts
@@ -1,0 +1,95 @@
+import { join } from "node:path";
+import type { EmbeddingConfig } from "../../config/greplica-config.js";
+import { greplicaHome } from "../../config/greplica-home.js";
+import type { Embedder } from "./embedder.js";
+
+interface TensorLike {
+  data: Float32Array | number[];
+  dims: number[];
+}
+
+type FeatureExtractionPipeline = (
+  input: string | string[],
+  options: { pooling: "mean"; normalize: boolean },
+) => Promise<TensorLike>;
+
+const localModelAliases: Record<string, string> = {
+  "all-mpnet-base-v2": "Xenova/all-mpnet-base-v2",
+  "all-MiniLM-L6-v2": "Xenova/all-MiniLM-L6-v2",
+};
+
+export class LocalEmbedder implements Embedder {
+  private extractor: Promise<FeatureExtractionPipeline> | undefined;
+  private readonly modelId: string;
+  private readonly cacheDir: string;
+
+  constructor(private readonly options: EmbeddingConfig) {
+    this.modelId = resolveLocalModelId(options.model);
+    this.cacheDir = join(greplicaHome(), "models");
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const [embedding] = await this.embedBatch([text]);
+    if (!embedding) throw new Error("Local embedding model returned no embedding for query.");
+    return embedding;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const embeddings: number[][] = [];
+    for (let index = 0; index < texts.length; index += this.options.batchSize) {
+      embeddings.push(...(await this.embedChunk(texts.slice(index, index + this.options.batchSize))));
+    }
+    return embeddings;
+  }
+
+  private async embedChunk(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const extractor = await this.loadExtractor();
+    const output = await extractor(texts, { pooling: "mean", normalize: true });
+    return splitTensorRows(output, texts.length, this.options.dimensions, this.modelId);
+  }
+
+  private async loadExtractor(): Promise<FeatureExtractionPipeline> {
+    this.extractor ??= loadFeatureExtractionPipeline(this.modelId, this.cacheDir);
+    return this.extractor;
+  }
+}
+
+async function loadFeatureExtractionPipeline(modelId: string, cacheDir: string): Promise<FeatureExtractionPipeline> {
+  const { pipeline } = await import("@huggingface/transformers");
+  const options = {
+    cache_dir: cacheDir,
+    dtype: "q8",
+  } as const;
+
+  try {
+    return await pipeline("feature-extraction", modelId, {
+      ...options,
+      local_files_only: true,
+    }) as FeatureExtractionPipeline;
+  } catch {
+    return pipeline("feature-extraction", modelId, options) as Promise<FeatureExtractionPipeline>;
+  }
+}
+
+function resolveLocalModelId(model: string): string {
+  return localModelAliases[model] ?? model;
+}
+
+function splitTensorRows(output: TensorLike, expectedRows: number, expectedDimensions: number, modelId: string): number[][] {
+  const [rows, dimensions] = output.dims;
+  if (rows !== expectedRows || dimensions !== expectedDimensions) {
+    throw new Error(
+      `Local embedding model ${modelId} returned shape [${output.dims.join(", ")}]; expected [${expectedRows}, ${expectedDimensions}].`,
+    );
+  }
+
+  const data = output.data;
+  const embeddings: number[][] = [];
+  for (let row = 0; row < rows; row += 1) {
+    const start = row * dimensions;
+    embeddings.push(Array.from(data.slice(start, start + dimensions)));
+  }
+  return embeddings;
+}

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -4,6 +4,7 @@ import type { Claim } from "./claim.js";
 import type { Edge } from "./edge.js";
 import type { Component, Flow, Source } from "./schema.js";
 import { GraphContextBuilder } from "./graph-context/context-builder.js";
+import { graphContextConfig, type GraphContextConfig } from "./graph-context/config.js";
 import type { EmbeddingStatus, GraphContextResult } from "./graph-context/types.js";
 import { defaultDatabasePath, openDatabase } from "../storage/sqlite/db.js";
 import type { SqliteRepository } from "../storage/sqlite/repository.js";
@@ -50,6 +51,7 @@ export interface ApplyProposalResult {
 export class KnowledgeGraphService {
   constructor(
     private readonly repository: SqliteRepository,
+    private readonly contextConfig: GraphContextConfig = graphContextConfig,
     private readonly contextBuilder = new GraphContextBuilder(repository),
   ) {}
 
@@ -86,6 +88,7 @@ export class KnowledgeGraphService {
   async contextGraph(input: RepoRef, query: string): Promise<GraphContextResult> {
     const initialized = this.ensureInitialized(input);
     return this.contextBuilder.build(initialized.repo_id, this.repository.readGraphView(initialized.repo_id), query, {
+      config: this.contextConfig,
       warnOnCreatedEmbeddings: true,
     });
   }
@@ -114,6 +117,7 @@ export class KnowledgeGraphService {
     const embeddingStatus = await this.contextBuilder.ensureForGraph(
       initialized.repo_id,
       this.repository.readGraphView(initialized.repo_id),
+      this.contextConfig,
     );
 
     return {
@@ -135,6 +139,6 @@ export class KnowledgeGraphService {
   }
 }
 
-export function createLocalKnowledgeGraphService(): KnowledgeGraphService {
-  return new KnowledgeGraphService(new SqliteKnowledgeGraphRepository(openDatabase()));
+export function createLocalKnowledgeGraphService(config: GraphContextConfig = graphContextConfig): KnowledgeGraphService {
+  return new KnowledgeGraphService(new SqliteKnowledgeGraphRepository(openDatabase()), config);
 }

--- a/libs/storage/sqlite/db.ts
+++ b/libs/storage/sqlite/db.ts
@@ -1,12 +1,11 @@
 import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { greplicaHome } from "../../config/greplica-home.js";
 import { migrate } from "./migrate.js";
 
 export function defaultDatabasePath(): string {
-  const home = process.env.GREPLICA_HOME ?? process.env.ENGINEERING_CONTEXT_HOME ?? join(homedir(), ".greplica");
-  return join(home, "graph.db");
+  return join(greplicaHome(), "graph.db");
 }
 
 export function openDatabase(path = defaultDatabasePath()): Database.Database {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "greplica",
       "version": "0.0.0",
       "dependencies": {
+        "@huggingface/transformers": "^4.2.0",
         "better-sqlite3": "^11.9.1"
       },
       "bin": {
@@ -18,6 +19,572 @@
         "@types/node": "^22.15.3",
         "typescript": "^5.8.3"
       }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -33,10 +600,18 @@
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/base64-js": {
@@ -89,6 +664,13 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -144,6 +726,40 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -153,6 +769,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -160,6 +782,42 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/expand-template": {
@@ -177,6 +835,12 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -188,6 +852,69 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -220,6 +947,30 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -266,6 +1017,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -274,6 +1034,55 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -300,6 +1109,30 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pump": {
@@ -341,6 +1174,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -371,6 +1221,71 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/simple-concat": {
@@ -418,6 +1333,12 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -464,6 +1385,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -474,6 +1402,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -494,7 +1434,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "README.md"
   ],
   "dependencies": {
+    "@huggingface/transformers": "^4.2.0",
     "better-sqlite3": "^11.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add a Greplica config file flow with local/OpenAI embedding selection
- add local in-process embeddings via Hugging Face Transformers with MPNet as the default local model and MiniLM as the smaller option
- wire configured embeddings through graph context/proposal apply and update onboarding docs
- add eval overrides for comparing embedding providers/models

## Verification
- npm run typecheck
- npm run build
- GREPLICA_EVAL_EMBEDDING_PROVIDER=local npm run eval:search-current
- greplica init --local smoke test with MPNet default

## Measured defaults
- MPNet cache: ~113M
- fresh init --local: 3.11s
- warm init --local: 0.84s
- local search eval: 80.59 / 100