### PR TITLE
Add OpenCode install platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Claude Code:
 greplica install --platform claude --embedding local
 ```
 
+OpenCode:
+```bash
+greplica install --platform opencode --embedding local
+```
+
 Do not manually copy skills. Let the installer do it.
 
 After installation, tell me where the skills were installed, which embedding mode was configured, whether I should restart the agent, and how to switch later to OpenAI embeddings if I want that.
@@ -61,7 +66,7 @@ Then tell me how to use Greplica:
 - If this repo has not been initialized yet, tell me to run "Use greplica-bootstrap for this repo." once. If repo memory already exists, do not run it again.
 - Tell me that during work, the agent can use `greplica graph context "<question>"` to fetch relevant repo context, including prior working memory, before broad manual exploration.
 - Tell me that near the end of a useful session, I should run "Use greplica-update-working-memory for this session." so decisions, changed flows, constraints, and follow-up work are stored.
-- Tell me that OpenAI embeddings are also available later by rerunning `greplica install --platform <codex-or-claude> --embedding openai`.
+- Tell me that OpenAI embeddings are also available later by rerunning `greplica install --platform <codex-or-claude-or-opencode> --embedding openai`.
 - IMPORTANT: tell me to add the Greplica guidance block manually to AGENTS.md or CLAUDE.md if I want the agent to keep using Greplica automatically.
 `````
 
@@ -94,6 +99,12 @@ Claude Code:
 
 ```bash
 greplica install --platform claude --embedding local
+```
+
+OpenCode:
+
+```bash
+greplica install --platform opencode --embedding local
 ```
 
 </details>
@@ -154,14 +165,14 @@ Broader context-retrieval benchmarking, including SWE-Context benchmark work, is
 
 ## Roadmap
 
-- Codex and Claude Code plugins so Greplica can be installed and used as a first-class agent integration.
+- Codex, Claude Code, and OpenCode plugins so Greplica can be installed and used as a first-class agent integration.
 - Review UX for memory updates before the agent applies them.
 - SWE-Context benchmark coverage and sharper retrieval evals for real coding tasks.
 
 ## Commands
 
 ```bash
-greplica install --platform codex|claude --embedding local|openai
+greplica install --platform codex|claude|opencode --embedding local|openai
 greplica init [--local|--openai]
 greplica config
 greplica doctor [--check-embeddings]

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -16,7 +16,7 @@ import { graphContextConfigFromGreplicaConfig } from "../../libs/knowledge-graph
 import { createEmbedder } from "../../libs/knowledge-graph/graph-context/embedder.js";
 import { compactGraphContextResult, renderGraphContextMarkdown } from "../../libs/knowledge-graph/graph-context/render.js";
 import { buildGraphFolderExport } from "../../libs/knowledge-graph/folder-export.js";
-import { installGreplica } from "../../libs/install/install.js";
+import { installGreplica, platformDisplayName } from "../../libs/install/install.js";
 import type { InstallEmbedding, InstallPlatform } from "../../libs/install/paths.js";
 import { detectRepoContext } from "./repo-context.js";
 
@@ -302,7 +302,7 @@ function requireFlagValue(args: string[], index: number, flag: string): string {
 }
 
 function parseInstallPlatform(value: string): InstallPlatform {
-  if (value === "codex" || value === "claude") return value;
+  if (value === "codex" || value === "claude" || value === "opencode") return value;
   throw new Error(`Invalid --platform ${value}.\n${installUsage()}`);
 }
 
@@ -312,7 +312,7 @@ function parseInstallEmbedding(value: string): InstallEmbedding {
 }
 
 function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>): void {
-  console.log(`Installed Greplica for ${result.platform === "codex" ? "Codex" : "Claude Code"}.`);
+  console.log(`Installed Greplica for ${platformDisplayName(result.platform)}.`);
   console.log("");
   console.log("Skills:");
   for (const skill of result.skills) console.log(`- ${skill}`);
@@ -332,12 +332,16 @@ function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>)
     console.log(`- Local embeddings are also available if you want to switch back later: greplica install --platform ${result.platform} --embedding local`);
   }
   for (const note of result.notes) console.log(`- ${note}`);
-  console.log(`- IMPORTANT: add the Greplica guidance block to ${result.platform === "codex" ? "AGENTS.md" : "CLAUDE.md"} yourself if you want the agent to keep using Greplica automatically.`);
+  console.log(`- IMPORTANT: add the Greplica guidance block to ${platformGuidanceFile(result.platform)} yourself if you want the agent to keep using Greplica automatically.`);
+}
+
+function platformGuidanceFile(platform: InstallPlatform): string {
+  return platform === "claude" ? "CLAUDE.md" : "AGENTS.md";
 }
 
 function installUsage(): string {
   const cli = basename(process.argv[1] ?? "greplica");
-  return `Usage: ${cli} install --platform codex|claude --embedding local|openai`;
+  return `Usage: ${cli} install --platform codex|claude|opencode --embedding local|openai`;
 }
 
 function printEmbeddingConfig(config: EmbeddingConfig): void {
@@ -402,7 +406,7 @@ function field(item: object, key: string): string {
 function printHelp(): void {
   const cli = basename(process.argv[1] ?? "greplica");
   console.log(`Usage:
-  ${cli} install --platform codex|claude --embedding local|openai
+  ${cli} install --platform codex|claude|opencode --embedding local|openai
   ${cli} init [--local|--openai]
   ${cli} config
   ${cli} doctor [--check-embeddings]

--- a/libs/install/install.ts
+++ b/libs/install/install.ts
@@ -39,11 +39,7 @@ export async function installGreplica(options: InstallOptions): Promise<InstallR
   if (options.embedding === "local") {
     notes.push("Local embeddings were configured without prewarming; the first graph-context query may download the local model.");
   }
-  if (options.platform === "codex") {
-    notes.push("Restart Codex if the new skills do not appear immediately.");
-  } else {
-    notes.push("Restart Claude Code if the new skills do not appear immediately.");
-  }
+  notes.push(`Restart ${platformDisplayName(options.platform)} if the new skills do not appear immediately.`);
 
   return {
     platform: options.platform,
@@ -53,6 +49,12 @@ export async function installGreplica(options: InstallOptions): Promise<InstallR
     databasePath: init.database_path,
     notes,
   };
+}
+
+export function platformDisplayName(platform: InstallPlatform): string {
+  if (platform === "codex") return "Codex";
+  if (platform === "opencode") return "OpenCode";
+  return "Claude Code";
 }
 
 function installSkills(skillsRoot: string): string[] {

--- a/libs/install/paths.ts
+++ b/libs/install/paths.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type InstallPlatform = "codex" | "claude";
+export type InstallPlatform = "codex" | "claude" | "opencode";
 export type InstallEmbedding = "local" | "openai";
 
 export const skillNames = ["greplica-bootstrap", "greplica-update-working-memory"] as const;
@@ -27,6 +27,13 @@ export function platformPaths(platform: InstallPlatform): PlatformPaths {
     const codexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
     return {
       skillsRoot: join(codexHome, "skills"),
+    };
+  }
+
+  if (platform === "opencode") {
+    const configHome = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+    return {
+      skillsRoot: join(configHome, "opencode", "skills"),
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `opencode` as a third `greplica install --platform` target alongside Codex and Claude Code
- Deploy bundled skills to `~/.config/opencode/skills/` (or `$XDG_CONFIG_HOME/opencode/skills/`)
- OpenCode uses `AGENTS.md` for persistent guidance, same as Codex

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Sandboxed `greplica install --platform opencode --embedding local` deploys both skills
- [x] Codex and Claude Code install regressions pass
- [x] Invalid `--platform foo` rejected with updated usage
- [ ] OpenCode E2E skill discovery (not tested — `opencode` not on PATH locally; worth verifying after merge)


Made with [Cursor](https://cursor.com)