### PR TITLE
Improve Greplica memory skill evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ Broader context-retrieval benchmarking, including SWE-Context benchmark work, is
 
 ```bash
 greplica install --platform codex|claude|opencode --embedding local|openai
-greplica init [--local|--openai]
 greplica config
 greplica doctor [--check-embeddings]
 greplica graph read
@@ -147,6 +146,6 @@ greplica proposal apply <proposal.json>
 
 `greplica graph context "<query>"` prints concise Markdown for coding-agent use. Use `--json` for compact structured output, or `--debug` for the full retrieval payload with ranking signals and embedding status.
 
-`greplica` automatically prepares memory state when commands run, so users should not need a separate init step.
+Run `greplica install` from each repo or folder where Greplica should work. Other commands require that repo to have been installed first.
 
 `greplica doctor` is for install verification and diagnosing failures, not a required preflight before every Greplica command.

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -8,9 +8,7 @@ import { envVarSource, loadRepoEnv, type LoadedRepoEnv } from "../../libs/env/lo
 import {
   ensureGreplicaConfig,
   greplicaConfigPath,
-  updateEmbeddingConfig,
   type EmbeddingConfig,
-  type EmbeddingProvider,
   type GreplicaConfig,
 } from "../../libs/config/greplica-config.js";
 import { graphContextConfigFromGreplicaConfig } from "../../libs/knowledge-graph/graph-context/config.js";
@@ -59,33 +57,6 @@ async function main(argv: string[]): Promise<void> {
 
   if (area === "session" && action === "mark-memory-current") {
     runSessionMarkMemoryCurrent(rest);
-    return;
-  }
-
-  if (area === "init") {
-    const initArgs = [action, ...rest].filter((arg): arg is string => arg !== undefined);
-    const provider = parseOptionalEmbeddingSelection(initArgs);
-    let configuredEmbedding: EmbeddingConfig | undefined;
-    if (provider !== undefined) {
-      const config = updateEmbeddingConfig({ provider });
-      configuredEmbedding = config.embedding;
-      console.log(`Config: ${displayConfigPath()}`);
-      printEmbeddingConfig(config.embedding);
-    }
-
-    const { repo, service } = createCommandContext();
-    const result = service.initRepo(repo);
-    console.log(result.created ? "Initialized Greplica memory." : "Greplica memory already initialized.");
-    console.log(`Repo: ${repo.repo_name}`);
-    console.log(`Repo root: ${repo.repo_root ?? ""}`);
-    console.log(`Remote: ${repo.remote_url ?? "none"}`);
-    console.log(`Default branch: ${repo.default_branch}`);
-    console.log(`Database: ${result.database_path}`);
-    console.log(`Main scope: ${result.main_scope_id}`);
-    console.log(`Working scope: ${result.working_scope_id}`);
-    if (configuredEmbedding !== undefined) {
-      if (!(await checkEmbeddings(configuredEmbedding))) process.exitCode = 1;
-    }
     return;
   }
 
@@ -155,7 +126,7 @@ async function main(argv: string[]): Promise<void> {
   if (area === "proposal" && action === "apply") {
     const file = requireFile(rest[0], "Usage: greplica proposal apply <file>");
     const { repo, service } = createCommandContext();
-    const init = service.initRepo(repo);
+    const installed = service.requireRepo(repo);
     const proposal = readProposal(file);
     const result = await service.applyProposal(repo, proposal);
     console.log("Applied proposal to working memory.");
@@ -169,7 +140,7 @@ async function main(argv: string[]): Promise<void> {
     console.log(`Embeddings checked: ${result.embedding_status.checked_objects}`);
     console.log(`Embeddings created: ${result.embedding_status.created}`);
     console.log(`Embeddings reused: ${result.embedding_status.reused}`);
-    markProposalApplyMemoryUpdated(init.repo_id, proposal);
+    markProposalApplyMemoryUpdated(installed.repo_id, proposal);
     return;
   }
 
@@ -198,11 +169,16 @@ function runHookIngest(args: string[]): void {
   try {
     const repository = new SqliteKnowledgeGraphRepository(db);
     const service = new KnowledgeGraphService(repository);
-    const init = service.initRepo(repo);
+    let installed: ReturnType<KnowledgeGraphService["requireRepo"]>;
+    try {
+      installed = service.requireRepo(repo);
+    } catch {
+      return;
+    }
     const sessionStore = new HookSessionStore(db);
     const result = sessionStore.recordHook({
       platform,
-      repoId: init.repo_id,
+      repoId: installed.repo_id,
       sessionId: hookSessionId(hook),
       transcriptPath: hookTranscriptPath(hook),
       cwd,
@@ -231,10 +207,10 @@ const greplicaContextMarker = "Greplica hook guidance";
 function runSessionMarkMemoryCurrent(args: string[]): void {
   const sessionRef = parseRequiredOption(args, "--session-ref", "Usage: greplica session mark-memory-current --session-ref <ref>");
   const { repo, service } = createCommandContext();
-  const init = service.initRepo(repo);
+  const installed = service.requireRepo(repo);
   const db = openDatabase();
   try {
-    const marked = markMemoryCurrentFromSessionRef(new HookSessionStore(db), init.repo_id, sessionRef);
+    const marked = markMemoryCurrentFromSessionRef(new HookSessionStore(db), installed.repo_id, sessionRef);
     if (marked) {
       console.log("Marked session memory current.");
       return;
@@ -319,15 +295,16 @@ async function runDoctor(args: string[]): Promise<void> {
   console.log(`Default branch: ${context.repo.default_branch}`);
 
   try {
-    const result = context.service.initRepo(context.repo);
+    const result = context.service.requireRepo(context.repo);
     console.log(`Database: ${result.database_path}`);
-    console.log(`Memory state: ${result.created ? "initialized" : "ready"}`);
+    console.log("Memory state: ready");
     console.log(`Main scope: ${result.main_scope_id}`);
     console.log(`Working scope: ${result.working_scope_id}`);
   } catch (error: unknown) {
     ready = false;
-    console.log("Memory state: failed");
-    console.log(error instanceof Error ? error.message : String(error));
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(message.startsWith("Greplica is not installed") ? "Memory state: not installed" : "Memory state: failed");
+    console.log(message);
   }
 
   console.log(`Config: ${displayConfigPath()}`);
@@ -392,18 +369,6 @@ function runConfigCommand(args: string[]): void {
   console.log("- local MPNet base: provider=local, model=all-mpnet-base-v2, dimensions=768, batchSize=16");
   console.log("- local MiniLM: provider=local, model=all-MiniLM-L6-v2, dimensions=384, batchSize=32");
   console.log("- OpenAI small: provider=openai, model=text-embedding-3-small, dimensions=1536, batchSize=100");
-}
-
-function parseOptionalEmbeddingSelection(args: string[]): EmbeddingProvider | undefined {
-  const local = args.includes("--local");
-  const openai = args.includes("--openai");
-  if (local && openai) throw new Error("Use either --local or --openai, not both.");
-  if (!local && !openai) {
-    if (args.length === 0) return undefined;
-    throw new Error("Usage: greplica init [--local|--openai]");
-  }
-  if (args.length !== 1) throw new Error("Usage: greplica init [--local|--openai]");
-  return local ? "local" : "openai";
 }
 
 function parseInstallArgs(args: string[]): { platform: InstallPlatform; embedding: InstallEmbedding } {
@@ -482,7 +447,8 @@ function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>)
   console.log("Next steps:");
   console.log("- Restart your coding agent if the new skills or hooks do not appear immediately.");
   if (result.hooks !== undefined) {
-    console.log("- Accept or trust the installed hooks if your agent asks. Hooks record session activity and attempt background working-memory updates.");
+    console.log("- Accept or trust the installed hooks if your agent asks. Hook dispatchers ignore repos where greplica install was not run.");
+    console.log("- Hooks record session activity and attempt background working-memory updates for this repo.");
     console.log("- If you do not accept the hooks, background saves will not run; manually ask the agent to use greplica-update-working-memory near the end of useful sessions.");
   } else {
     console.log("- Hooks were not installed for this platform. Manually ask the agent to use greplica-update-working-memory near the end of useful sessions.");
@@ -585,7 +551,6 @@ function printHelp(): void {
   const cli = basename(process.argv[1] ?? "greplica");
   console.log(`Usage:
   ${cli} install --platform codex|claude|opencode --embedding local|openai
-  ${cli} init [--local|--openai]
   ${cli} config
   ${cli} doctor [--check-embeddings]
   ${cli} graph read

