### PR TITLE
Tighten onboarding output and session selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ Ask your agent to find 1-3 recent prior sessions for this repo and show you the 
 
 Candidate locations:
 
-- Codex: `~/.codex/sessions/**/*.jsonl`; prefer transcripts whose metadata `cwd` matches this repo.
-- Claude Code: `~/.claude/projects/<sanitized-current-cwd>/*.jsonl`; if needed, fall back to `~/.claude/projects/**/*.jsonl` and filter by transcript metadata `cwd`.
+- Codex: `~/.codex/sessions/**/*.jsonl`.
+- Claude Code: search both `~/.claude/projects/<sanitized-current-cwd>/*.jsonl` and `~/.claude/projects/**/*.jsonl`.
+- Same-repo matching should handle worktrees and renamed folders. Prefer exact metadata `cwd` matches, but also accept transcripts whose metadata `cwd` still exists and has the same Git `remote.origin.url` or normalized repo identity as the current repo. If the old path no longer exists, use cwd text, repo name, branch, and recent session content as weaker matching evidence.
 - OpenCode: transcript backfill is not supported yet.
 
 Bundle them:

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -567,42 +567,28 @@ function parseInstallEmbedding(value: string): InstallEmbedding {
 
 function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>): void {
   console.log(`Installed Greplica for ${platformDisplayName(result.platform)}.`);
-  console.log("");
-  console.log("Skills:");
-  for (const skill of result.skills) console.log(`- ${skill}`);
-  console.log("");
+  console.log(`Skills: ${result.skills.length} installed.`);
   if (result.hooks !== undefined) {
-    console.log("Hooks:");
-    console.log(`- events: ${result.hooks.events.join(", ")}`);
-    console.log(`- command: ${result.hooks.command}`);
-    for (const configFile of result.hooks.configFiles) console.log(`- config: ${configFile}`);
-    console.log("- note: your agent may ask you to trust or accept these hooks the next time it starts.");
-    console.log("");
+    console.log(`Hooks: installed for ${result.hooks.events.join(", ")}.`);
+  } else {
+    console.log("Hooks: not installed for this platform.");
   }
-  console.log("Embedding:");
-  console.log(`- ${result.embedding}`);
-  console.log(`- config: ${result.configFile}`);
-  console.log(`- database: ${result.databasePath}`);
-  console.log(`- session stop threshold: ${result.session.stopThreshold}`);
-  console.log(`- session time threshold: ${result.session.timeThresholdMinutes} minutes`);
-  console.log(`- session current grace: ${result.session.currentGraceMinutes} minutes`);
+  console.log(`Embedding: ${result.embedding}.`);
+  console.log(`Config: ${result.configFile}`);
+  console.log(`Database: ${result.databasePath}`);
   console.log("");
   console.log("Next steps:");
   console.log("- Restart your coding agent if the new skills or hooks do not appear immediately.");
   if (result.hooks !== undefined) {
-    console.log("- Accept or trust the installed hooks if your agent asks. Hook dispatchers ignore repos where greplica install was not run.");
-    console.log("- Hooks record session activity and attempt background working-memory updates for this repo.");
-    console.log("- If you do not accept the hooks, background saves will not run; manually ask the agent to use greplica-update-working-memory near the end of useful sessions.");
+    console.log("- Accept or trust the installed hooks if your agent asks.");
   } else {
-    console.log("- Hooks were not installed for this platform. Manually ask the agent to use greplica-update-working-memory near the end of useful sessions.");
+    console.log("- Ask the agent to use greplica-update-working-memory near the end of useful sessions.");
   }
-  console.log("- Add a short AGENTS.md/CLAUDE.md instruction if hooks are unavailable or not accepted: use greplica graph context \"<question>\" before broad manual exploration.");
   console.log("- Ask the agent to use greplica-bootstrap once for repos that do not have memory yet.");
-  console.log("- During work, the agent can run greplica graph context \"<question>\" to fetch relevant repo memory.");
   if (result.embedding === "local") {
-    console.log(`- OpenAI embeddings are also available if you want better retrieval quality later: greplica install --platform ${result.platform} --embedding openai`);
+    console.log(`- Optional later: greplica install --platform ${result.platform} --embedding openai`);
   } else {
-    console.log(`- Local embeddings are also available if you want to switch back later: greplica install --platform ${result.platform} --embedding local`);
+    console.log(`- Optional later: greplica install --platform ${result.platform} --embedding local`);
   }
   for (const note of result.notes) console.log(`- ${note}`);
 }

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -10,7 +10,7 @@ npm install -g greplica
 greplica install --platform <codex|claude|opencode> --embedding local
 ```
 
-Use the platform matching this agent. Do not manually copy skills. After installation, summarize the installer output, including skills, embedding mode, whether hooks were installed, and whether I need to restart or trust hooks.
+Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps. Give only a compact status line: platform, embedding mode, whether hooks were installed, and whether I may need to restart or trust hooks.
 
 Before running any command, ask me one question:
 "Allow Greplica to learn from your past sessions to show what it can learn?"
@@ -57,5 +57,5 @@ One correction I will remember
 ```
 
 Then tell me how to use Greplica:
