### PR TITLE
Support folder memory without git remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Greplica (`greplica`) stores lightweight codebase memory for coding agents. The CLI provides small graph-memory primitives; agent workflows are provided as skills.
 
+Greplica normally stores the current Git repository's real remote URL and target root path. If the current directory is not inside a Git repository, Greplica stores memory against that folder path with no remote URL.
+
 ## Requirements
 
 - Node.js and npm.
@@ -12,12 +14,13 @@ Greplica (`greplica`) stores lightweight codebase memory for coding agents. The 
 
 Copy this prompt into the coding agent from the repository you want to use with Greplica:
 
-````txt
+`````txt
 Install Greplica for this repo.
 
 Goal:
 - Install the `greplica` CLI from the Greplica GitHub repo.
 - Install the bundled Greplica skills into this coding agent's user-level skills directory.
+- Add Greplica usage guidance to the project instruction location this coding agent actually reads.
 - Ask me whether to use local or OpenAI embeddings, then initialize Greplica with that choice.
 
 Use this repo unless I provide a different URL or branch:
@@ -26,24 +29,30 @@ Use this repo unless I provide a different URL or branch:
 git@github.com:Autoloops/greplica.git
 ```
 
-Do the install in the way that fits this environment. A typical CLI install flow is:
+Do the install in the way that fits this environment. Prefer a persistent source checkout so future updates do not need a fresh clone:
 
 ```bash
-git clone --depth 1 git@github.com:Autoloops/greplica.git /tmp/greplica
-npm install --prefix /tmp/greplica
-npm run --prefix /tmp/greplica build
-npm install -g /tmp/greplica
+GREPLICA_SRC="${GREPLICA_SRC:-$HOME/.greplica/src/greplica}"
+if [ -d "$GREPLICA_SRC/.git" ]; then
+  git -C "$GREPLICA_SRC" fetch --prune origin
+  git -C "$GREPLICA_SRC" pull --ff-only
+else
+  mkdir -p "$(dirname "$GREPLICA_SRC")"
+  git clone --depth 1 git@github.com:Autoloops/greplica.git "$GREPLICA_SRC"
+fi
+npm install --prefix "$GREPLICA_SRC"
+npm install -g "$GREPLICA_SRC"
 ```
 
-If `/tmp/greplica` already exists, update it or use a fresh temporary clone.
+`npm install --prefix "$GREPLICA_SRC"` runs Greplica's build through the package `prepare` script, so do not run a separate build unless troubleshooting.
 
-If global npm install is not allowed, use the agent's normal npm prefix/tool-install approach and make sure `greplica` is on PATH for future sessions. For an isolated npm prefix, use the equivalent of `npm install -g --prefix <prefix-dir> /tmp/greplica` and add `<prefix-dir>/bin` to PATH.
+If global npm install is not allowed, use the agent's normal npm prefix/tool-install approach and make sure `greplica` is on PATH for future sessions. For an isolated npm prefix, use the equivalent of `npm install -g --prefix <prefix-dir> "$GREPLICA_SRC"` and add `<prefix-dir>/bin` to PATH.
 
 Install these two skill folders from the cloned repo:
 
 ```txt
-/tmp/greplica/skills/greplica-bootstrap
-/tmp/greplica/skills/greplica-update-working-memory
+$GREPLICA_SRC/skills/greplica-bootstrap
+$GREPLICA_SRC/skills/greplica-update-working-memory
 ```
 
 Use the native skill install location for the coding agent:
@@ -60,36 +69,62 @@ greplica-bootstrap
 greplica-update-working-memory
 ```
 
+Update this project's agent instruction location so future coding agents know how to use Greplica. Use the place this project and agent already use for durable agent guidance.
+
+Common examples are `AGENTS.md` for Codex and `CLAUDE.md` for Claude Code, but do not assume either file is correct for every environment. If an instruction file already exists, update that file. If multiple relevant instruction files exist, update each one that future agents in this project are expected to read. If no instruction location is clear, ask me where to save the block before creating a new file.
+
+Add or update this block:
+
+````md
+## Greplica
+
+When `greplica` is available, use it before broad manual exploration:
+
+```bash
+greplica graph context "<natural-language question about the current task>"
+```
+
+Use the returned claims, components, flows, and code anchors to decide which files to inspect next. Treat Greplica as navigation and prior context, not final truth: verify implementation facts against current files and diffs before editing.
+
+For large or unclear tasks, run 2-4 focused `greplica graph context` queries from different angles, such as the feature area, eval/test path, data model, and command/entrypoint. Avoid generic query spam.
+
+Do not run `greplica doctor` as a routine preflight. Run the intended Greplica command directly; use `doctor` only after a command fails and the failure suggests installation, target detection, or embedding-provider diagnosis would help.
+````
+
 Before running Greplica init, ask me whether to use local embeddings or OpenAI embeddings.
 
 Local is the default recommendation: it runs on this laptop without an API key and downloads the local embedding model into `~/.greplica/models`. OpenAI may be faster or higher quality, but requires `OPENAI_API_KEY`.
 
-If I choose local, run:
+If I choose local, use the default local config and initialize memory without pre-downloading the embedding model:
 
 ```bash
-greplica init --local
+greplica graph read >/dev/null
 ```
 
-If I choose OpenAI, verify `OPENAI_API_KEY` is available in the environment, this repo's `.env.local`, or this repo's `.env`, then run:
+Do not run `greplica init --local` during setup unless I explicitly ask to pre-warm local embeddings. `greplica init --local` checks local embeddings and may download the model immediately; otherwise the model downloads on first `greplica graph context` or proposal apply.
+
+If I choose OpenAI, verify `OPENAI_API_KEY` is available in the environment, the target root's `.env.local`, or the target root's `.env`, then run:
 
 ```bash
 greplica init --openai
 ```
 
-If OpenAI is selected and `OPENAI_API_KEY` is missing or invalid, stop and ask me to set it. Do not ask me to paste the key into chat. I can set it either in my shell before starting the coding agent, or in this repo's `.env.local` file:
+If OpenAI is selected and `OPENAI_API_KEY` is missing or invalid, stop and ask me to set it. Do not ask me to paste the key into chat. I can set it either in my shell before starting the coding agent, or in the target root's `.env.local` file:
 
 ```txt
 OPENAI_API_KEY=...
 ```
 
 After setup, tell me:
+- where the Greplica source checkout is
 - where the CLI was installed
 - where the two skills were installed
+- which project instruction file or location was updated
 - which embedding mode was selected
 - where the Greplica config file is
 - whether I need to restart the coding agent for skills to appear
 - how to invoke `greplica-bootstrap` and `greplica-update-working-memory`
-````
+`````
 
 ## Using Greplica
 
@@ -105,7 +140,37 @@ Use greplica-update-working-memory for this session.
 
 Run bootstrap once near the start of using Greplica in a repo. Run update working memory near the end of a coding session when the session contains durable decisions, changed flows, constraints, follow-up work, or useful implementation context.
 