--- a/evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/rubric.json
+++ b/evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/rubric.json
@@ -1,0 +1,254 @@
+{
+  "case_id": "curated-doc-bootstrap-vercel-chat-at-f3de128",
+  "target_repo_url": "https://github.com/vercel/chat.git",
+  "target_commit": "f3de12823cae746b34b2641ce9ea0798914370b6",
+  "score": {
+    "pass_threshold": 82,
+    "node_coverage_points": 55,
+    "edge_coverage_points": 15,
+    "quality_points": 30,
+    "quality_penalties": {
+      "noisy_structure_node_points": 3,
+      "noisy_structure_node_max": 12,
+        "bad_claim_points": 3,
+        "bad_claim_max": 12,
+      "bad_anchor_points": 3,
+      "bad_anchor_max": 9,
+      "depth_violation_points": 10,
+      "weak_graph_linking_points": 8
+    }
+  },
+  "judge": {
+    "instructions": [
+      "Judge whether the proposal is a good Greplica bootstrap memory graph for curated documentation ingestion in the pinned vercel/chat repo.",
+      "Do not compute a numeric score. Only classify expected nodes, expected edges, and quality issues.",
+      "Judge semantic equivalence, not exact IDs or exact wording.",
+      "A node can satisfy an expected item if it clearly represents the same concept, even with a different ID.",
+      "A claim can satisfy an expected node if it explicitly preserves the same durable memory, even with different wording.",
+      "An edge can satisfy an expected relation if the proposal connects the same semantic subjects through inline compact fields or canonical edges.",
+      "Compact relationship fields are graph edges: flow.touches creates Flow -> Component touches edges, claim.about creates Claim -> Component/Flow about edges, component.contains creates Component -> Component contains edges, and flow.contains creates Flow -> Flow contains edges.",
+      "This eval rewards memory distilled from tracked curated docs anywhere in the repo: root README/AGENTS/CLAUDE/CONTRIBUTING docs, apps/docs Markdown/MDX, package AGENTS.md files, package README.md files, sample-messages.md, architecture/design/development/testing/publishing docs, and similar curated Markdown/MDX.",
+      "Repo-wide claims should be about component.repository or a semantically equivalent repository component. Package-specific adapter or CLI facts should not be attached only to component.repository.",
+      "Do not require source objects for doc-derived claims. This schema currently allows only session sources, so doc evidence is represented by distilled claim text and anchors.",
+      "Do not mark a real existing source file or source folder as a bad anchor merely because it is broad. Bad anchors are fake paths, generated/dependency paths, .git paths, or useless anchors like the repo root.",
+      "Do not mark a combined top-level component as noisy merely because a more detailed rubric has separate expected nodes. Missing specificity belongs in node coverage, not quality penalties.",
+      "Do not treat a claim's truth label by itself as proof of a depth violation. A model may label a doc-derived claim code_verified; judge the content and anchors, not the label alone.",
+      "Do not penalize a fact merely because it comes from a deep Markdown/MDX file. Deep package docs are good bootstrap input when they contain durable contracts, rules, or rationale and the claim is attached to an appropriate package/component.",
+      "For claim.slack_adapter_contract, require the proposal to explicitly preserve the Slack-specific thread ID contract: slack:{channelId}:{threadTs} or an equivalent channelId/threadTs encodeThreadId/decodeThreadId statement. A generic repo-wide {adapter}:{channel}:{thread} claim is not enough.",
+      "Penalize depth when the proposal appears to derive low-level behavior from source-code spelunking, maps every package/file/function, or stores implementation trivia not presented as durable guidance in Markdown/MDX.",
+      "The proposal should be useful to a future coding agent that needs repo-level rules plus a few key package contracts before editing."
+    ],
+    "actual_repo_facts": [
+      "README.md says Chat SDK is a unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp.",
+      "README.md says the create-chat-sdk CLI generates Chat configuration, webhook routes, .env.example, dependencies, and optional Web adapter route from the adapter catalog.",
+      "README.md says official, vendor-official, and community adapters are browsed on chat-sdk.dev/adapters.",
+      "Root AGENTS.md lists root commands: pnpm install, pnpm build, pnpm typecheck, pnpm check, pnpm fix, pnpm knip, pnpm konsistent, pnpm test, pnpm validate, pnpm dev.",
+      "Root AGENTS.md says pnpm validate is knip plus check plus typecheck plus test plus build and should be run before declaring a task done.",
+      "Root AGENTS.md says dependencies should be installed with pnpm add rather than editing package.json by hand.",
+      "Root AGENTS.md says commits must be signed and verified and should follow Conventional Commits.",
+      "Root AGENTS.md says the repo is a pnpm monorepo orchestrated with Turborepo; all packages are ESM TypeScript bundled with tsup.",
+      "Root AGENTS.md lists major packages: packages/chat, packages/adapter-*, packages/adapter-shared, packages/state-*, packages/integration-tests, apps/docs, and examples/nextjs-chat.",
+      "Root AGENTS.md defines core concepts: Chat, Adapter, StateAdapter, Thread, and Message.",
+      "Root AGENTS.md says thread IDs use {adapter}:{channel}:{thread}, with some adapters base64-encoding delimiter-containing IDs.",
+      "Root AGENTS.md says the webhook flow is platform webhook to /api/webhooks/{platform}, adapter verifies/parses, Chat locks and routes to handlers, and handlers receive Thread and Message.",
+      "Root AGENTS.md says messages use mdast as the canonical format, and each adapter FormatConverter implements toAst, fromAst, and renderPostable.",
+      "Root AGENTS.md says packages/chat/src/adapters/index.ts powers the zero-dependency chat/adapters subpath and must stay in sync with apps/docs/adapters.json; it must not import adapter packages or platform SDKs.",
+      "Root AGENTS.md says chat/adapters catalog entries should include package metadata and peer dependencies, describe env vars, credential modes, secrets, and constructor-only config, and keep official and vendor-official adapter metadata in sync with docs.",
+      "packages/chat/src/adapters/AGENTS.md says the chat/adapters public API shape includes ADAPTERS, ADAPTER_NAMES, AdapterSlug, CatalogAdapter, AdapterEnvSpec, EnvGroup, EnvVar, getAdapter, isAdapterSlug, listPlatformAdapters, listStateAdapters, listEnvVars, and getSecretEnvVars.",
+      "Root AGENTS.md says user-facing docs live in apps/docs/content/docs and behavior/API/env-var changes should update relevant docs in the same PR.",
+      "Root AGENTS.md and .github/CONTRIBUTING.md say Changesets with fixed versioning are used and every PR changing package behavior must include pnpm changeset.",
+      "Root AGENTS.md has an Ultracite code standards section saying pnpm check/fix run Ultracite/Biome and durable rules include preferring unknown over any, awaiting returned promises, function React components, throwing Error objects, no shipped console.log/debugger/alert, top-level regex literals, and never using eval() or assigning document.cookie.",
+      ".github/CONTRIBUTING.md says konsistent enforces public surface conventions for adapter and state packages.",
+      ".github/CONTRIBUTING.md says adapter packages export a ${Name}Adapter class, create${Name}Adapter factory, and ${Name}AdapterConfig type from consistent places.",
+      ".github/CONTRIBUTING.md says state packages export a ${Name}StateAdapter class, create${Name}State factory, and ${Name}StateAdapterOptions type.",
+      ".github/CONTRIBUTING.md says docs preview runs with pnpm --filter docs dev.",
+      "apps/docs/content/docs/contributing/testing.mdx says adapters are a trust boundary; high coverage is expected with unit tests for every public method and integration tests wiring Chat to Adapter to handler.",
+      "apps/docs/content/docs/contributing/testing.mdx says adapter tests should cover factory config/env fallback, thread ID encode/decode, webhook signature verification, message parsing, and format conversion.",
+      "apps/docs/content/docs/contributing/documenting.mdx says Vercel-maintained adapters follow a consistent README structure including install, quick start, env vars, config reference, platform setup, features, and license.",
+      "apps/docs/content/docs/contributing/documenting.mdx says adapter packages should include TSDoc on exported interfaces/factories and sample-messages.md with real platform webhook payloads.",
+      "apps/docs/content/docs/contributing/publishing.mdx says community adapters should be ESM, publish compiled dist only, define explicit exports, declare chat as a peer dependency, and avoid publishing under the reserved @chat-adapter/ scope.",
+      "apps/docs/content/docs/contributing/publishing.mdx says adapter listings in apps/docs/adapters.json should pin README refs to a commit or tag, and unpinned refs are rejected during PR review.",
+      "packages/adapter-slack/AGENTS.md says the Slack adapter connects Chat SDK bots to Slack through HTTP webhooks, optional Socket Mode, single-workspace or OAuth auth, Block Kit rendering, and native streaming.",
+      "packages/adapter-slack/AGENTS.md says Slack thread IDs use slack:{channelId}:{threadTs} and the adapter exposes encodeThreadId/decodeThreadId.",
+      "packages/adapter-slack/AGENTS.md and README.md say createSlackAdapter auto-detects Slack auth env vars, but when any auth-related field is passed explicitly, env fallback for remaining auth fields is disabled to prevent accidental auth mode mixing.",
+      "packages/adapter-slack/AGENTS.md says background work must use the adapter context waitUntil helper, not raw setTimeout or floating promises.",
+      "packages/adapter-slack/AGENTS.md says production code outside the adapter factory should not read process.env directly; new env vars must be threaded through SlackAdapterConfig.",
+      "packages/adapter-slack/sample-messages.md stores captured Slack payloads for replay and regression testing.",
+      "packages/adapter-slack/AGENTS.md says Slack integration tests and replay tests live under packages/integration-tests and use recorded fixtures without workspace credentials.",
+      "packages/adapter-github/AGENTS.md says the GitHub adapter connects bots to issue and pull-request comment threads, supports GitHub App auth, and uses issue/pr/review thread types.",
+      "packages/adapter-github/AGENTS.md says GitHub thread IDs use github:{owner}:{repo}:{type}:{number}.",
+      "packages/adapter-github/AGENTS.md says webhook redeliveries and duplicate events must be idempotent and X-GitHub-Delivery should be surfaced in metadata for debugging.",
+      "packages/adapter-github/AGENTS.md says GitHub App private keys are sensitive and must not be logged, embedded in fixtures, or written to sample messages.",
+      "packages/adapter-github/sample-messages.md stores captured GitHub payloads for replay and regression testing.",
+      "packages/state-redis/README.md describes @chat-adapter/state-redis as a Redis-backed StateAdapter intended for production, serverless, and multi-instance deployments.",
+      "packages/state-redis/AGENTS.md says @chat-adapter/state-redis is built on node-redis and covers subscriptions, distributed locks, key-value cache, lists, queues, queue dedupe, and automatic key prefixing for multi-tenant isolation.",
+      "packages/state-redis/README.md and AGENTS.md say Redis state can be configured with url, kvUrl, restUrl/restToken, or existing Redis clients, with lazy connection behavior.",
+      "packages/state-redis/AGENTS.md says most tests should use vi.fn Redis stubs and real Redis tests should only run when REDIS_URL is provided.",
+      "packages/create-chat-sdk/AGENTS.md says create-chat-sdk scaffolds Chat SDK bot projects; adapter metadata comes from chat/adapters and CLI-only scaffold behavior belongs in src/catalog/scaffold-spec.ts.",
+      "packages/create-chat-sdk/AGENTS.md, README.md, and ARCHITECTURE.md say the generated template is webhook-only and should not include pages, layouts, or client UI.",
+      "packages/create-chat-sdk/ARCHITECTURE.md says tests verify scaffold-spec coverage, generators for every catalog adapter, and an e2e path that scaffolds every catalog adapter through the real CLI."
+    ],
+    "expected_nodes": [
+      {
+        "id": "component.repository",
+        "kind": "component",
+        "description": "Repository-level component used as the about target for repo-wide identity, workflow, contribution, docs, release, and agent-guidance facts."
+      },
+      {
+        "id": "component.core_sdk",
+        "kind": "component",
+        "description": "Core Chat SDK package/concepts, including Chat, Adapter, StateAdapter, Thread, Message, mdast formatting, and webhook routing."
+      },
+      {
+        "id": "component.adapter_packages",
+        "kind": "component",
+        "description": "Adapter package family and shared adapter conventions for official, vendor-official, and community adapters."
+      },
+      {
+        "id": "component.docs_site",
+        "kind": "component",
+        "description": "User-facing docs site/content under apps/docs/content/docs and adapter listing metadata."
+      },
+      {
+        "id": "component.slack_adapter",
+        "kind": "component",
+        "description": "Slack adapter package and its package-level AGENTS.md contract."
+      },
+      {
+        "id": "component.github_adapter",
+        "kind": "component",
+        "description": "GitHub adapter package and its package-level AGENTS.md contract."
+      },
+      {
+        "id": "component.create_chat_sdk",
+        "kind": "component",
+        "description": "create-chat-sdk CLI package and scaffold contract."
+      },
+      {
+        "id": "flow.root_validation_workflow",
+        "kind": "flow",
+        "description": "Whole-repo setup, validation, lint/typecheck/test/build, and docs preview workflow from root curated docs."
+      },
+      {
+        "id": "flow.webhook_message_flow",
+        "kind": "flow",
+        "description": "Webhook-to-adapter-to-Chat routing flow from AGENTS.md."
+      },
+      {
+        "id": "flow.adapter_contribution_workflow",
+        "kind": "flow",
+        "description": "Adapter contribution workflow covering package shape, tests, docs, publishing, and adapter listing rules."
+      },
+      {
+        "id": "claim.repo_identity",
+        "kind": "claim",
+        "description": "Chat SDK is a unified TypeScript SDK for building cross-platform chat bots across Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp."
+      },
+      {
+        "id": "claim.repo_commands_validate",
+        "kind": "claim",
+        "description": "Root pnpm commands are captured, especially pnpm validate as the required final validation before declaring a task done."
+      },
+      {
+        "id": "claim.monorepo_architecture",
+        "kind": "claim",
+        "description": "The repo is a pnpm/Turborepo ESM TypeScript monorepo bundled with tsup, with major package families and apps documented."
+      },
+      {
+        "id": "claim.docs_update_rule",
+        "kind": "claim",
+        "description": "Behavior, public API, and environment variable changes should update relevant apps/docs/content/docs pages in the same PR."
+      },
+      {
+        "id": "claim.changeset_release_rule",
+        "kind": "claim",
+        "description": "Changesets use fixed versioning and package behavior changes require pnpm changeset."
+      },
+      {
+        "id": "claim.adapter_surface_conventions",
+        "kind": "claim",
+        "description": "Adapter and state packages must follow consistent public surface/export naming conventions enforced by konsistent."
+      },
+      {
+        "id": "claim.adapter_catalog_contract",
+        "kind": "claim",
+        "description": "packages/chat/src/adapters/index.ts powers chat/adapters, stays in sync with apps/docs/adapters.json, and must not import adapter packages or platform SDKs."
+      },
+      {
+        "id": "claim.adapter_testing_expectations",
+        "kind": "claim",
+        "description": "Adapters are a trust boundary and should test public methods, config/env fallback, thread ID roundtrip, webhook signatures, message parsing, and format conversion."
+      },
+      {
+        "id": "claim.adapter_documentation_expectations",
+        "kind": "claim",
+        "description": "Adapter docs should include README structure, env vars, config reference, platform setup, exported-interface TSDoc, and sample-messages.md with real payloads."
+      },
+      {
+        "id": "claim.adapter_publishing_contract",
+        "kind": "claim",
+        "description": "Community adapters should be ESM, publish dist, use explicit exports, declare chat as peer dependency, avoid @chat-adapter scope, and pin README refs for listings."
+      },
+      {
+        "id": "claim.slack_adapter_contract",
+        "kind": "claim",
+        "description": "Slack adapter package-level contract captures Slack webhook/socket/OAuth/Block Kit/streaming behavior and slack:{channelId}:{threadTs} thread IDs."
+      },
+      {
+        "id": "claim.github_adapter_contract",
+        "kind": "claim",
+        "description": "GitHub adapter package-level contract captures issue/PR/review comments, GitHub App auth, and thread ID/format quirks."
+      },
+      {
+        "id": "claim.create_chat_sdk_contract",
+        "kind": "claim",
+        "description": "create-chat-sdk scaffolds bot projects, uses chat/adapters as adapter metadata source, and keeps scaffold behavior in src/catalog/scaffold-spec.ts."
+      }
+    ],
+    "expected_edges": [
+      {
+        "id": "edge_repo_claims_about_repository",
+        "from": "repo-wide claims",
+        "to": "component.repository",
+        "description": "Repo-wide identity, command, monorepo, docs-update, and changeset claims are about component.repository."
+      },
+      {
+        "id": "edge_root_validation_touches_repository",
+        "from": "root validation workflow",
+        "to": "component.repository",
+        "description": "Root validation/setup workflow touches component.repository."
+      },
+      {
+        "id": "edge_webhook_flow_touches_core_and_adapters",
+        "from": "webhook message flow",
+        "to": "core SDK and adapter package components",
+        "description": "Webhook flow connects the core Chat SDK concepts with adapter packages."
+      },
+      {
+        "id": "edge_adapter_contribution_touches_adapter_docs",
+        "from": "adapter contribution workflow",
+        "to": "adapter packages and docs site components",
+        "description": "Adapter contribution workflow touches adapter packages and docs site/listing rules."
+      },
+      {
+        "id": "edge_package_claims_about_narrow_components",
+        "from": "Slack/GitHub/create-chat-sdk claims",
+        "to": "their package-specific components",
+        "description": "Package-specific contracts are about Slack adapter, GitHub adapter, or create-chat-sdk components rather than only component.repository."
+      },
+      {
+        "id": "edge_claims_not_disconnected",
+        "from": "important claims",
+        "to": "relevant components or flows",
+        "description": "Important claims are graph-linked to relevant components or flows instead of left disconnected."
+      }
+    ],
+    "quality_rules": {
+      "noisy_structure_nodes": "Components and flows that do not help curated-doc repo orientation, such as one node per adapter package, every docs page, every package.json, generic source-code components, generated/dependency folders, or single-helper-function flows. Do not count the required repository/core/adapter/docs/Slack/GitHub/create-chat-sdk components as noisy.",
+      "bad_claims": "Claims that are wrong, unsupported by any inspected tracked Markdown/MDX or source anchor, raw copied prose, too vague, duplicated, or misplaced. Do not mark package-specific details bad just because they are deep in the repo when they are durable contracts from package AGENTS.md, README.md, sample-messages.md, ARCHITECTURE.md, or docs Markdown/MDX and are attached to package-specific components. Do not mark a claim bad only because its truth field says code_verified when the same content is documented in tracked Markdown/MDX. Mark low-level implementation details bad when they appear to come only from source-code inspection and are not framed by curated docs as durable guidance. Mark repo-level claims bad if they are only about package-specific Slack/GitHub/create-chat-sdk behavior. Mark package-specific claims bad if they are attached only to component.repository.",
+      "bad_anchors": "Anchors that point to fake paths, generated output, dependency folders, .git, or a vague repo root without a strong reason. Real curated docs such as README.md, AGENTS.md, .github/CONTRIBUTING.md, apps/docs/content/docs, and package AGENTS.md files are good anchors.",
+      "depth_violation": "The proposal is clearly too deep for bootstrap because it maps source packages/files/functions or stores code-derived implementation trivia that is not documented as durable guidance. Deep Markdown/MDX ingestion is not a depth violation by itself; internal package docs may contain high-value durable memory. A code_verified truth label alone is not enough to establish a depth violation.",
+      "weak_graph_linking": "The proposal creates nodes but does not meaningfully connect repo-wide claims to component.repository, flows to touched components, and package-specific claims to narrower components."
+    }
+  }
+}