-- IMPORTANT: tell me that hooks and installed skills are the primary integration. Add a short AGENTS.md or CLAUDE.md instruction only if hooks are unavailable, not accepted, or I want extra repo-local guidance.
+- Keep this to one sentence: hooks and installed skills are the primary integration; add repo-local AGENTS.md or CLAUDE.md guidance only if hooks are unavailable, not accepted, or I want extra guidance.
 `````

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -26,8 +26,11 @@ After I answer, run the install commands above, then bootstrap shallow memory fo
 If I opted into prior-session learning:
 - Find recent prior sessions for this same repo and platform, preferring work from the last 1-2 days.
 - Candidate locations: Codex `~/.codex/sessions/**/*.jsonl`; Claude Code `~/.claude/projects/**/*.jsonl`.
+- Do not require transcript metadata `cwd` to equal the current checkout path. Users may use worktrees, renamed folders, or multiple checkouts of the same repo.
+- Treat a transcript as same-repo when its metadata `cwd` is the current path, or when that `cwd` still exists and Git reports the same `remote.origin.url` or same normalized repo identity as the current repo. If the old path no longer exists, use transcript cwd text, repo name, branch, and recent session content as weaker matching evidence.
 - For OpenCode, tell me transcript backfill is not supported yet.
 - Select 1-3 transcripts. Use one if there is a large high-signal session, two by default when multiple sessions are useful, and three only when sessions are smaller or cover distinct work.
+- Show me the selected transcripts before bundling them: title if available, date/time, path, size/turn count if available, and why each matched this repo.
 - Since I already opted in, continue without asking a second confirmation and run:
 
 ```bash

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -10,7 +10,7 @@ npm install -g greplica
 greplica install --platform <codex|claude|opencode> --embedding local
 ```
 
-Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps. Give only a compact status line: platform, embedding mode, whether hooks were installed, and whether I may need to restart or trust hooks.
+Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps.
 
 Before running any command, ask me one question:
 "Allow Greplica to learn from your past sessions to show what it can learn?"
@@ -21,7 +21,7 @@ After I answer, run the install commands above, then bootstrap shallow memory fo
 - Prefer using the `greplica-bootstrap` skill.
 - If the skill is not visible until restart, read the installed `greplica-bootstrap/SKILL.md` file and follow it directly.
 - Create, validate, and apply the bootstrap proposal.
-- Keep bootstrap output brief: give a one-sentence summary of what this repo does and say baseline memory was applied.
+- Keep bootstrap output for the final answer to one line: `Greplica is installed and baseline memory was applied.`
 
 If I opted into prior-session learning:
 - Find recent prior sessions for this same repo and platform, preferring work from the last 1-2 days.
@@ -31,14 +31,14 @@ If I opted into prior-session learning:
 - For OpenCode, tell me transcript backfill is not supported yet.
 - Select 1-3 transcripts. Use one if there is a large high-signal session, two by default when multiple sessions are useful, and three only when sessions are smaller or cover distinct work.
 - Show me the selected transcripts before bundling them: title if available, date/time, path, size/turn count if available, and why each matched this repo.
-- Since I already opted in, continue without asking a second confirmation and run:
+- Since I already opted in, continue without asking a second confirmation and run this with a temporary bundle path:
 
 ```bash
 greplica transcript bundle --platform <codex-or-claude> --file <path-1> [--file <path-2>] [--file <path-3>] --out <greplica-transcript-backfill.md>
 ```
 
 - Then use the `greplica-fast-session-bootstrap` skill on `<greplica-transcript-backfill.md>`.
-- After apply, show one important flow/component Greplica can now reconstruct without broad grepping. Include the optional correction section only if there is a strong repo-specific user correction or risk/gotcha:
+- After apply, preserve this transcript-backfill value section in the final answer. Include the optional correction section only if there is a strong repo-specific user correction or risk/gotcha:
 
 ```markdown
 Applied transcript backfill to working memory.
@@ -56,6 +56,9 @@ One correction I will remember
 <Only include this section if there is a strong user correction tied to a repo-specific risk/gotcha. Explain what the agent would otherwise get wrong and what will be considered next time.>
 ```
 
-Then tell me how to use Greplica:
-- Keep this to one sentence: hooks and installed skills are the primary integration; add repo-local AGENTS.md or CLAUDE.md guidance only if hooks are unavailable, not accepted, or I want extra guidance.
+Final answer rules:
+- Start with exactly: `Greplica is installed and baseline memory was applied.`
+- If transcript backfill ran, include the transcript-backfill value section above unchanged.
+- End with exactly: `Hooks and installed skills are active; restart/trust hooks only if prompted.`
+- Do not include installer output, selected transcript recap, proposal paths, apply counts, command lists, bundle paths, or a long usage guide unless I ask.
 `````

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greplica",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greplica",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "hasInstallScript": true,
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greplica",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Long-term, searchable AGENTS.md for coding agents.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
- make prior-session selection work better across worktrees / moved repo paths
- compact installer and final onboarding output while preserving the transcript-backfill value section
- bump package version to 0.1.6 and tag v0.1.6

## Validation
- npm run typecheck
- npm run test:transcript-bundle