### PR TITLE
Add OpenCode plugin support and tests

### DIFF
--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -292,12 +292,12 @@ function parseHookIngestPlatform(args: string[]): InstallPlatform {
     if (arg === "--platform") return parseHookPlatform(args[index + 1]);
     if (arg.startsWith("--platform=")) return parseHookPlatform(arg.slice("--platform=".length));
   }
-  throw new Error("Usage: greplica hook ingest --platform codex|claude");
+  throw new Error("Usage: greplica hook ingest --platform <supported-platform>");
 }
 
 function parseHookPlatform(value: string | undefined): InstallPlatform {
-  if (value === "codex" || value === "claude") return value;
-  throw new Error("Usage: greplica hook ingest --platform codex|claude");
+  if (value === "codex" || value === "claude" || value === "opencode") return value;
+  throw new Error("Usage: greplica hook ingest --platform <supported-platform>");
 }
 
 async function runDoctor(args: string[]): Promise<void> {
@@ -490,7 +490,7 @@ function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>)
 
 function installUsage(): string {
   const cli = basename(process.argv[1] ?? "greplica");
-  return `Usage: ${cli} install --platform codex|claude|opencode --embedding local|openai`;
+  return `Usage: ${cli} install --platform <platform> --embedding local|openai`;
 }
 
 function printEmbeddingConfig(config: EmbeddingConfig): void {
@@ -637,7 +637,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function printHelp(): void {
   const cli = basename(process.argv[1] ?? "greplica");
   console.log(`Usage:
-  ${cli} install --platform codex|claude|opencode --embedding local|openai
+  ${cli} install --platform <platform> --embedding local|openai
+  ${cli} init [--local|--openai]
   ${cli} config
   ${cli} doctor [--check-embeddings]
   ${cli} graph read

--- a/libs/install/platforms/opencode.ts
+++ b/libs/install/platforms/opencode.ts
@@ -1,26 +1,225 @@
+import { spawn } from "node:child_process";
+import { createWriteStream, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { hookCommand } from "../hook-config.js";
 import { copyBundledSkills } from "../skills.js";
+import {
+  copyStringField,
+  isRecord,
+  parseJsonLine,
+  renderSessionTranscriptMarkdown,
+  sanitizeTranscriptMessage,
+  type SessionTranscriptMessage,
+} from "../../session-transcript/markdown.js";
 import type { PlatformInstallResult, PlatformInstaller, WorkingMemoryUpdateInput } from "./types.js";
 
 export const opencodeInstaller: PlatformInstaller = {
   platform: "opencode",
   install(): PlatformInstallResult {
     const configHome = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+    const pluginPath = join(configHome, "opencode", "plugins", "greplica.js");
+    mkdirSync(dirname(pluginPath), { recursive: true });
+    writeFileSync(pluginPath, opencodePluginSource(hookCommand("opencode")), "utf8");
+
     return {
       skills: copyBundledSkills(join(configHome, "opencode", "skills")),
+      hooks: {
+        platform: "opencode",
+        configFiles: [pluginPath],
+        events: ["session.updated", "session.idle"],
+        command: pluginPath,
+      },
     };
   },
-  sessionSourceRef(_sessionId: string): string {
-    throw new Error("OpenCode session source refs are not supported yet.");
+  sessionSourceRef(sessionId: string): string {
+    return `opencode-session:${sessionId}`;
   },
-  sessionIdFromSourceRef(_ref: string): string | undefined {
-    return undefined;
+  sessionIdFromSourceRef(ref: string): string | undefined {
+    return ref.startsWith("opencode-session:") ? ref.slice("opencode-session:".length) : undefined;
   },
-  transcriptToMarkdown(_transcript: string): string {
-    throw new Error("OpenCode transcript projection is not supported yet.");
+  transcriptToMarkdown(transcript: string): string {
+    return opencodeTranscriptToMarkdown(transcript);
   },
-  async runWorkingMemoryUpdate(_input: WorkingMemoryUpdateInput): Promise<void> {
-    throw new Error("OpenCode background working-memory updates are not supported yet.");
+  async runWorkingMemoryUpdate(input: WorkingMemoryUpdateInput): Promise<void> {
+    await runOpenCode(input);
   },
 };
+
+function opencodeTranscriptToMarkdown(transcript: string): string {
+  const metadata: Record<string, string> = {};
+  const messages: SessionTranscriptMessage[] = [];
+
+  for (const event of parseTranscriptEvents(transcript)) {
+    copyStringField(metadata, event, "sessionID", "session_id");
+    copyStringField(metadata, event, "sessionId", "session_id");
+    copyStringField(metadata, event, "session_id", "session_id");
+    copyStringField(metadata, event, "id", "session_id");
+    copyStringField(metadata, event, "cwd", "cwd");
+    copyStringField(metadata, event, "directory", "cwd");
+
+    const message = messageFromEvent(event);
+    if (message !== undefined) messages.push(message);
+  }
+
+  return renderSessionTranscriptMarkdown({ metadata, messages });
+}
+
+function parseTranscriptEvents(transcript: string): Record<string, unknown>[] {
+  const trimmed = transcript.trim();
+  if (trimmed.length === 0) return [];
+
+  const parsedJson = parseJsonLine(trimmed);
+  if (Array.isArray(parsedJson)) return parsedJson.filter(isRecord);
+  if (isRecord(parsedJson)) return [parsedJson];
+
+  return transcript
+    .split("\n")
+    .map(parseJsonLine)
+    .filter(isRecord);
+}
+
+function messageFromEvent(event: Record<string, unknown>): SessionTranscriptMessage | undefined {
+  const source = isRecord(event.message) ? event.message : event;
+  const role = roleFromValue(source.role ?? event.role ?? event.type);
+  if (role === undefined) return undefined;
+
+  const message = extractText(source.content ?? source.text ?? source.message ?? event.content ?? event.text);
+  const sanitizedMessage = sanitizeTranscriptMessage(message);
+  if (sanitizedMessage.length === 0) return undefined;
+
+  return {
+    timestamp: stringValue(event.time ?? event.timestamp ?? source.time ?? source.timestamp),
+    role,
+    phase: stringValue(event.type),
+    message: sanitizedMessage,
+  };
+}
+
+function roleFromValue(value: unknown): SessionTranscriptMessage["role"] | undefined {
+  if (value === "user" || value === "human") return "human";
+  if (value === "assistant" || value === "agent") return "agent";
+  return undefined;
+}
+
+function extractText(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (!Array.isArray(value)) return "";
+
+  const parts: string[] = [];
+  for (const item of value) {
+    if (typeof item === "string") {
+      parts.push(item);
+    } else if (isRecord(item) && typeof item.text === "string") {
+      parts.push(item.text);
+    }
+  }
+  return parts.join("\n\n").trim();
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function runOpenCode(input: WorkingMemoryUpdateInput): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transcript = createWriteStream(input.transcriptPath, { flags: "w" });
+    const child = spawn("opencode", ["run", input.prompt], {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+
+    child.once("error", (error) => {
+      transcript.end();
+      reject(error);
+    });
+    child.stdout.pipe(transcript);
+    child.once("close", (exitCode, signal) => {
+      transcript.end();
+      writeFileSync(
+        input.finalMessagePath,
+        `OpenCode update runner exited with code ${exitCode ?? "null"} and signal ${signal ?? "null"}.\n`,
+        "utf8",
+      );
+      resolve();
+    });
+  });
+}
+
+function opencodePluginSource(command: string): string {
+  return `import { spawn } from "node:child_process";
+
+export const GreplicaPlugin = async ({ directory }) => {
+  return {
+    event: async ({ event }) => {
+      if (process.env.GREPLICA_HOOK_DISABLE === "1") return;
+      if (!event || typeof event.type !== "string") return;
+
+      const hookEventName = hookEventNameFor(event.type);
+      if (hookEventName === undefined) return;
+
+      const payload = {
+        hook_event_name: hookEventName,
+        session_id: sessionIdFromEvent(event),
+        cwd: cwdFromEvent(event, directory),
+        transcript_path: transcriptPathFromEvent(event),
+      };
+
+      await runHook(${JSON.stringify(command)}, payload);
+    },
+  };
+};
+
+function hookEventNameFor(type) {
+  if (type === "session.updated") return "UserPromptSubmit";
+  if (type === "session.idle") return "Stop";
+  return undefined;
+}
+
+function sessionIdFromEvent(event) {
+  return stringValue(event.sessionID)
+    ?? stringValue(event.sessionId)
+    ?? stringValue(event.session_id)
+    ?? stringValue(event.session?.id)
+    ?? stringValue(event.properties?.sessionID)
+    ?? stringValue(event.properties?.sessionId)
+    ?? stringValue(event.properties?.session_id);
+}
+
+function transcriptPathFromEvent(event) {
+  return stringValue(event.transcript_path)
+    ?? stringValue(event.transcriptPath)
+    ?? stringValue(event.session?.transcript_path)
+    ?? stringValue(event.session?.transcriptPath)
+    ?? stringValue(event.properties?.transcript_path)
+    ?? stringValue(event.properties?.transcriptPath);
+}
+
+function cwdFromEvent(event, directory) {
+  return stringValue(event.cwd)
+    ?? stringValue(event.directory)
+    ?? stringValue(event.properties?.cwd)
+    ?? stringValue(event.properties?.directory)
+    ?? directory;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function runHook(command, payload) {
+  return new Promise((resolve) => {
+    const child = spawn(command, {
+      shell: true,
+      stdio: ["pipe", "ignore", "ignore"],
+      env: process.env,
+    });
+
+    child.once("error", () => resolve());
+    child.once("close", () => resolve());
+    child.stdin.end(JSON.stringify(payload));
+  });
+}
+`;
+}

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -101,7 +101,7 @@ export class KnowledgeGraphService {
   }
 
   buildGraphView(input: RepoRef): string {
-    const initialized = this.ensureInitialized(input);
+    const initialized = this.requireRepo(input);
     const graph = this.repository.readGraphView(initialized.repo_id);
     const provenance = this.repository.readClaimProvenance(initialized.repo_id);
     const supersededClaims = this.repository.readSupersededClaims(initialized.repo_id);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preinstall": "node scripts/check-node-version.js",
     "build": "tsc -p tsconfig.build.json",
     "prepare": "npm run build",
+    "test": "npm run build && node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",
     "eval:coding-proposal-apply-atomicity": "npm run build && node dist/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/run.js",

--- a/tests/opencode-platform.test.mjs
+++ b/tests/opencode-platform.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { opencodeInstaller } from "../dist/libs/install/platforms/opencode.js";
+
+test("maps OpenCode session refs to stable source refs", () => {
+  assert.equal(opencodeInstaller.sessionSourceRef("session-123"), "opencode-session:session-123");
+  assert.equal(opencodeInstaller.sessionIdFromSourceRef("opencode-session:session-123"), "session-123");
+  assert.equal(opencodeInstaller.sessionIdFromSourceRef("other:session-123"), undefined);
+});
+
+test("projects simple OpenCode JSONL transcripts to filtered markdown", () => {
+  const markdown = opencodeInstaller.transcriptToMarkdown(
+    [
+      JSON.stringify({
+        sessionID: "session-123",
+        directory: "/repo",
+        type: "message.updated",
+        role: "user",
+        content: "Please inspect the storage flow.",
+      }),
+      JSON.stringify({
+        type: "message.updated",
+        role: "assistant",
+        content: [{ text: "The storage flow writes graph records." }],
+      }),
+    ].join("\n"),
+  );
+
+  assert.match(markdown, /session_id: session-123/);
+  assert.match(markdown, /cwd: \/repo/);
+  assert.match(markdown, /Please inspect the storage flow/);
+  assert.match(markdown, /The storage flow writes graph records/);
+});


### PR DESCRIPTION
## Summary
- add OpenCode plugin-based install support that forwards session events into Greplica hook ingestion
- add OpenCode session source refs, transcript projection, and background working-memory update runner support
- add a normal `npm test` script with coverage for OpenCode helpers, proposal validation, and SQLite-backed storage behavior
- fix SQLite inserts for optional `code_anchor` and `title` fields by normalizing omitted values to `null`
- make user-facing platform usage text generic with `<platform>`

## Why
OpenCode was accepted as an install target, but its session refs, transcript projection, and background working-memory update paths were placeholders. This fills in that path using OpenCode's plugin model and adds focused tests around the graph/storage behaviors touched along the way.

## Validation
- `npm test`
- `npm run typecheck`
- `git diff --check`

Maintainer edits should be enabled for this fork PR.
