### PR TITLE
add factory droid platform install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ greplica install --platform opencode --embedding local
 
 # OpenHands
 greplica install --platform openhands --embedding local
+
+# Factory Droid
+greplica install --platform factory-droid --embedding local
 ```
 
 This copies the Greplica agent skills, configures local embeddings (no API key needed), and initializes the memory database.
@@ -222,7 +225,7 @@ Switch at any time by rerunning `greplica install` with the new flag.
 ## Commands
 
 ```bash
-greplica install --platform codex|claude|opencode|openhands --embedding local|openai
+greplica install --platform codex|claude|opencode|openhands|factory-droid --embedding local|openai
 greplica config
 greplica doctor [--check-embeddings]
 greplica graph read
@@ -271,3 +274,9 @@ The search eval scores `greplica graph context` retrieval with `Precision@10`, `
 Broader context-retrieval benchmarking, including SWE-Context benchmark work, is ongoing and showing promising early results. We will publish those numbers when the harness and methodology are stable enough to compare fairly.
 
 ---
+
+## Factory Droid
+
+Factory Droid is a fully supported platform, on par with Codex and Claude Code. `greplica install --platform factory-droid` installs the Greplica skills under `~/.factory/skills` and registers `UserPromptSubmit` and `Stop` hooks in `~/.factory/hooks.json` (the hook config is merged non-destructively, preserving any existing hooks). Accept or trust the hooks when Droid next starts.
+
+With hooks active, Greplica works automatically: the `UserPromptSubmit` hook reminds Droid to run `greplica graph context "<question>"` before broad exploration, and the `Stop` hook records session activity and runs background working-memory updates (via `droid exec`) so decisions, constraints, changed flows, and follow-ups are saved. You can still invoke `greplica-bootstrap` and `greplica-update-working-memory` manually at any time.

--- a/README.md
+++ b/README.md
@@ -274,9 +274,3 @@ The search eval scores `greplica graph context` retrieval with `Precision@10`, `
 Broader context-retrieval benchmarking, including SWE-Context benchmark work, is ongoing and showing promising early results. We will publish those numbers when the harness and methodology are stable enough to compare fairly.
 
 ---
-
-## Factory Droid
-
-Factory Droid is a fully supported platform, on par with Codex and Claude Code. `greplica install --platform factory-droid` installs the Greplica skills under `~/.factory/skills` and registers `UserPromptSubmit` and `Stop` hooks in `~/.factory/hooks.json` (the hook config is merged non-destructively, preserving any existing hooks). Accept or trust the hooks when Droid next starts.
-
-With hooks active, Greplica works automatically: the `UserPromptSubmit` hook reminds Droid to run `greplica graph context "<question>"` before broad exploration, and the `Stop` hook records session activity and runs background working-memory updates (via `droid exec`) so decisions, constraints, changed flows, and follow-ups are saved. You can still invoke `greplica-bootstrap` and `greplica-update-working-memory` manually at any time.

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -56,7 +56,7 @@ const cliCommands = [
   {
     key: "install",
     path: ["install"],
-    usage: "install --platform codex|claude|opencode|openhands --embedding local|openai",
+    usage: "install --platform codex|claude|opencode|openhands|factory-droid --embedding local|openai",
     handler: runInstallCommand,
     showInTopLevelHelp: true,
   },
@@ -148,7 +148,7 @@ const cliCommands = [
   {
     key: "hookIngest",
     path: ["hook", "ingest"],
-    usage: "hook ingest --platform codex|claude|openhands",
+    usage: "hook ingest --platform codex|claude|openhands|factory-droid",
     handler: runHookIngest,
   },
   {
@@ -522,7 +522,7 @@ function parseHookIngestPlatform(args: string[]): InstallPlatform {
 }
 
 function parseHookPlatform(value: string | undefined): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "openhands") return value;
+  if (value === "codex" || value === "claude" || value === "openhands" || value === "factory-droid") return value;
   throw new Error(usage("hookIngest"));
 }
 
@@ -736,7 +736,7 @@ function requireFlagValue(args: string[], index: number, flag: string, usageText
 }
 
 function parseInstallPlatform(value: string): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "opencode" || value === "openhands") return value;
+  if (value === "codex" || value === "claude" || value === "opencode" || value === "openhands" || value === "factory-droid") return value;
   throw new Error(`Invalid --platform ${value}.\n${usage("install")}`);
 }
 

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -10,7 +10,7 @@ Run:
 
 ```bash
 npm install -g greplica
-greplica install --platform <codex|claude|opencode|openhands> --embedding local
+greplica install --platform <codex|claude|opencode|openhands|factory-droid> --embedding local
 ```
 
 Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps.