--- a/evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/run.ts
+++ b/evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/run.ts
@@ -17,8 +17,9 @@ import { runCodexAgent } from "../../../libs/agent-runner/codex.js";
 import type { AgentRunResult } from "../../../libs/agent-runner/types.js";
 import { loadRepoEnv } from "../../../libs/env/load-local-env.js";
 
-const caseId = "bootstrap-current-repo-at-8038fe8";
-const targetCommit = "8038fe8c82c3cf7c9175c188f503aa0df72d2fa2";
+const caseId = "curated-doc-bootstrap-vercel-chat-at-f3de128";
+const targetCommit = "f3de12823cae746b34b2641ce9ea0798914370b6";
+const defaultTargetRepoUrl = "https://github.com/vercel/chat.git";
 
 interface Args {
   proposal?: string;
@@ -149,7 +150,7 @@ async function main(): Promise<void> {
   const success = commandsSucceeded && (judge === undefined || judge.score.passed);
   writeResult(context, commands, success, generation, judge);
 
-  console.log(success ? "Eval run passed." : "Eval run failed.");
+  console.log(success ? "Curated-doc bootstrap eval passed." : "Curated-doc bootstrap eval failed.");
   console.log(`Run directory: ${context.runDir}`);
   if (judge) {
     console.log(`Score: ${judge.score.final_score.toFixed(2)} / 100`);
@@ -162,11 +163,11 @@ function prepareRun(): RunContext {
   loadRepoEnv(repoRoot);
   const runDir = resolve(repoRoot, "eval-runs", timestamp(), caseId);
   const targetRepoDir = resolve(runDir, "target-repo");
-  const targetRepoUrl = process.env.GREPLICA_EVAL_TARGET_REPO_URL ?? repoRoot;
+  const targetRepoUrl = process.env.GREPLICA_EVAL_TARGET_REPO_URL ?? defaultTargetRepoUrl;
   const greplicaHomeDir = resolve(runDir, "greplica-home");
   const codexHomeDir = resolve(runDir, "codex-home");
   const proposalPath = resolve(runDir, "proposal.json");
-  const rubricPath = resolve(repoRoot, "evals/cases/bootstrap-current-repo-at-8038fe8/rubric.json");
+  const rubricPath = resolve(repoRoot, "evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/rubric.json");
   const greplicaCommand = ["node", resolve(repoRoot, "dist/apps/cli/main.js")];
 
   mkdirSync(runDir, { recursive: true });
@@ -213,7 +214,7 @@ async function getProposal(context: RunContext, args: Args): Promise<AgentRunRes
     const model = args.agentModel ?? "gpt-5.4-mini";
     const result = await runCodexAgent({
       cwd: context.targetRepoDir,
-      env: { ...process.env, CODEX_HOME: context.codexHomeDir, GREPLICA_HOME: context.greplicaHomeDir },
+      env: agentEnv(context),
       model,
       prompt: codexBootstrapPrompt(context),
       transcriptPath: resolve(context.runDir, "agent-events.jsonl"),
@@ -242,12 +243,23 @@ function runProductCommands(context: RunContext): CommandResult[] {
 }
 
 function runProductCommand(context: RunContext, ...args: string[]): CommandResult {
-  const env = {
+  return run([...context.greplicaCommand, ...args], context.targetRepoDir, evalEnv(context), { stdio: "inherit" });
+}
+
+function evalEnv(context: RunContext): NodeJS.ProcessEnv {
+  return {
     ...process.env,
     CODEX_HOME: context.codexHomeDir,
     GREPLICA_HOME: context.greplicaHomeDir,
   };
-  return run([...context.greplicaCommand, ...args], context.targetRepoDir, env, { stdio: "inherit" });
+}
+
+function agentEnv(context: RunContext): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    CODEX_HOME: context.codexHomeDir,
+    GREPLICA_HOME: context.greplicaHomeDir,
+  };
 }
 
 async function runOpenAiJudge(
@@ -263,7 +275,7 @@ async function runOpenAiJudge(
   const rubric = readJson<Rubric>(context.rubricPath);
   const proposal = readJson<unknown>(context.proposalPath);
   const judgeInput: JudgeInput = {
-    task: "Judge this bootstrap memory proposal for the pinned repo commit. Return JSON classification only; do not compute numeric scores.",
+    task: "Judge this Greplica bootstrap proposal for curated documentation ingestion in the pinned vercel/chat repo. Return JSON classification only; do not compute numeric scores.",
     rubric: rubric.judge,
     repo_tree: repoTree(context.targetRepoDir),
     proposal,
@@ -311,7 +323,7 @@ function parseArgs(args: string[]): Args {
   const proposal = valueAfter(args, "--proposal");
   const agent = valueAfter(args, "--agent");
   if ((proposal === undefined && agent === undefined) || (proposal !== undefined && agent !== undefined)) {
-    throw new Error("Usage: npm run eval:bootstrap-current -- (--proposal /path/to/proposal.json | --agent codex) [--agent-model model] [--judge openai] [--judge-model model]");
+    throw new Error("Usage: npm run eval:curated-doc-bootstrap-vercel-chat -- (--proposal /path/to/proposal.json | --agent codex) [--agent-model model] [--judge openai] [--judge-model model]");
   }
   if (agent !== undefined && agent !== "codex") throw new Error("Only --agent codex is supported.");
 
@@ -330,7 +342,7 @@ function codexBootstrapPrompt(context: RunContext): string {
   const skill = readFileSync(resolve(context.repoRoot, "skills/greplica-bootstrap/SKILL.md"), "utf8");
   const greplica = context.greplicaCommand.join(" ");
 
-  return `You are running a Greplica bootstrap workflow for this repository.
+  return `You are running a Greplica bootstrap workflow for the pinned vercel/chat repository.
 
 Use this exact user-facing skill as the workflow contract:
 
@@ -343,18 +355,26 @@ Runtime facts for this eval:
 - GREPLICA_HOME is already set to an isolated eval directory.
 - Use this greplica command exactly: ${greplica}
 - Write the final proposal JSON exactly here: ${context.proposalPath}
-- If this repository contains any skills/*/SKILL.md files, treat those files as part of the repository being bootstrapped. Do not ignore skill files just because the bootstrap skill content is included above as the workflow contract.
-- If this repository contains graph schema/type/model files that define components, flows, claims, edges, scopes, memberships, or commits, consider whether they are important top-level memory.
+- This eval specifically checks curated documentation ingestion. Inventory tracked *.md and *.mdx files across the repository before source code, then read the relevant durable docs.
+- Read both root-level curated docs and package-level docs/agent files. In this repo, high-signal examples include README.md, AGENTS.md, .github/CONTRIBUTING.md, apps/docs/content/docs/contributing/testing.mdx, apps/docs/content/docs/contributing/documenting.mdx, apps/docs/content/docs/contributing/publishing.mdx, packages/adapter-slack/AGENTS.md, packages/adapter-github/AGENTS.md, and packages/create-chat-sdk/AGENTS.md.
+- Use component.repository for repo-wide facts from root README, root AGENTS.md, .github/CONTRIBUTING.md, and docs/contributing pages.
+- Do not ingest skills/**/SKILL.md files as generic curated context.
+- Do not create component-per-file source maps or copy raw documentation prose.
+- Preserve the repo identity from README.md, the root command/release/docs rules from AGENTS.md and CONTRIBUTING.md, and the adapter testing/documentation/publishing contracts from apps/docs/content/docs/contributing/*.mdx.
+- Preserve package-specific contracts from package-level AGENTS.md files on narrower components; do not attach Slack/GitHub/create-chat-sdk specifics only to component.repository.
+- Prefer source_verified claims for doc-derived facts. Use code_verified only for facts actually checked in source, and avoid extra source-code details that are not needed for curated-doc bootstrap memory.
+- Use a general adapter package-family component for adapter/state package conventions, and a docs-site component for apps/docs content and adapter listing rules.
+- Avoid implementation-level constants, auth/storage internals, or fixture claims unless a curated doc explicitly makes them durable guidance.
 
 Task:
 1. Run the skill workflow for bootstrap memory on this repo.
-2. Inspect the repo shallowly. Prefer top-level components, flows, and durable claims.
+2. Inspect curated docs first, then inspect source shallowly only to validate top-level anchors.
 3. Create a compact proposal JSON at ${context.proposalPath}.
 4. Validate it with: ${greplica} proposal validate ${context.proposalPath}
 5. Fix validation errors until valid.
 6. Do not apply the proposal.
 
-The proposal should be useful to a future coding agent and should avoid deep implementation trivia.`;
+The proposal should help a future coding agent understand repo-level conventions plus a few key package/interface contracts without a deep code audit.`;
 }
 
 async function requestJudge(apiKey: string, model: string, input: JudgeInput): Promise<JudgeOutput> {
@@ -370,7 +390,7 @@ async function requestJudge(apiKey: string, model: string, input: JudgeInput): P
         {
           role: "system",
           content:
-            "You are an evaluator for Greplica bootstrap proposals. Return JSON only. Classify expected nodes, expected edges, and quality issues. Do not calculate numeric scores.",
+            "You are an evaluator for Greplica curated-document bootstrap proposals. Return JSON only. Classify expected nodes, expected edges, and quality issues. Do not calculate numeric scores.",
         },
         {
           role: "user",
@@ -380,7 +400,7 @@ async function requestJudge(apiKey: string, model: string, input: JudgeInput): P
       text: {
         format: {
           type: "json_schema",
-          name: "bootstrap_eval_judge",
+          name: "curated_doc_bootstrap_eval_judge",
           strict: true,
           schema: judgeOutputSchema(),
         },

--- a/evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/sample-good.proposal.json
+++ b/evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/sample-good.proposal.json
@@ -1,0 +1,280 @@
+{
+  "title": "Bootstrap curated-doc memory for vercel/chat",
+  "summary": "Curated documentation memory for Chat SDK repo-level rules, core concepts, adapter contribution contracts, and representative package-specific agent guidance.",
+  "creates": {
+    "components": [
+      {
+        "id": "component.repository",
+        "name": "Repository",
+        "code_anchor": "README.md, AGENTS.md, .github/CONTRIBUTING.md"
+      },
+      {
+        "id": "component.core_sdk",
+        "name": "Core Chat SDK concepts",
+        "code_anchor": "AGENTS.md, packages/chat"
+      },
+      {
+        "id": "component.adapter_packages",
+        "name": "Adapter package family",
+        "code_anchor": ".github/CONTRIBUTING.md, apps/docs/content/docs/contributing"
+      },
+      {
+        "id": "component.docs_site",
+        "name": "User-facing docs site",
+        "code_anchor": "apps/docs/content/docs"
+      },
+      {
+        "id": "component.slack_adapter",
+        "name": "Slack adapter package",
+        "code_anchor": "packages/adapter-slack/AGENTS.md, packages/adapter-slack"
+      },
+      {
+        "id": "component.github_adapter",
+        "name": "GitHub adapter package",
+        "code_anchor": "packages/adapter-github/AGENTS.md, packages/adapter-github"
+      },
+      {
+        "id": "component.create_chat_sdk",
+        "name": "create-chat-sdk CLI",
+        "code_anchor": "packages/create-chat-sdk/AGENTS.md, packages/create-chat-sdk"
+      }
+    ],
+    "flows": [
+      {
+        "id": "flow.root_validation_workflow",
+        "name": "Root setup and validation workflow",
+        "touches": [
+          "component.repository"
+        ]
+      },
+      {
+        "id": "flow.webhook_message_flow",
+        "name": "Platform webhook to Chat handler flow",
+        "touches": [
+          "component.core_sdk",
+          "component.adapter_packages"
+        ]
+      },
+      {
+        "id": "flow.adapter_contribution_workflow",
+        "name": "Adapter contribution, documentation, and publishing workflow",
+        "touches": [
+          "component.repository",
+          "component.adapter_packages",
+          "component.docs_site"
+        ]
+      }
+    ],
+    "claims": [
+      {
+        "id": "claim.repo_identity",
+        "kind": "fact",
+        "text": "Chat SDK is a unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.repository"
+        ]
+      },
+      {
+        "id": "claim.repo_commands_validate",
+        "kind": "requirement",
+        "text": "Repository work uses pnpm commands from the root, and pnpm validate runs knip, check, typecheck, test, and build before a task is declared complete.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.repository",
+          "flow.root_validation_workflow"
+        ]
+      },
+      {
+        "id": "claim.monorepo_architecture",
+        "kind": "fact",
+        "text": "The repository is a pnpm monorepo orchestrated by Turborepo; packages are ESM TypeScript bundled with tsup, with core chat, adapter, shared-adapter, state, integration-test, docs, and example app areas.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.repository",
+          "component.core_sdk",
+          "component.adapter_packages",
+          "component.docs_site"
+        ]
+      },
+      {
+        "id": "claim.repo_dependency_commit_rules",
+        "kind": "requirement",
+        "text": "Dependencies should be added with pnpm add rather than hand-editing package.json, commits must be signed and verified, and commit messages should follow Conventional Commits.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.repository"
+        ]
+      },
+      {
+        "id": "claim.docs_update_rule",
+        "kind": "requirement",
+        "text": "When behavior, public APIs, or environment variables change, the relevant user-facing docs under apps/docs/content/docs should be updated in the same PR and previewed with pnpm --filter docs dev.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.repository",
+          "component.docs_site",
+          "flow.adapter_contribution_workflow"
+        ]
+      },
+      {
+        "id": "claim.changeset_release_rule",
+        "kind": "requirement",
+        "text": "The monorepo uses Changesets with fixed versioning, so every PR that changes package behavior must include a pnpm changeset and all packages share the same release version.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.repository"
+        ]
+      },
+      {
+        "id": "claim.core_concepts",
+        "kind": "fact",
+        "text": "Core Chat SDK concepts are Chat, Adapter, StateAdapter, Thread, and Message; adapters normalize platform messages while Thread exposes actions such as post, subscribe, startTyping, and setState.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.core_sdk"
+        ]
+      },
+      {
+        "id": "claim.webhook_message_flow",
+        "kind": "fact",
+        "text": "Incoming platform webhooks hit /api/webhooks/{platform}; the adapter verifies and parses the request, Chat acquires a thread lock and routes to the matching handler, and handlers receive Thread and Message objects.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.core_sdk",
+          "component.adapter_packages",
+          "flow.webhook_message_flow"
+        ]
+      },
+      {
+        "id": "claim.formatting_contract",
+        "kind": "fact",
+        "text": "Messages use mdast as the canonical format, and each adapter FormatConverter provides toAst, fromAst, and renderPostable for platform-specific conversion.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.core_sdk",
+          "component.adapter_packages"
+        ]
+      },
+      {
+        "id": "claim.adapter_catalog_contract",
+        "kind": "requirement",
+        "text": "packages/chat/src/adapters/index.ts powers the zero-dependency chat/adapters subpath, must stay in sync with apps/docs/adapters.json, and must not import adapter packages or platform SDKs.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.core_sdk",
+          "component.adapter_packages",
+          "component.docs_site"
+        ]
+      },
+      {
+        "id": "claim.adapter_surface_conventions",
+        "kind": "requirement",
+        "text": "konsistent enforces adapter and state package public surfaces: adapter packages expose a NameAdapter class, createNameAdapter factory, and NameAdapterConfig type; state packages expose matching StateAdapter, createNameState, and options exports.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.adapter_packages",
+          "flow.adapter_contribution_workflow"
+        ]
+      },
+      {
+        "id": "claim.adapter_testing_expectations",
+        "kind": "requirement",
+        "text": "Adapters are a trust boundary and should have high coverage: unit tests for public methods plus tests for factory config/env fallback, thread ID roundtrip, webhook signatures, message parsing, and format conversion.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.adapter_packages",
+          "flow.adapter_contribution_workflow"
+        ]
+      },
+      {
+        "id": "claim.adapter_documentation_expectations",
+        "kind": "requirement",
+        "text": "Adapter documentation should include README badges, install, quick start, environment variables, configuration reference, platform setup, features, license, TSDoc for exported interfaces/factories, and sample-messages.md with real webhook payloads.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.adapter_packages",
+          "component.docs_site",
+          "flow.adapter_contribution_workflow"
+        ]
+      },
+      {
+        "id": "claim.adapter_publishing_contract",
+        "kind": "requirement",
+        "text": "Community adapters should be ESM, publish compiled dist only, define explicit exports, declare chat as a peer dependency, avoid the reserved @chat-adapter npm scope, and pin README refs in apps/docs/adapters.json listings.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.adapter_packages",
+          "component.docs_site",
+          "flow.adapter_contribution_workflow"
+        ]
+      },
+      {
+        "id": "claim.slack_adapter_contract",
+        "kind": "fact",
+        "text": "The Slack adapter connects Chat SDK bots to Slack via HTTP webhooks, optional Socket Mode, single-workspace or OAuth authentication, Block Kit rendering, native streaming, and slack:{channelId}:{threadTs} thread IDs.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.slack_adapter"
+        ]
+      },
+      {
+        "id": "claim.slack_testing_contract",
+        "kind": "fact",
+        "text": "Slack package tests are pure Vitest unit tests, while Slack integration and replay tests live under packages/integration-tests and use recorded fixtures without requiring workspace credentials.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.slack_adapter"
+        ]
+      },
+      {
+        "id": "claim.github_adapter_contract",
+        "kind": "fact",
+        "text": "The GitHub adapter connects bots to issue and pull-request comment threads, supports GitHub App authentication with installation-scoped tokens, and distinguishes issue, pr, and review thread types.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.github_adapter"
+        ]
+      },
+      {
+        "id": "claim.github_adapter_gotchas",
+        "kind": "fact",
+        "text": "GitHub adapter gotchas include bot logins ending in [bot], separate review-comment and issue-comment endpoints, edit history on comments, webhook redeliveries, and X-GitHub-Delivery as the replay dedupe key.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.github_adapter"
+        ]
+      },
+      {
+        "id": "claim.create_chat_sdk_contract",
+        "kind": "requirement",
+        "text": "create-chat-sdk scaffolds Chat SDK bot projects; adapter metadata must come from chat/adapters, CLI-only scaffold behavior belongs in src/catalog/scaffold-spec.ts, and the generated template is webhook-only without pages, layouts, or client UI.",
+        "truth": "source_verified",
+        "intent": "intended",
+        "about": [
+          "component.create_chat_sdk"
+        ]
+      }
+    ],
+    "sources": [],
+    "edges": []
+  }
+}

--- a/evals/cases/update-working-memory-source-evidence-at-0438915/run.ts
+++ b/evals/cases/update-working-memory-source-evidence-at-0438915/run.ts
@@ -1,4 +1,5 @@
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { resolve } from "node:path";
 import {
   type CommandResult,
@@ -34,6 +35,7 @@ interface RunContext {
   targetRepoDir: string;
   targetRepoUrl: string;
   greplicaHomeDir: string;
+  codexHomeDir: string;
   seedProposalPath: string;
   sessionTranscriptPath: string;
   sessionTranscriptMarkdownPath: string;
@@ -269,6 +271,7 @@ function prepareRun(): RunContext {
   const targetRepoDir = resolve(runDir, "target-repo");
   const targetRepoUrl = process.env.GREPLICA_EVAL_TARGET_REPO_URL ?? repoRoot;
   const greplicaHomeDir = resolve(runDir, "greplica-home");
+  const codexHomeDir = resolve(runDir, "codex-home");
 
   mkdirSync(runDir, { recursive: true });
 
@@ -279,6 +282,7 @@ function prepareRun(): RunContext {
     targetRepoDir,
     targetRepoUrl,
     greplicaHomeDir,
+    codexHomeDir,
     seedProposalPath: resolve(runDir, "bootstrap-seed.proposal.json"),
     sessionTranscriptPath: resolve(runDir, "session.codex.jsonl"),
     sessionTranscriptMarkdownPath: resolve(runDir, "session.messages.md"),
@@ -304,10 +308,21 @@ function prepareTargetRepo(context: RunContext): void {
 
 function prepareGreplicaHome(context: RunContext): void {
   mkdirSync(context.greplicaHomeDir, { recursive: true });
+  mkdirSync(context.codexHomeDir, { recursive: true });
+  seedCodexRuntimeHome(context.codexHomeDir);
+}
+
+function seedCodexRuntimeHome(codexHomeDir: string): void {
+  const sourceHome = resolve(homedir(), ".codex");
+  for (const file of ["auth.json", "config.toml", "models_cache.json", ".codex-global-state.json", "installation_id"]) {
+    const source = resolve(sourceHome, file);
+    if (existsSync(source)) copyFileSync(source, resolve(codexHomeDir, file));
+  }
 }
 
 function seedBootstrapMemory(context: RunContext): CommandResult[] {
   return [
+    runProductCommand(context, "install", "--platform", "codex", "--embedding", "local"),
     runProductCommand(context, "proposal", "validate", context.seedProposalPath),
     runProductCommand(context, "proposal", "apply", context.seedProposalPath),
   ];
@@ -321,7 +336,7 @@ async function runUpdateAgent(context: RunContext, args: Args): Promise<AgentRun
   const model = args.agentModel ?? "gpt-5.4-mini";
   const result = await runCodexAgent({
     cwd: context.targetRepoDir,
-    env: { ...process.env, GREPLICA_HOME: context.greplicaHomeDir },
+    env: { ...process.env, CODEX_HOME: context.codexHomeDir, GREPLICA_HOME: context.greplicaHomeDir },
     model,
     prompt: codexUpdatePrompt(context),
     transcriptPath: resolve(context.runDir, "agent-events.jsonl"),
@@ -353,7 +368,11 @@ function readFinalGraph(context: RunContext): CommandResult {
 }
 
 function runProductCommand(context: RunContext, ...args: string[]): CommandResult {
-  const env = { ...process.env, GREPLICA_HOME: context.greplicaHomeDir };
+  const env = {
+    ...process.env,
+    CODEX_HOME: context.codexHomeDir,
+    GREPLICA_HOME: context.greplicaHomeDir,
+  };
   return run([...context.greplicaCommand, ...args], context.targetRepoDir, env);
 }
 

--- a/libs/env/load-local-env.ts
+++ b/libs/env/load-local-env.ts
@@ -26,7 +26,7 @@ export type EnvVarSource =
 
 export function loadRepoEnv(repoRoot: string): LoadedRepoEnv {
   const initialEnvKeys = new Set(Object.keys(process.env).filter(hasEnvValue));
-  const repoEnvKeys = new Set(["OPENAI_API_KEY"]);
+  const repoEnvKeys = new Set(["OPENAI_API_KEY", "OPENAI_MODEL"]);
   const files = [".env.local", ".env"]
     .map((file) => loadEnvFile(resolve(repoRoot, file), repoEnvKeys))
     .filter((file): file is LoadedEnvFile => file !== undefined);

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -80,13 +80,27 @@ export class KnowledgeGraphService {
     };
   }
 
+  requireRepo(input: RepoRef): InitRepoResult {
+    const repo = this.repository.requireRepo(input);
+    const main = this.repository.requireMainScope(repo.id);
+    const working = this.repository.requireWorkingScope(repo.id);
+
+    return {
+      repo_id: repo.id,
+      main_scope_id: main.id,
+      working_scope_id: working.id,
+      database_path: defaultDatabasePath(),
+      created: false,
+    };
+  }
+
   readGraph(input: RepoRef): GraphReadResult {
-    const initialized = this.ensureInitialized(input);
+    const initialized = this.requireRepo(input);
     return this.repository.readGraphView(initialized.repo_id);
   }
 
   async contextGraph(input: RepoRef, query: string): Promise<GraphContextResult> {
-    const initialized = this.ensureInitialized(input);
+    const initialized = this.requireRepo(input);
     return this.contextBuilder.build(initialized.repo_id, this.repository.readGraphView(initialized.repo_id), query, {
       config: this.contextConfig,
       warnOnCreatedEmbeddings: true,
@@ -94,7 +108,7 @@ export class KnowledgeGraphService {
   }
 
   validateProposal(input: RepoRef, proposal: unknown): ProposalValidationResult {
-    this.ensureInitialized(input);
+    this.requireRepo(input);
     return validateProposal(normalizeProposal(proposal, this.repository), this.repository);
   }
 
@@ -105,7 +119,7 @@ export class KnowledgeGraphService {
       throw new Error(`Proposal is invalid:\n${validation.errors.map((error) => `- ${error}`).join("\n")}`);
     }
 
-    const initialized = this.ensureInitialized(input);
+    const initialized = this.requireRepo(input);
     const working = this.repository.requireWorkingScope(initialized.repo_id);
     const memoryCommit = this.repository.createMemoryCommit({
       scope_id: working.id,
@@ -134,9 +148,6 @@ export class KnowledgeGraphService {
     };
   }
 
-  private ensureInitialized(input: RepoRef): InitRepoResult {
-    return this.initRepo(input);
-  }
 }
 
 export function createLocalKnowledgeGraphService(config: GraphContextConfig = graphContextConfig): KnowledgeGraphService {

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -101,10 +101,14 @@ export class SqliteRepository {
     return this.db.prepare("SELECT * FROM repos WHERE root_path = ?").get(rootPath) as RepoRecord | undefined;
   }
 
-  requireRepo(remoteUrl: string): RepoRecord {
-    const repo = this.getRepoByRemote(remoteUrl);
+  getRepo(input: UpsertRepoInput): RepoRecord | undefined {
+    return this.findRepo(input)?.repo;
+  }
+
+  requireRepo(input: UpsertRepoInput): RepoRecord {
+    const repo = this.getRepo(input);
     if (!repo) {
-      throw new Error(`Repo memory is not ready for ${remoteUrl}. Run 'greplica doctor' to diagnose setup.`);
+      throw new Error("Greplica is not installed for this repo. Run greplica install --platform <codex|claude|opencode> --embedding local from the repo you want to use.");
     }
     return repo;
   }
@@ -178,7 +182,15 @@ export class SqliteRepository {
     const scope = this.db
       .prepare("SELECT * FROM graph_scopes WHERE repo_id = ? AND kind = 'working' AND name = 'working'")
       .get(repoId) as GraphScope | undefined;
-    if (!scope) throw new Error("Working scope is missing. Run 'greplica doctor' to diagnose setup.");
+    if (!scope) throw new Error("Working scope is missing. Run 'greplica install --platform <codex|claude|opencode> --embedding local' from this repo.");
+    return scope;
+  }
+
+  requireMainScope(repoId: string): GraphScope {
+    const scope = this.db
+      .prepare("SELECT * FROM graph_scopes WHERE repo_id = ? AND kind = 'main' ORDER BY created_at LIMIT 1")
+      .get(repoId) as GraphScope | undefined;
+    if (!scope) throw new Error("Main scope is missing. Run 'greplica install --platform <codex|claude|opencode> --embedding local' from this repo.");
     return scope;
   }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typecheck": "tsc --noEmit",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",
     "eval:coding-proposal-apply-atomicity": "npm run build && node dist/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/run.js",
+    "eval:curated-doc-bootstrap-vercel-chat": "npm run build && node dist/evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/run.js",
     "eval:search-current": "npm run build && node dist/evals/cases/search-current-repo-at-8038fe8/run.js",
     "eval:update-working-memory-source-evidence": "npm run build && node dist/evals/cases/update-working-memory-source-evidence-at-0438915/run.js"
   },

--- a/skills/greplica-bootstrap/SKILL.md
+++ b/skills/greplica-bootstrap/SKILL.md
@@ -12,36 +12,148 @@ Create shallow, high-signal Greplica memory for the current repository or folder
 
 Run from the target repository root, a subdirectory inside it, or a non-Git folder that should have its own memory.
 
-Do not run `greplica doctor` as a routine preflight. Run the needed Greplica commands directly; if one fails, use the error to decide whether `greplica doctor` would help diagnose installation, target detection, or embedding-provider configuration.
+Do not run `greplica doctor` as a routine preflight. Run the needed Greplica commands directly; if one fails, use the error to decide whether install or doctor would help diagnose installation, target detection, or embedding-provider configuration.
 
 If `greplica` is missing, tell the user to run the Greplica setup prompt from the README.
 
+If a Greplica command reports that Greplica is not installed for this repo, or that the main or working scope is missing, run `greplica install --platform <platform> --embedding local` from the target repo and retry the failed command once. Use the platform matching the current agent: `codex` for Codex, `claude` for Claude Code, and `opencode` for OpenCode. If the platform is genuinely unclear, ask the user which platform to install for.
+
 Local embeddings are the default and do not require `OPENAI_API_KEY`. If Greplica is configured for OpenAI and a command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in target-root `.env.local`.
 
-`greplica` automatically prepares memory state; do not ask the user to run a separate initialization command.
+## Inspect Curated Repo Context First
+
+Read tracked Markdown context before source code. Use `git ls-files` when available to inventory all tracked `*.md` and `*.mdx` files, then decide which files contain durable repo memory.
+
+High-priority Markdown/MDX often includes README files, AGENTS.md, CLAUDE.md, CONTEXT.md, CONTRIBUTING files, architecture/design docs, docs under any `docs/` directory, package-level agent guidance, and docs that define public APIs, config, tests, releases, or workflows. Do not assume these names are exhaustive; a file like `architecture.md`, `design.md`, `development.md`, or `testing.mdx` can be just as important.
+
+Do not treat `skills/**/SKILL.md` files as generic curated context. Skill files are often agent workflow instructions, and ingesting them wholesale creates noisy memory. Only inspect them if they are clearly product source artifacts needed to understand this repository, and still summarize them shallowly.
+
+Assume most meaningful content in curated docs deserves memory if it fits one of these durable categories:
+
+- **What this repo is**: product purpose, audience, core concepts, and major architecture boundaries.
+- **How to work in it**: setup, run, test, build, eval, required tools, environment, services, and local workflow gotchas.
+- **Rules to preserve**: agent instructions, coding/repo conventions, invariants, compatibility/security/privacy constraints, and do-not guidance.
+- **Interfaces and contracts**: public CLI/API/config/file formats, integration behavior, schemas, protocols, and examples that define expected behavior.
+- **Why things are this way**: explicit decisions, rationale, rejected alternatives, historical context, roadmap, future work, and known risks.
+
+When the docs provide them, make sure bootstrap memory preserves the repo identity from README-style docs and durable contribution/workflow contracts from testing, documentation, publishing, architecture, design, or development guides. Do not let source-code inspection replace these curated-doc facts.
+
+Curated docs are the starting inventory, not the whole bootstrap. After reading them, inspect the shallow source/config surfaces needed to verify and complete the durable memory. A good bootstrap should merge documented intent with the current implementation surface when both matter.
+
+Do not use source inspection to embellish curated-doc facts with extra mechanics. If a doc says a command, boundary, or rule has a specific shape, preserve that shape without adding implementation details that are only visible in tests or source. Source inspection can verify anchors, public surfaces, and central operational boundaries; it should not turn a documented rule into a stronger or more detailed claim than the docs support.
+
+When curated docs give exact formats, schemas, protocols, ID shapes, configuration keys, command examples, file formats, or sanctioned helper names, preserve those exact contracts. Do not replace an exact documented contract with only a generic parent rule.
+
+Do not copy documentation prose into memory verbatim. Distill docs into focused components, flows, and claims that future agents can query. Prefer multiple precise claims over one broad summary when the doc contains separate durable facts.
+
+For package-level docs, a component plus exact contracts is usually better than a broad feature catalog. Store package-specific claims only when they preserve a stable interface, ID format, config/env rule, security/privacy rule, publishing/docs/test rule, sanctioned helper, or known risk. Do not create "scope" claims that list every feature, method, integration operation, or supported action from a README, AGENTS file, source export, or marketing overview.
+
+It is acceptable for a component to exist without a detailed "scope" claim. Do not add a claim merely to prove every component has one. A component name, anchor, and flow link are often enough when the only available details are package capabilities or source internals.
+
+## Repo-Level Memory
+
+When curated docs contain facts that apply to the whole repository or workspace, create a conventional component for them:
+
+```json
+{
+  "id": "component.repository",
+  "name": "Repository",
+  "code_anchor": "README.md"
+}
+```
+
+Use `component.repository` as the `about` target for repo-level claims. Add more curated root files to `code_anchor` only when they are central to the repo-level facts, for example `README.md, AGENTS.md, CONTRIBUTING.md`.
+
+Repo-level facts include:
+
+- identity: what the repo is, product purpose, audience, and main value.
+- global architecture: monorepo layout, major package families, ownership boundaries, and where docs/source/examples live.
+- whole-repo workflow: root install/build/test/lint/eval commands, package manager requirements, local prerequisites, env vars, services, and ports.
+- global contribution rules: PR rules, changesets, commit conventions, branch rules, and review requirements.
+- agent-wide instructions: root AGENTS.md/CLAUDE.md guidance, search-before-edit rules, docs-update rules, and safety constraints.
+- cross-cutting conventions: coding style, generated-file policy, docs policy, naming conventions, and test placement rules.
+- public contracts spanning the repo: CLI/API compatibility rules, config guarantees, package versioning, and release process.
+- repo-wide risks, gotchas, rationale, history, roadmap, and non-goals.
+
+Do not force package, module, service, endpoint, or function-specific facts into `component.repository`. Create or reuse a narrower component or flow for those facts.
 
 ## Inspect The Repo Shallowly
 
 Read enough to orient a future coding agent:
 
-- README and docs if present.
+- curated repo context from the files listed above.
 - package/config/build files.
 - top-level tree.
-- app/lib entrypoints.
+- app/lib entrypoints and public control surfaces.
+- install/setup/config/doctor/health-check surfaces when the repo has them.
+- environment/config loading and required external service checks.
 - schema/type/model files that define durable concepts.
-- bundled skill files such as `skills/*/SKILL.md`, when present.
+- public API, CLI, config, file-format, protocol, or plugin boundaries.
+- persistence/repository/storage boundaries when data durability matters.
 - tests only when they clarify important behavior.
 - existing memory with `greplica graph read`.
 
 Do not perform a deep audit. Prefer major subsystems and human workflows over file-by-file or function-level memory.
+
+Before writing the proposal, do a short coverage pass. Ask what a future agent would need to know before editing this repo:
+
+- How is the tool or product installed, configured, run, diagnosed, and validated?
+- Where do required environment variables, credentials, config files, ports, services, or local state come from?
+- What public commands, APIs, packages, routes, events, schemas, protocols, config files, file formats, or generated artifacts are compatibility contracts?
+- Which modules are the application boundaries that coordinate storage, validation, external services, or user-visible behavior?
+- Which documented rules are enforced in code, and which implemented behavior is not obvious from docs but is durable enough to matter?
+
+If one of those answers is central to the repository and not yet represented, add a component, flow, or claim for it. This is still shallow bootstrap work; the goal is to capture operational contracts and boundaries, not private helper details.
+
+For every claim candidate, do a support audit before writing the final proposal:
+
+- If supported by curated docs, keep the claim at the level of detail the docs actually state.
+- If supported only by source code, keep it only when it describes a public contract, entrypoint/API/config/file-format/protocol boundary, storage boundary, operational setup/diagnostic behavior, or major architecture boundary.
+- If supported only by tests, fixtures, examples, or implementation internals, normally drop it. Keep it only when it documents a public compatibility contract or a repo-wide workflow that future agents must preserve.
+- Do not infer stronger requirements from examples, tests, helper names, or nearby code. Store what is evidenced, not what seems plausible.
+- Prefer "this component owns this boundary" over enumerating methods, flags, retry behavior, timeout details, fixture mechanics, or private algorithms.
+- A type/interface/schema file can justify a component or boundary anchor, but do not create exhaustive method, field, or export inventories from it unless curated docs present that inventory as a durable contract.
+- When docs provide an explicit allow/deny list, requirement list, or compatibility rule, do not extend that list with additional items inferred from source.
+
+Then do a pruning pass:
+
+- Replace script implementation details with the durable workflow contract. Store "run the aggregate validation command" rather than the private command chain unless the chain itself is a public compatibility rule.
+- Replace interface or type method inventories with the durable role of the interface/type. Store "this interface is the platform boundary" rather than every method it exposes unless the method list is the contract being changed.
+- Replace package feature catalogs with the package purpose plus the few exact invariants, identifiers, config keys, protocol formats, or do-not rules that future edits must preserve.
+- For integrations, adapters, state backends, CLIs, plugins, or SDK packages, avoid claims that read like "this package supports A, B, C, D, E." Keep the component to establish ownership, then store only exact contracts and hazards that future edits must preserve.
+- For style and linting docs, avoid expanding generic tool rules into long best-practice inventories. Store the governing tool or policy, and only preserve unusual or repo-specific do/don't rules that are explicitly documented.
+- Drop test/fixture/emulator/recording mechanics unless they are the documented workflow a future agent must run or preserve.
+- Be suspicious of long comma-separated claims. If a claim lists many methods, features, flags, or mechanics, reduce it to the durable abstraction or split out only the exact documented contracts.
+- For component or package "scope" claims, state the purpose and ownership boundary. Do not copy overview bullet lists of capabilities into memory. Only keep capabilities that are exact contracts, compatibility guarantees, safety rules, or identifiers that future edits must preserve.
+- For deep operational runbooks, fixture guides, replay guides, emulator guides, migration notes, or package-specific test procedures, bootstrap usually needs only the location and purpose. Store step-by-step commands or flags only when the runbook is a root workflow or a public contract future agents are expected to run frequently.
+
+Before validation, run a hard deletion filter:
+
+- Delete any claim whose main evidence is source-code exploration and whose content is not a public command/API/config/file-format/protocol/storage/diagnostic boundary.
+- Delete any claim that lists many capabilities, methods, operations, routes, flags, lifecycle steps, fallback behaviors, or generated files unless a curated doc explicitly presents that exact list as the durable contract.
+- Delete any package-specific "what it supports" claim when the component and flow already tell future agents where the package lives.
+- Delete any claim that adds extra items to a documented list. Keep only the documented list or narrow the claim to the items the docs actually state.
+- Delete `code_verified` claims for doc-first bootstrap when a `source_verified` doc-level claim or component/flow link would be enough.
+- Delete package-specific fallback defaults, concurrency edge cases, checker override maps, auth/signature algorithm details, routing subcases, or generated-file inventories unless they are documented as user-facing compatibility contracts or repo-wide rules. Bootstrap can leave those for working-memory updates when a task actually touches that package.
+
+When setup, initialization, configuration, or diagnostic behavior is central, represent it as a flow, not only as a loose claim. That flow should touch the entrypoint or public surface plus the components that provide target detection, environment/config loading, persistence, external service checks, or health reporting.
+
+Do not confuse "do not run a diagnostic command as routine preflight" with "do not remember diagnostic behavior." If the target repo implements a diagnostic, health-check, status, setup, or initialization path that future agents may need when something fails, capture what it checks and which boundaries it exercises.
+
+When a central workflow depends on separately owned files or modules, prefer separate components for those boundaries even if one top-level entrypoint calls them all. Do not bury target detection, environment/config loading, storage, validation, retrieval, protocol handling, or external-service integration inside a generic app component when they have their own durable module boundary.
+
+Be precise about public surfaces. Treat commands, APIs, config keys, routes, events, protocols, file formats, and exports as public contracts only when they are documented, shown in help, exported, or intentionally exposed. Do not list hidden, compatibility, or legacy code paths as supported public surfaces. Include them only when the hidden/internal distinction itself is durable and important to future edits.
+
+Only store facts about the target repository checkout. Do not create drift claims by comparing the target repo's docs or bundled skills against this skill prompt, the current workspace, or newer product behavior outside the target checkout.
 
 When the repo has separate files for related responsibilities, keep them separate if that helps navigation. In particular:
 
 - Do not collapse proposal normalization and proposal validation when they live in different files.
 - Do not collapse persistent repository operations and database schema/open/migration code when they live in different files.
 - Represent graph schema/type/model files as their own component when they define the memory model.
-- Represent bundled agent skills as a component when the repo ships skills that guide important workflows.
 - Add a dedicated flow for compact relationship fields becoming canonical graph edges when the repo supports compact proposal syntax.
+
+Choose anchors that match the claim support. If a component or claim is primarily doc-derived, anchor it to the relevant docs or agent guidance. Prefer doc anchors for doc-first bootstrap when durable docs exist for that component. Use source-file anchors for source-derived public boundaries, not as a substitute for documented evidence. Avoid adding implementation source files to a doc-derived component's `code_anchor` unless the source file is the only stable public entrypoint needed to navigate the boundary.
 
 ## Proposal Format
 
@@ -102,7 +214,11 @@ Sources currently represent session artifacts. Do not create a source just becau
 - Prefer roughly 4-10 major components for a small repo.
 - Include major flows that help future agents decide where to look.
 - Include claims that capture why the main modules matter, not just which commands exist.
-- Capture boundary facts such as thin CLI wrappers, service boundaries, target detection, global source storage, and shallow bootstrap guidance when the inspected code or skill files support them.
+- Capture high-signal curated-doc facts unless they are purely promotional, duplicate, obsolete, or not useful to future agents.
+- Capture boundary facts such as thin entrypoint wrappers, public dispatch/routing, install/setup flows, diagnostic flows, environment/config loading, service boundaries, target detection, persistence boundaries, global source storage, and shallow bootstrap guidance when the inspected code or curated docs support them.
+- Do not let a broad repository component hide important operational surfaces. Repo-level claims belong on `component.repository`, but central command/config/env/diagnostic/storage/API surfaces usually deserve narrower components or flows too.
+- Avoid speculative drift claims during bootstrap. If a checked-out repo's docs, skills, or code disagree with your own current instructions, capture what the checked-out repo says and leave reconciliation to a later working-memory update.
+- Drop claims that mostly summarize test harness mechanics, fixture recording details, emulator wiring, private dispatch branches, or exhaustive method inventories unless curated docs explicitly present them as durable contracts.
 - Use `code_verified` only for claims grounded in inspected code.
 - Use `unknown` truth for unverified questions, risks, or tasks.
 - Add open questions/tasks for important areas that need deeper inspection.

--- a/skills/greplica-update-working-memory/SKILL.md
+++ b/skills/greplica-update-working-memory/SKILL.md
@@ -16,9 +16,9 @@ Do not run `greplica doctor` as a routine preflight. Run the needed Greplica com
 
 If `greplica` is missing, tell the user to run the Greplica setup prompt from the README.
 
-Local embeddings are the default and do not require `OPENAI_API_KEY`. If Greplica is configured for OpenAI and a command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in target-root `.env.local`.
+If a Greplica command reports that Greplica is not installed for this repo, tell the user to run the Greplica setup prompt from the README inside this repo.
 
-`greplica` automatically prepares memory state; do not ask the user to run a separate initialization command.
+Local embeddings are the default and do not require `OPENAI_API_KEY`. If Greplica is configured for OpenAI and a command reports that `OPENAI_API_KEY` is missing, stop. Do not ask the user to paste the key into chat. Tell them to set it in their shell before launching the coding agent, or in target-root `.env.local`.
 
 ## Gather Evidence
 
@@ -32,17 +32,75 @@ Use the current conversation/session context plus code evidence. Read:
 
 Use the current session as context, but verify durable code facts against files or diffs when possible.
 
+The update proposal must preserve the session delta, not just the final patch. A useful update usually has separate memories for:
+
+- the explored route or pre-existing behavior that made the problem understandable.
+- the behavior or contract that changed.
+- the scope rule that limits where the new behavior applies.
+- the exact approaches, artifact types, or representations the session rejected.
+- the future workflow or capability that was discussed but deliberately left unbuilt.
+- the older memory that is now too broad and needs `supersedes[]`.
+
+If one of those buckets has explicit session evidence and existing memory is missing or too vague, include it as a focused claim. A proposal that only describes the final implementation is incomplete when the session's decisions depended on old behavior, rejected alternatives, or deferred work.
+
+Update-working-memory is not a second bootstrap, and it is not diff-only. Preserve durable context from the route the agent explored when that context shaped the work or would save a future agent from rediscovering where behavior lives. Do not rescan the whole repository's documentation just because curated docs exist. Only inspect curated context that was edited, explicitly cited, or needed to understand a decision made during the session. For those files, read the relevant before/after content carefully. Use `git ls-files` when needed to identify tracked curated files anywhere in the repository:
+
+- files whose basename starts with `README`
+- files named `AGENTS.md`
+- files named `CLAUDE.md`
+- files named `CONTEXT.md`
+- files whose basename starts with `CONTRIBUTING`
+- Markdown or MDX files under any `docs/` directory
+
+Do not treat `skills/**/SKILL.md` files as generic curated context. Skill files are often agent workflow instructions, and ingesting them wholesale creates noisy memory. Only inspect them when the session actually changed, used, or discussed that skill's behavior, and still summarize only the durable delta.
+
+For touched or explicitly used curated docs, preserve the changed or newly relied-on facts when they fit one of these durable categories:
+
+- **What this repo is**: product purpose, audience, core concepts, and major architecture boundaries.
+- **How to work in it**: setup, run, test, build, eval, required tools, environment, services, and local workflow gotchas.
+- **Rules to preserve**: agent instructions, coding/repo conventions, invariants, compatibility/security/privacy constraints, and do-not guidance.
+- **Interfaces and contracts**: public CLI/API/config/file formats, integration behavior, schemas, protocols, and examples that define expected behavior.
+- **Why things are this way**: explicit decisions, rationale, rejected alternatives, historical context, roadmap, future work, and known risks.
+
+Do not store raw documentation prose. Distill changed or newly discovered curated-doc content into focused claims, and preserve removals or corrections when they change what future agents should believe. If a doc fact was already true before the session and was not used to make a decision, leave it for bootstrap memory instead of duplicating it here.
+
+When curated docs or session decisions contain repo-wide facts, create or reuse `component.repository`:
+
+```json
+{
+  "id": "component.repository",
+  "name": "Repository",
+  "code_anchor": "README.md"
+}
+```
+
+Use `component.repository` as the `about` target for claims that apply to the whole repository or workspace, such as:
+
+- what the repo is, its product purpose, audience, and main value.
+- monorepo layout, major package families, ownership boundaries, and where docs/source/examples live.
+- root setup/build/test/lint/eval commands, package manager requirements, local prerequisites, env vars, services, and ports.
+- PR rules, changesets, commit conventions, branch rules, and review requirements.
+- root AGENTS.md/CLAUDE.md guidance, search-before-edit rules, docs-update rules, and safety constraints.
+- cross-cutting coding, generated-file, docs, naming, testing, compatibility, security, privacy, versioning, and release rules.
+- repo-wide risks, gotchas, rationale, history, roadmap, and non-goals.
+
+Do not attach package, module, service, endpoint, or function-specific claims to `component.repository`; create or reuse a narrower component or flow for those.
+
+In update-working-memory, do not create `component.repository` as a default bucket. Reuse or create it only when the kept claim is a true standing repo-wide rule, identity fact, global workflow, or repository-level rationale. A one-off verification checklist, eval run summary, or session process note should usually be dropped or attached to the narrower flow/component it governs.
+
 When you have a transcript file, run this transcript extraction workflow before writing the proposal:
 
 1. Get the transcript line count, then read every line in chunks if needed.
 2. Build a scratch candidate inventory from the transcript before relying on code diffs or final assistant summaries. Do this even when the final patch is small.
-3. Put candidates into buckets: explored existing repo facts, changed code facts, flow facts, user constraints, rationale, trade-offs/rejected alternatives, negative decisions/do-not-do rules, deferred work/future work, drift, naming collisions/terminology distinctions, and eval/fixture/testing/process constraints.
-4. For each candidate, record the source line/message, intended memory role, whether it should be code_verified, source_verified, unknown, or dropped, and whether it was already present in existing memory.
-5. Treat explored existing repo facts as eligible memory when they were non-obvious, affected the design, or would save future navigation. Do not drop a useful fact only because the final patch did not edit that exact code path.
-6. Drop only candidates that are transient, duplicate without session clarification, unsupported, trivial to rediscover from the immediately edited file, or not useful to a future agent.
-7. Keep explicit user corrections, "do not" statements, "not built" statements, naming collisions, rejected alternatives, future-work boundaries, and eval/process constraints unless they are clearly transient.
-8. Write one focused claim per kept durable candidate. Do not merge candidates from different buckets into one broad claim.
-9. Before validating, review dropped candidates and re-add any durable explored context or session decision that would be hard to recover from code alone.
+3. Put candidates into buckets: explored navigation path, pre-session behavior discovered, changed behavior, changed or relied-on curated-doc facts, user constraints, rationale, trade-offs/rejected alternatives, negative decisions/do-not-do rules, deferred work/future work, drift, naming collisions/terminology distinctions, eval/fixture/testing/process constraints, and old memory that may need superseding.
+4. For each candidate, record the source line/message, intended memory role, whether it should be code_verified, source_verified, unknown, or dropped, whether it was already present in existing memory, and whether it needs an explicit `supersedes[]` link.
+5. Treat explored existing repo facts as required memory when they were non-obvious, affected the design, would save future navigation, and are missing or too vague in existing memory. Do not drop a useful fact only because the final patch did not edit that exact code path.
+6. Store the explored path as durable navigation knowledge only when it explains the system: which component owns behavior, which flow crosses boundaries, which similarly named concept is not the same thing, where the source of truth lives, or which apparently relevant path was ruled out. Do not store a raw list of files opened, commands run, search terms, or transient debugging steps.
+7. If explored evidence came from outside the target repository, store it only when it defines a durable external contract, dependency behavior, operational constraint, or user-approved rationale that future repo work must preserve. Otherwise keep repository memory focused on this codebase.
+8. Drop only candidates that are transient, duplicate without session clarification, unsupported, trivial to rediscover from the immediately edited file, or not useful to a future agent.
+9. Keep explicit user corrections, "do not" statements, "not built" statements, naming collisions, rejected alternatives, future-work boundaries, and eval/process constraints unless they are clearly transient.
+10. Write one focused claim per kept durable candidate. Do not merge candidates from different buckets into one broad claim. In particular, keep "where the agent had to look", "how it worked before", "how it works now", "where the new behavior applies", "why this shape was chosen", "what exact representation was rejected", and "what remains future work" as separate claims when the session contains separate evidence for them.
+11. Before validating, review dropped candidates and re-add any durable explored context or session decision that would be hard to recover from code alone.
 
 Prioritize user messages and final accepted decisions over assistant suggestions. Search around terms such as `source`, `evidence`, `session`, `reason`, `metadata`, `future`, `next`, `later`, `out of scope`, `not built`, `proposal`, `eval`, `fixture`, `rubric`, `wrong`, `reject`, `don't`, and `instead`.
 
@@ -56,11 +114,14 @@ When creating a session source, derive its identity from the actual session:
 Before writing the proposal, scan the session against this checklist:
 
 - What existing repo behavior did the agent discover before editing?
+- What path through the repository did the agent have to understand, and is that path useful durable navigation knowledge?
+- What was true before this session, and what is true after this session?
 - What code facts changed?
 - What cross-component flows changed?
 - What constraints did the user impose?
 - What rationale explains why the code was shaped this way?
 - What trade-offs or alternatives were discussed, rejected, or deferred?
+- What provenance, evidence, storage, API, workflow, or implementation approaches were explicitly rejected or postponed?
 - What drift did the implementation introduce without an explicit durable decision?
 - What terms, model concepts, or type names were easy to confuse?
 - What old memory was too broad, incomplete, or newly qualified by the session?
@@ -70,10 +131,28 @@ Before writing the proposal, scan the session against this checklist:
 
 Skip a category when the session has no clear evidence for it. Do not invent future work from implementation gaps; future work should be explicit in the session or clearly stated as a deferred part of the larger plan.
 
+When the session changes how a system represents or exposes information, capture both sides if they matter to future agents: the old behavior that was replaced or found insufficient, and the new behavior that now exists. This applies generically to storage, retrieval, provenance, validation, public APIs, config, workflows, and generated artifacts.
+
+When the user rejects an approach, store the rejection as a durable decision or constraint if future agents might reasonably try it again. Preserve the exact rejected shape, not only a broader category. For example, if the session rejects a snapshot, commit-state marker, raw artifact, metadata field, command, source type, schema shape, or automation path, record that rejected representation separately from the chosen implementation.
+
+When the session says a workflow, command, automation path, ingestion path, adapter, protocol, or migration was discussed but not built, create a task or future-work claim for the deferred capability. Do not collapse that into a claim that merely says the current slice did not build it.
+
+Store process or eval constraints only when they are durable standing rules for future repository work. Do not store a session's command checklist, test-run sequence, or compatibility check as memory unless the user explicitly turned it into a reusable rule.
+
+When the session discusses provenance or evidence, keep these roles separate:
+
+- A provenance artifact records where a session-derived claim came from; it is useful for auditability and grouping.
+- A code-verified claim is made true by code or diffs, not by attaching session provenance.
+- If the session made that distinction, say it directly: provenance groups and audits where a claim came from; it is not the mechanism that makes a code fact true.
+- An inspected file, commit state, or working-tree state should not become a provenance source unless the session explicitly made that artifact part of the memory model.
+- A current session source should attach only to claims created, materially changed, or materially clarified by that session. Do not attach it to every old or reused claim.
+- If the session discusses that scope rule, store it as its own constraint rather than assuming future agents will infer it from the proposal edges.
+
 ## What To Store
 
 Create memory for durable changes only:
 
+- **Curated-doc facts**: meaningful tracked README/AGENTS/CLAUDE/CONTEXT/CONTRIBUTING/docs content that explains what the repo is, how to work in it, rules to preserve, interfaces/contracts, or why things are this way.
 - **Explored existing facts**: non-obvious repo behavior discovered while solving the task, especially behavior that shaped the design.
 - **Code facts**: specific implementation facts verified against code or diffs.
 - **Flow facts**: how behavior works across multiple components or commands.
@@ -83,6 +162,13 @@ Create memory for durable changes only:
 - **Drift**: important behavior or design consequences that exist without a clear explicit decision.
 - **Tasks**: next work that should be done.
 - **Future work**: planned later capabilities or follow-up directions that should not be forgotten.
+
+For session-derived claims, choose the claim kind and truth value by what supports the claim:
+
+- Use `fact`/`code_verified` for behavior verified in code or diffs.
+- Use `decision` or `requirement`/`source_verified` for user-approved design choices, rejected alternatives, policy constraints, and process rules from the conversation.
+- Use `task` or `question`/`unknown` for unresolved future work.
+- Do not mark guidance from a skill/doc change as a code-verified requirement unless enforcement exists in code. If it is a user/session policy or instruction, keep it source-verified and attach session evidence.
 
 When existing memory is now too vague or stale, create a clearer claim with `supersedes[]` pointing at the old claim. In particular, look for old claims returned by `greplica graph context` that describe the changed area broadly but miss the new session nuance. A claim can be worth superseding even when the old text is not false, if it is now materially incomplete and future agents would be misled by leaving it active.
 
@@ -94,6 +180,7 @@ Do not store:
 - every implementation detail
 - command logs
 - secrets or environment variable values
+- raw curated-doc prose or copied sections that have not been distilled into memory
 - obvious local code facts that a future agent can read immediately
 - claims based only on vague conversation unless marked `unknown`
 
@@ -103,11 +190,20 @@ Do not stop at patch-visible facts. Also extract non-obvious session nuance: why
 
 Keep distinct durable memories distinct. "Small update" means no transcript junk or unnecessary implementation detail; it does not mean merging separate code facts, constraints, rationales, trade-offs, drift, tasks, and future work into one broad claim. If the session contains separate durable statements, create separate focused claims with the right claim kind and truth value.
 
-Preserve explicit negative or deferred decisions as first-class memory when they affect future work. Examples include "do not create code sources from code inspection", "proposal JSON remains the primitive", "a session ingest command was discussed but not built", "fixed eval fixtures should stay stable", and "compact shorthand still exists but no longer satisfies reasoned evidence validation".
+Preserve explicit negative or deferred decisions as first-class memory when they affect future work. Examples include rejecting an otherwise tempting artifact type as provenance, keeping an existing workflow primitive instead of adding a new command, discussing but not building an ingestion path, keeping pinned eval fixtures stable, or leaving a compatibility shorthand in place even though it no longer satisfies a stricter new contract by itself.
+
+Preserve "not yet built" and "out of scope for this slice" decisions separately from the implemented facts. If the session says a capability will require a later command, ingestion path, adapter, migration, protocol, or workflow, create a future-work/task claim rather than hiding it inside an implementation summary.
 
 Preserve terminology distinctions when confusion affected the task. For example, if the session distinguishes an evidence/source model from a similarly named ranking or retrieval signal, create a separate constraint or rationale so future agents do not conflate them.
 
 When the session refines a broad existing memory, store the refined rule and supersede the old broad claim. If the old memory said "validation enforces source kinds" and the session learned "validation now allows only session sources and every evidence edge needs a reason," the refined claim should supersede the broad one.
+
+Before final validation, do a missing-memory pass:
+
+- List the durable old behavior, new behavior, rejected approaches, deferred work, terminology distinctions, and process constraints from the session.
+- Check that each item is either represented by a focused claim, intentionally dropped for a clear reason, or superseded by a more precise claim.
+- Check that any claim narrowing or qualifying old memory uses `supersedes[]` structurally.
+- Check that session evidence is attached only to claims created or materially changed by this session, not to unchanged bootstrap facts.
 
 Avoid broad code-verified claims about entire skills or workflows unless every part was verified against the patch. Prefer narrower claims tied to exact code/doc changes, and keep rationale or policy from the transcript as separate source-verified claims.
 


### PR DESCRIPTION
## Summary
- require Greplica repo commands to run only after `greplica install`, removing the old `init` flow
- update bootstrap/update-working-memory skills for curated-doc ingestion, repo-level memory, explored-path context, and stricter noise pruning
- add the pinned `vercel/chat` curated-doc bootstrap eval and update skill eval harnesses to install current Codex skills in isolated eval homes

## Verification
- `npm run build`
- `npm run eval:bootstrap-current -- --agent codex --agent-model gpt-5.5 --judge openai` => 94.21 / 100
- `npm run eval:curated-doc-bootstrap-vercel-chat -- --agent codex --agent-model gpt-5.5 --judge openai` => 88.00 / 100
- `npm run eval:update-working-memory-source-evidence -- --agent-model gpt-5.5 --judge openai` => 90.03 / 100
- `git diff --check`