-Do not run `greplica doctor` before normal Greplica commands. Use the intended command directly, such as `greplica graph context "<query>"`; if it fails, use the error message to decide whether `doctor` would help diagnose installation, repo detection, or OpenAI configuration.
+Do not run `greplica doctor` before normal Greplica commands. Use the intended command directly, such as `greplica graph context "<query>"`; if it fails, use the error message to decide whether `doctor` would help diagnose installation, target detection, or embedding-provider configuration.
+
+## Updating Greplica
+
+If Greplica was installed from a persistent source checkout, update it with:
+
+```bash
+GREPLICA_SRC="${GREPLICA_SRC:-$HOME/.greplica/src/greplica}"
+before="$(git -C "$GREPLICA_SRC" rev-parse HEAD)"
+git -C "$GREPLICA_SRC" pull --ff-only --prune
+after="$(git -C "$GREPLICA_SRC" rev-parse HEAD)"
+
+if [ "$before" != "$after" ]; then
+  npm install --prefix "$GREPLICA_SRC"
+  npm install -g "$GREPLICA_SRC"
+fi
+```
+
+If the checkout changed, copy the two skill folders from `$GREPLICA_SRC/skills/` over the installed skill folders again so agent instructions stay current.
+
+Current source-install benchmark on this machine:
+
+- Fresh documented clone/install/build/global-install flow: about 9.7s.
+- Fresh persistent-checkout flow without the redundant explicit build: about 9.0s.
+- Full cold start after deleting `~/.greplica`, with local embedding pre-warm via `greplica init --local`: about 38.9s.
+- Optimized local cold start without pre-warming embeddings: about 7.6s; first graph-context query pays the local model download later.
+- No-op update with unconditional reinstall: about 9.2s.
+- No-op update with the conditional reinstall command above: about 2.9s.
+- Direct `npm install -g git+ssh://...` is not reliable yet because the git dependency prepare step can fail before `tsc` is available.
+
+The better long-term install path is to publish or attach a built package artifact that already contains `dist/`, `skills/`, and `README.md`. Then install/update can become a single `npm install -g <package-or-tarball>` command without cloning the repo or compiling TypeScript during user setup.
 
 ## Configuration
 
@@ -145,7 +210,7 @@ Edit the printed JSON file directly to change the selected embedding provider, m
 
 Allowed `embedding.provider` values are `local` and `openai`.
 
-`greplica init --local` and `greplica init --openai` also update the same config file to provider defaults while initializing repo memory and checking that the selected embedding provider is ready.
+`greplica init --local` and `greplica init --openai` also update the same config file to provider defaults while initializing memory for the current repo or folder and checking that the selected embedding provider is ready.
 
 Local embeddings run in-process with a quantized Hugging Face Transformers model and cache model files under `~/.greplica/models`. The first `greplica init --local` or local embedding check downloads the configured model; subsequent runs reuse the cache.
 
@@ -157,8 +222,8 @@ Useful local model choices:
 `greplica` looks for `OPENAI_API_KEY` in this order:
 
 1. the process environment
-2. `<repo-root>/.env.local`
-3. `<repo-root>/.env`
+2. `<target-root>/.env.local`
+3. `<target-root>/.env`
 
 The key is never printed by `greplica doctor`.
 
@@ -178,7 +243,7 @@ greplica proposal apply <proposal.json>
 
 `greplica graph context "<query>"` prints concise Markdown for coding-agent use. Use `--json` for compact structured output, or `--debug` for the full retrieval payload with ranking signals and embedding status.
 