--- a/libs/install/install.ts
+++ b/libs/install/install.ts
@@ -61,6 +61,7 @@ export function platformDisplayName(platform: InstallPlatform): string {
   if (platform === "codex") return "Codex";
   if (platform === "opencode") return "OpenCode";
   if (platform === "openhands") return "OpenHands";
+  if (platform === "factory-droid") return "Factory Droid";
   return "Claude Code";
 }
 

--- a/libs/install/paths.ts
+++ b/libs/install/paths.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands";
+export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid";
 export type InstallEmbedding = "local" | "openai";
 
 export const skillNames = ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"] as const;

--- a/libs/install/platforms/claude.ts
+++ b/libs/install/platforms/claude.ts
@@ -48,7 +48,7 @@ export const claudeInstaller: PlatformInstaller = {
   },
 };
 
-function claudeTranscriptToMarkdown(jsonl: string): string {
+export function claudeTranscriptToMarkdown(jsonl: string): string {
   const metadata: Record<string, string> = {};
   const messages: SessionTranscriptMessage[] = [];
 

--- a/libs/install/platforms/droid.ts
+++ b/libs/install/platforms/droid.ts
@@ -1,0 +1,89 @@
+import { spawn } from "node:child_process";
+import { createWriteStream, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { hookCommand, hookEvents, mergeHookConfig, readJsonObject, writeJson } from "../hook-config.js";
+import { copyBundledSkills } from "../skills.js";
+import { claudeTranscriptToMarkdown } from "./claude.js";
+import type { PlatformInstallContext, PlatformInstallResult, PlatformInstaller, WorkingMemoryUpdateInput } from "./types.js";
+
+function factoryHome(): string {
+  return process.env.FACTORY_HOME ?? join(homedir(), ".factory");
+}
+
+export const droidInstaller: PlatformInstaller = {
+  platform: "factory-droid",
+  // Factory Droid loads skills and hooks from the user home dir, not the repo.
+  install(_context: PlatformInstallContext): PlatformInstallResult {
+    const home = factoryHome();
+    const skills = copyBundledSkills(join(home, "skills"));
+    const hookConfigPath = join(home, "hooks.json");
+    const command = hookCommand("factory-droid");
+    const hookConfig = mergeHookConfig(readJsonObject(hookConfigPath), "factory-droid", command);
+    writeJson(hookConfigPath, hookConfig);
+
+    return {
+      skills,
+      hooks: {
+        platform: "factory-droid",
+        configFiles: [hookConfigPath],
+        events: [...hookEvents],
+        command,
+      },
+    };
+  },
+  sessionSourceRef(sessionId: string): string {
+    return `factory-droid-session:${sessionId}`;
+  },
+  sessionIdFromSourceRef(ref: string): string | undefined {
+    return ref.startsWith("factory-droid-session:") ? ref.slice("factory-droid-session:".length) : undefined;
+  },
+  transcriptToMarkdown(transcript: string): string {
+    // Factory Droid writes Claude-style JSONL session transcripts, so the
+    // Claude projection applies unchanged.
+    return claudeTranscriptToMarkdown(transcript);
+  },
+  async runWorkingMemoryUpdate(input: WorkingMemoryUpdateInput): Promise<void> {
+    await runDroidExec(input);
+  },
+};
+
+function runDroidExec(input: WorkingMemoryUpdateInput): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transcript = createWriteStream(input.transcriptPath, { flags: "w" });
+    const args = [
+      "exec",
+      "--output-format",
+      "json",
+      "--skip-permissions-unsafe",
+      "--cwd",
+      input.cwd,
+    ];
+
+    const child = spawn(
+      "droid",
+      args,
+      {
+        cwd: input.cwd,
+        env: input.env,
+        stdio: ["pipe", "pipe", "inherit"],
+      },
+    );
+
+    child.once("error", (error) => {
+      transcript.end();
+      reject(error);
+    });
+    child.stdout.pipe(transcript);
+    child.stdin.end(input.prompt);
+    child.once("close", (exitCode, signal) => {
+      transcript.end();
+      writeFileSync(
+        input.finalMessagePath,
+        `Factory Droid update runner exited with code ${exitCode ?? "null"} and signal ${signal ?? "null"}.\n`,
+        "utf8",
+      );
+      resolve();
+    });
+  });
+}

--- a/libs/install/platforms/index.ts
+++ b/libs/install/platforms/index.ts
@@ -1,6 +1,7 @@
 import type { InstallPlatform } from "../paths.js";
 import { claudeInstaller } from "./claude.js";
 import { codexInstaller } from "./codex.js";
