### PR TITLE
Fix graph view repo initialization

### DIFF
--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -101,7 +101,7 @@ export class KnowledgeGraphService {
   }
 
   buildGraphView(input: RepoRef): string {
-    const initialized = this.ensureInitialized(input);
+    const initialized = this.requireRepo(input);
     const graph = this.repository.readGraphView(initialized.repo_id);
     const provenance = this.repository.readClaimProvenance(initialized.repo_id);
     const supersededClaims = this.repository.readSupersededClaims(initialized.repo_id);


### PR DESCRIPTION
## Summary
- fix graph view generation to use the current repo installation guard
- replace the stale ensureInitialized call with requireRepo

## Test
- npm run typecheck