-`greplica` automatically prepares repo memory state when commands run, so users should not need a separate init step.
+`greplica` automatically prepares memory state when commands run, so users should not need a separate init step.
 
 `greplica doctor` is for install verification and diagnosing failures, not a required preflight before every Greplica command.
 

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -43,7 +43,8 @@ async function main(argv: string[]): Promise<void> {
     const result = service.initRepo(repo);
     console.log(result.created ? "Initialized Greplica memory." : "Greplica memory already initialized.");
     console.log(`Repo: ${repo.repo_name}`);
-    console.log(`Remote: ${repo.remote_url}`);
+    console.log(`Repo root: ${repo.repo_root ?? ""}`);
+    console.log(`Remote: ${repo.remote_url ?? "none"}`);
     console.log(`Default branch: ${repo.default_branch}`);
     console.log(`Database: ${result.database_path}`);
     console.log(`Main scope: ${result.main_scope_id}`);
@@ -163,7 +164,7 @@ async function runDoctor(args: string[]): Promise<void> {
   console.log("Greplica doctor");
   console.log(`Repo: ${context.repo.repo_name}`);
   console.log(`Repo root: ${context.repo.repo_root ?? ""}`);
-  console.log(`Remote: ${context.repo.remote_url}`);
+  console.log(`Remote: ${context.repo.remote_url ?? "none"}`);
   console.log(`Default branch: ${context.repo.default_branch}`);
 
   try {
@@ -186,7 +187,7 @@ async function runDoctor(args: string[]): Promise<void> {
     if (source === undefined) {
       ready = false;
       console.log("OPENAI_API_KEY: missing");
-      console.log("Set OPENAI_API_KEY in the shell, repo-root .env.local, or repo-root .env.");
+      console.log("Set OPENAI_API_KEY in the shell, target-root .env.local, or target-root .env.");
     } else if (source.kind === "environment") {
       console.log("OPENAI_API_KEY: found in environment");
     } else {

--- a/apps/cli/repo-context.ts
+++ b/apps/cli/repo-context.ts
@@ -1,17 +1,38 @@
 import { execFileSync } from "node:child_process";
-import { basename } from "node:path";
+import { realpathSync } from "node:fs";
+import { basename, resolve } from "node:path";
 import type { RepoRef } from "../../libs/knowledge-graph/service.js";
 
 export function detectRepoContext(cwd = process.cwd()): RepoRef {
-  const repoRoot = git(cwd, ["rev-parse", "--show-toplevel"]);
-  const remoteUrl = gitOptional(repoRoot, ["config", "--get", "remote.origin.url"]) ?? `local:${repoRoot}`;
+  const repoRoot = canonicalPath(gitOptional(cwd, ["rev-parse", "--show-toplevel"]));
+  if (repoRoot === undefined) return folderContext(cwd);
+
+  const remoteUrl = gitOptional(repoRoot, ["config", "--get", "remote.origin.url"]);
 
   return {
     repo_root: repoRoot,
     remote_url: remoteUrl,
-    repo_name: repoName(remoteUrl, repoRoot),
+    repo_name: remoteUrl === undefined ? basename(repoRoot) : repoName(remoteUrl, repoRoot),
     default_branch: defaultBranch(repoRoot),
   };
+}
+
+function folderContext(cwd: string): RepoRef {
+  const folderRoot = canonicalPath(cwd) ?? resolve(cwd);
+  return {
+    repo_root: folderRoot,
+    repo_name: basename(folderRoot),
+    default_branch: "main",
+  };
+}
+
+function canonicalPath(path: string | undefined): string | undefined {
+  if (path === undefined) return undefined;
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
 }
 
 function defaultBranch(repoRoot: string): string {
@@ -22,19 +43,18 @@ function defaultBranch(repoRoot: string): string {
 }
 
 function repoName(remoteUrl: string, repoRoot: string): string {
-  if (remoteUrl.startsWith("local:")) return basename(repoRoot);
   const withoutGit = remoteUrl.endsWith(".git") ? remoteUrl.slice(0, -4) : remoteUrl;
   const lastPart = withoutGit.split(/[/:]/).filter(Boolean).at(-1);
   return lastPart ?? basename(repoRoot);
 }
 
-function git(cwd: string, args: string[]): string {
-  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
-}
-
 function gitOptional(cwd: string, args: string[]): string | undefined {
   try {
-    const output = git(cwd, args);
+    const output = execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
     return output.length > 0 ? output : undefined;
   } catch {
     return undefined;

--- a/libs/knowledge-graph/graph-context/openai-embedder.ts
+++ b/libs/knowledge-graph/graph-context/openai-embedder.ts
@@ -16,7 +16,7 @@ export class OpenAIEmbedder {
   constructor(private readonly options: OpenAIEmbedderOptions) {
     const apiKey = (options.apiKey ?? process.env.OPENAI_API_KEY)?.trim();
     if (!apiKey) {
-      throw new Error("OPENAI_API_KEY is required for graph context embeddings. Set it in the environment, repo-root .env.local, or repo-root .env.");
+      throw new Error("OPENAI_API_KEY is required for graph context embeddings. Set it in the environment, target-root .env.local, or target-root .env.");
     }
     this.apiKey = apiKey;
   }

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -14,7 +14,7 @@ export type { GraphContextResult } from "./graph-context/types.js";
 
 export interface RepoRef {
   repo_root?: string;
-  remote_url: string;
+  remote_url?: string;
   repo_name: string;
   default_branch: string;
 }

--- a/libs/storage/sqlite/migrate.ts
+++ b/libs/storage/sqlite/migrate.ts
@@ -3,4 +3,57 @@ import { schemaSql } from "./schema.js";
 
 export function migrate(db: Database.Database): void {
   db.exec(schemaSql);
+  migrateReposTable(db);
+}
+
+function migrateReposTable(db: Database.Database): void {
+  const columns = db.prepare("PRAGMA table_info(repos)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+  const remoteUrl = columns.find((column) => column.name === "remote_url");
+  const hasRootPath = columns.some((column) => column.name === "root_path");
+  if (hasRootPath && remoteUrl?.notnull === 0) return;
+
+  const foreignKeys = db.pragma("foreign_keys", { simple: true }) as number;
+  const legacyAlterTable = db.pragma("legacy_alter_table", { simple: true }) as number;
+  db.pragma("foreign_keys = OFF");
+  db.pragma("legacy_alter_table = ON");
+  try {
+    db.exec(`
+      BEGIN;
+      ALTER TABLE repos RENAME TO repos_old;
+      CREATE TABLE repos (
+        id TEXT PRIMARY KEY,
+        remote_url TEXT UNIQUE,
+        root_path TEXT UNIQUE,
+        repo_name TEXT NOT NULL,
+        default_branch TEXT NOT NULL
+      );
+      INSERT INTO repos (id, remote_url, root_path, repo_name, default_branch)
+      SELECT
+        id,
+        CASE
+          WHEN remote_url LIKE 'folder:%' THEN NULL
+          WHEN remote_url LIKE 'local:%' THEN NULL
+          ELSE remote_url
+        END,
+        CASE
+          WHEN remote_url LIKE 'folder:%' THEN substr(remote_url, 8)
+          WHEN remote_url LIKE 'local:%' THEN substr(remote_url, 7)
+          ELSE NULL
+        END,
+        repo_name,
+        default_branch
+      FROM repos_old;
+      DROP TABLE repos_old;
+      COMMIT;
+    `);
+  } catch (error) {
+    db.exec("ROLLBACK;");
+    throw error;
+  } finally {
+    db.pragma(`legacy_alter_table = ${legacyAlterTable ? "ON" : "OFF"}`);
+    db.pragma(`foreign_keys = ${foreignKeys ? "ON" : "OFF"}`);
+  }
 }

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -9,13 +9,15 @@ import type { GraphScope, GraphScopeKind } from "../../knowledge-graph/scope.js"
 
 export interface RepoRecord {
   id: string;
-  remote_url: string;
+  remote_url: string | null;
+  root_path: string | null;
   repo_name: string;
   default_branch: string;
 }
 
 export interface UpsertRepoInput {
-  remote_url: string;
+  repo_root?: string;
+  remote_url?: string;
   repo_name: string;
   default_branch: string;
 }
@@ -41,6 +43,7 @@ type MembershipRow = {
 };
 
 type EdgeRow = Omit<Edge, "metadata"> & { metadata: string | null };
+type RepoMatch = { repo: RepoRecord; matchedBy: "remote" | "root" };
 
 export type EmbeddingObjectType = "claim" | "component" | "flow";
 
@@ -69,20 +72,21 @@ export class SqliteRepository {
   constructor(private readonly db: Database.Database) {}
 
   upsertRepo(input: UpsertRepoInput): { repo: RepoRecord; created: boolean } {
-    const existing = this.getRepoByRemote(input.remote_url);
-    if (existing) return { repo: existing, created: false };
+    const existing = this.findRepo(input);
+    if (existing) return { repo: this.updateRepo(existing.repo, input, existing.matchedBy), created: false };
 
     const repo: RepoRecord = {
-      id: makeId("repo", input.remote_url),
-      remote_url: input.remote_url,
+      id: makeId("repo", identityKey(input)),
+      remote_url: input.remote_url ?? null,
+      root_path: input.repo_root ?? null,
       repo_name: input.repo_name,
       default_branch: input.default_branch,
     };
 
     this.db
       .prepare(
-        `INSERT INTO repos (id, remote_url, repo_name, default_branch)
-         VALUES (@id, @remote_url, @repo_name, @default_branch)`,
+        `INSERT INTO repos (id, remote_url, root_path, repo_name, default_branch)
+         VALUES (@id, @remote_url, @root_path, @repo_name, @default_branch)`,
       )
       .run(repo);
 
@@ -93,11 +97,54 @@ export class SqliteRepository {
     return this.db.prepare("SELECT * FROM repos WHERE remote_url = ?").get(remoteUrl) as RepoRecord | undefined;
   }
 
+  getRepoByRootPath(rootPath: string): RepoRecord | undefined {
+    return this.db.prepare("SELECT * FROM repos WHERE root_path = ?").get(rootPath) as RepoRecord | undefined;
+  }
+
   requireRepo(remoteUrl: string): RepoRecord {
     const repo = this.getRepoByRemote(remoteUrl);
     if (!repo) {
       throw new Error(`Repo memory is not ready for ${remoteUrl}. Run 'greplica doctor' to diagnose setup.`);
     }
+    return repo;
+  }
+
+  private findRepo(input: UpsertRepoInput): RepoMatch | undefined {
+    if (input.remote_url !== undefined) {
+      const byRemote = this.getRepoByRemote(input.remote_url);
+      if (byRemote !== undefined) return { repo: byRemote, matchedBy: "remote" };
+    }
+    if (input.repo_root !== undefined) {
+      for (const rootPath of rootPathCandidates(input.repo_root)) {
+        const byRootPath = this.getRepoByRootPath(rootPath);
+        if (byRootPath !== undefined) return { repo: byRootPath, matchedBy: "root" };
+      }
+    }
+    return undefined;
+  }
+
+  private updateRepo(existing: RepoRecord, input: UpsertRepoInput, matchedBy: RepoMatch["matchedBy"]): RepoRecord {
+    const shouldUpdateRootPath =
+      matchedBy === "root" || existing.root_path === null || existing.root_path === input.repo_root;
+    const repo: RepoRecord = {
+      id: existing.id,
+      remote_url: input.remote_url ?? existing.remote_url,
+      root_path: shouldUpdateRootPath ? (input.repo_root ?? existing.root_path) : existing.root_path,
+      repo_name: input.repo_name,
+      default_branch: input.default_branch,
+    };
+
+    this.db
+      .prepare(
+        `UPDATE repos
+         SET remote_url = @remote_url,
+             root_path = @root_path,
+             repo_name = @repo_name,
+             default_branch = @default_branch
+         WHERE id = @id`,
+      )
+      .run(repo);
+
     return repo;
   }
 
@@ -382,6 +429,19 @@ function tableForType(type: GraphObjectType): string {
 function makeId(prefix: string, value: string): string {
   const hash = createHash("sha1").update(value).digest("hex").slice(0, 16);
   return `${prefix}_${hash}`;
+}
+
+function identityKey(input: UpsertRepoInput): string {
+  if (input.remote_url !== undefined) return input.remote_url;
+  if (input.repo_root !== undefined) return `root:${input.repo_root}`;
+  throw new Error("Repo memory needs either a remote URL or a root path.");
+}
+
+function rootPathCandidates(rootPath: string): string[] {
+  const candidates = [rootPath];
+  if (rootPath.startsWith("/private/var/")) candidates.push(rootPath.slice("/private".length));
+  if (rootPath.startsWith("/var/")) candidates.push(`/private${rootPath}`);
+  return candidates;
 }
 
 function now(): string {

--- a/libs/storage/sqlite/schema.ts
+++ b/libs/storage/sqlite/schema.ts
@@ -1,7 +1,8 @@
 export const schemaSql = `
 CREATE TABLE IF NOT EXISTS repos (
   id TEXT PRIMARY KEY,
-  remote_url TEXT NOT NULL UNIQUE,
+  remote_url TEXT UNIQUE,
+  root_path TEXT UNIQUE,
   repo_name TEXT NOT NULL,
   default_branch TEXT NOT NULL
 );

--- a/skills/greplica-bootstrap/SKILL.md
+++ b/skills/greplica-bootstrap/SKILL.md
@@ -1,24 +1,24 @@
 ---
 name: greplica-bootstrap
-description: Bootstrap Greplica memory for the current repository. Use only when the user explicitly invokes greplica-bootstrap or asks to create initial engineering memory for a repo with the greplica CLI.
+description: Bootstrap Greplica memory for the current repository or folder. Use only when the user explicitly invokes greplica-bootstrap or asks to create initial engineering memory with the greplica CLI.
 disable-model-invocation: true
 ---
 
 # Bootstrap Greplica Memory
 
-Create shallow, high-signal Greplica memory for the current repository.
+Create shallow, high-signal Greplica memory for the current repository or folder.
 
 ## Preconditions
 
-Run from the target repository root or any subdirectory inside it.
+Run from the target repository root, a subdirectory inside it, or a non-Git folder that should have its own memory.
 
-Do not run `greplica doctor` as a routine preflight. Run the needed Greplica commands directly; if one fails, use the error to decide whether `greplica doctor` would help diagnose installation, repo detection, or OpenAI configuration.
+Do not run `greplica doctor` as a routine preflight. Run the needed Greplica commands directly; if one fails, use the error to decide whether `greplica doctor` would help diagnose installation, target detection, or embedding-provider configuration.
 
 If `greplica` is missing, tell the user to run the Greplica setup prompt from the README.
 
-If a Greplica command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in repo-root `.env.local`.
+Local embeddings are the default and do not require `OPENAI_API_KEY`. If Greplica is configured for OpenAI and a command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in target-root `.env.local`.
 
-`greplica` automatically prepares repo memory state; do not ask the user to run a separate initialization command.
+`greplica` automatically prepares memory state; do not ask the user to run a separate initialization command.
 
 ## Inspect The Repo Shallowly
 
@@ -102,7 +102,7 @@ Sources currently represent session artifacts. Do not create a source just becau
 - Prefer roughly 4-10 major components for a small repo.
 - Include major flows that help future agents decide where to look.
 - Include claims that capture why the main modules matter, not just which commands exist.
-- Capture boundary facts such as thin CLI wrappers, service boundaries, git-based repo detection, global source storage, and shallow bootstrap guidance when the inspected code or skill files support them.
+- Capture boundary facts such as thin CLI wrappers, service boundaries, target detection, global source storage, and shallow bootstrap guidance when the inspected code or skill files support them.
 - Use `code_verified` only for claims grounded in inspected code.
 - Use `unknown` truth for unverified questions, risks, or tasks.
 - Add open questions/tasks for important areas that need deeper inspection.

--- a/skills/greplica-update-working-memory/SKILL.md
+++ b/skills/greplica-update-working-memory/SKILL.md
@@ -10,15 +10,15 @@ Update working memory with durable information learned during this coding sessio
 
 ## Preconditions
 
-Run from the target repository root or any subdirectory inside it.
+Run from the target repository root, a subdirectory inside it, or a non-Git folder that should have its own memory.
 
-Do not run `greplica doctor` as a routine preflight. Run the needed Greplica commands directly; if one fails, use the error to decide whether `greplica doctor` would help diagnose installation, repo detection, or OpenAI configuration.
+Do not run `greplica doctor` as a routine preflight. Run the needed Greplica commands directly; if one fails, use the error to decide whether `greplica doctor` would help diagnose installation, target detection, or embedding-provider configuration.
 
 If `greplica` is missing, tell the user to run the Greplica setup prompt from the README.
 
-If a Greplica command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in repo-root `.env.local`.
+Local embeddings are the default and do not require `OPENAI_API_KEY`. If Greplica is configured for OpenAI and a command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in target-root `.env.local`.
 
-`greplica` automatically prepares repo memory state; do not ask the user to run a separate initialization command.
+`greplica` automatically prepares memory state; do not ask the user to run a separate initialization command.
 
 ## Gather Evidence
 


### PR DESCRIPTION
## Summary
- detect non-git working folders as memory targets without synthetic remote URLs
- add root_path-backed repo identity and migration support for legacy folder/local remotes
- update README and Greplica skills for folder targets, local embeddings, and flexible agent instruction locations

## Tests
- npm run typecheck
- npm run build