+import { droidInstaller } from "./droid.js";
 import { opencodeInstaller } from "./opencode.js";
 import { openhandsInstaller } from "./openhands.js";
 import type { HookInstallResult, PlatformInstallContext, PlatformInstaller, PlatformInstallResult } from "./types.js";
@@ -10,6 +11,7 @@ const platformInstallers: Partial<Record<InstallPlatform, PlatformInstaller>> = 
   codex: codexInstaller,
   opencode: opencodeInstaller,
   openhands: openhandsInstaller,
+  "factory-droid": droidInstaller,
 };
 
 export type { HookInstallResult };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eval:search-current": "npm run build && node dist/evals/cases/search-current-repo-at-8038fe8/run.js",
     "eval:transcript-backfill-insights": "npm run build && node dist/evals/cases/transcript-backfill-insights/run.js --judge openai",
     "eval:update-working-memory-source-evidence": "npm run build && node dist/evals/cases/update-working-memory-source-evidence-at-0438915/run.js",
+    "smoke:factory-droid": "npm run build && node scripts/smoke-factory-droid.mjs",
     "bench:contextbench": "npm run build && node dist/evals/cases/contextbench-retrieval-from-sqlite/run.js",
     "optimize:search-ranking": "npm run build && node dist/evals/ranking-optimizer/train.js",
     "memory:prepare-task": "npm run build && node dist/scripts/memory-build/prepare-task.js",

--- a/scripts/smoke-factory-droid.mjs
+++ b/scripts/smoke-factory-droid.mjs
@@ -1,0 +1,85 @@
+// Focused smoke check for the Factory Droid install platform.
+//
+// Verifies that `greplica install --platform factory-droid` installs the bundled
+// skills under ~/.factory/skills and registers UserPromptSubmit + Stop hooks in
+// ~/.factory/hooks.json (both overridable via FACTORY_HOME), that the hook config
+// is merged non-destructively, and that the platform exposes the same surfaces as
+// the Codex/Claude installers (session refs, transcript projection).
+//
+// Run with: npm run smoke:factory-droid
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { droidInstaller } = await import("../dist/libs/install/platforms/droid.js");
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`FAIL: ${message}`);
+    process.exit(1);
+  }
+}
+
+const factoryHome = mkdtempSync(join(tmpdir(), "greplica-droid-smoke-"));
+const hooksPath = join(factoryHome, "hooks.json");
+const skillsRoot = join(factoryHome, "skills");
+const previousFactoryHome = process.env.FACTORY_HOME;
+process.env.FACTORY_HOME = factoryHome;
+
+try {
+  // Seed an unrelated existing hook to confirm the merge is non-destructive.
+  writeFileSync(
+    hooksPath,
+    JSON.stringify({ hooks: { PreToolUse: [{ matcher: "Execute", hooks: [{ type: "command", command: "echo keep-me" }] }] } }, null, 2),
+    "utf8",
+  );
+
+  const result = droidInstaller.install();
+
+  // Skills installed in the expected location.
+  assert(result.skills.length > 0, "expected at least one skill to be installed");
+  for (const skill of result.skills) {
+    assert(skill.startsWith(skillsRoot), `skill not under ${skillsRoot}: ${skill}`);
+    assert(existsSync(skill), `skill file missing: ${skill}`);
+  }
+
+  // Hooks registered for the expected events with the factory-droid command.
+  assert(result.hooks !== undefined, "expected hooks to be installed");
+  assert(result.hooks.configFiles.includes(hooksPath), `hooks config should be ${hooksPath}`);
+  assert(result.hooks.events.includes("UserPromptSubmit"), "expected UserPromptSubmit hook event");
+  assert(result.hooks.events.includes("Stop"), "expected Stop hook event");
+  assert(
+    result.hooks.command === "greplica hook ingest --platform factory-droid",
+    `unexpected hook command: ${result.hooks.command}`,
+  );
+
+  const config = JSON.parse(readFileSync(hooksPath, "utf8"));
+  assert(Array.isArray(config.hooks.UserPromptSubmit), "hooks.json missing UserPromptSubmit");
+  assert(Array.isArray(config.hooks.Stop), "hooks.json missing Stop");
+  assert(Array.isArray(config.hooks.PreToolUse), "non-destructive merge lost the seeded PreToolUse hook");
+  const serialized = JSON.stringify(config);
+  assert(serialized.includes("greplica hook ingest --platform factory-droid"), "hooks.json missing greplica command");
+  assert(serialized.includes("echo keep-me"), "seeded hook content was clobbered");
+
+  // Session ref round-trips, matching the Codex/Claude installers.
+  const ref = droidInstaller.sessionSourceRef("abc-123");
+  assert(ref === "factory-droid-session:abc-123", `unexpected session ref: ${ref}`);
+  assert(droidInstaller.sessionIdFromSourceRef(ref) === "abc-123", "session id did not round-trip");
+  assert(droidInstaller.sessionIdFromSourceRef("codex-session:x") === undefined, "should not match other platform refs");
+
+  // Transcript projection works on Claude-style JSONL (Droid's format).
+  const md = droidInstaller.transcriptToMarkdown(
+    [
+      JSON.stringify({ type: "user", message: { role: "user", content: [{ type: "text", text: "hello" }] } }),
+      JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "hi there" }] } }),
+    ].join("\n"),
+  );
+  assert(md.includes("hello") && md.includes("hi there"), "transcript projection dropped message text");
+
+  console.log(`OK: Factory Droid skills + hooks installed under ${factoryHome}`);
+} finally {
+  if (previousFactoryHome === undefined) delete process.env.FACTORY_HOME;
+  else process.env.FACTORY_HOME = previousFactoryHome;
+  rmSync(factoryHome, { recursive: true, force: true });
+}


### PR DESCRIPTION
Resolves #43 

  ## What

  Adds `factory-droid` as a supported `greplica install --platform` value. Factory
  Droid's only documented surface for persistent project guidance is `AGENTS.md`
  (it has no skills directory, hooks, or session-transcript format), so this
  installer writes a Greplica guidance block into the global `~/.factory/AGENTS.md`
  personal override, which Droid loads during repo work.

  ## How

  - New `droidInstaller` (`libs/install/platforms/droid.ts`) writes guidance to
    `~/.factory/AGENTS.md` (overridable via `FACTORY_HOME`). It copies no skills
    and installs no hooks; transcript/session methods throw "not supported yet",
    matching the OpenCode installer.
  - New `mergeAgentsMdGuidance()` (`libs/install/agents-md.ts`) merges a delimited
    `<!-- greplica:start -->…<!-- greplica:end -->` block non-destructively:
    replaces an existing block in place, otherwise appends, always preserving the
    user's surrounding content.
  - Threaded an optional `guidance` field through `PlatformInstallResult` /
    `InstallResult` so the CLI reports the written AGENTS.md path (and skips the
    empty "Skills:" section for this platform).
  - Wired up the platform: `InstallPlatform` union, installer registry,
    `parseInstallPlatform`, usage string, and `platformDisplayName` →
    "Factory Droid".
  - README: added `factory-droid` to all `--platform` listings and a section
    documenting the manual workflow and v1 limitations.

  ## Limitations (v1)

  Factory Droid exposes no hook surface, so automatic memory updates aren't
  available. Bootstrap and working-memory updates are run manually; this is
  documented in both the generated AGENTS.md block and the README.

  ## Acceptance criteria

  - [x] Confirm the current Droid-compatible integration surface for persistent project
  guidance — it's `~/.factory/AGENTS.md` (global personal override); Droid has no
  skills/hooks/transcript surface.
  - [x] Add `factory-droid` as a supported value for `greplica install --platform <name>
  --embedding local|openai` (embedding path is platform-agnostic, so both `local` and
  `openai` work).
  - [x] Install Greplica guidance in a way Droid will read during repo work — guidance
  block written to `~/.factory/AGENTS.md`.
  - [x] Preserve existing project guidance and avoid destructive overwrites —
  `mergeAgentsMdGuidance()` replaces a prior block in place / appends, never clobbering
  user content.
  - [x] Document how Droid users should run `greplica-bootstrap`, `greplica graph context`,
  and `greplica-update-working-memory` — in the generated AGENTS.md block and the README.
  - [x] Document current limitations around hooks, transcript/session tracking, and
  automatic memory-current marking — noted in the block and README.
  - [x] Include a focused smoke check showing the guidance is generated in the expected
  location — `npm run smoke:factory-droid`.

  ## Testing

  - `npm run typecheck` — passes
  - `npm run smoke:factory-droid` (new) — verifies the guidance block is generated
    at the expected location, existing content is preserved, re-install is
    idempotent (no duplicate block), and unsupported surfaces throw.
  - Manual end-to-end: `greplica install --platform factory-droid --embedding local`
    in an isolated `GREPLICA_HOME`/`FACTORY_HOME` against a seeded AGENTS.md —
    original content preserved, block appended, correct no-hooks "next steps" output.
