### PR TITLE
feat: show trust evidence in graph context

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,31 +78,28 @@ Running `greplica graph context "how does proposal apply work?"` outputs:
 ```markdown
 # Graph Context
 
-Query: how does proposal apply work?
+## Best Claims
 
-## Components
+### 1. claim.apply_validates_before_writing
 
-- `component.knowledge_graph_service` Knowledge Graph Service
-  Anchor: `libs/knowledge-graph/service.ts`
-- `component.sqlite_repository` SQLite Repository
-  Anchor: `libs/storage/sqlite/repository.ts`
+applyProposal validates the proposal before writing any records.
 
-## Flows
+Trust: fact | code_verified | intended.
 
-### Proposal Apply
+Anchor: `libs/knowledge-graph/service.ts:105-138#applyProposal`. About: flow Proposal Apply.
 
-ID: `flow.proposal_apply`
+Evidence: session Bootstrap run (`codex-session:abc`) - captured the validated apply workflow.
 
-Claims:
-- `claim.apply_validates_before_writing` (fact, code_verified): applyProposal validates the proposal before writing any records.
-- `claim.memory_commits_chain_with_parent` (fact, code_verified): Each memory commit stores a reference to its predecessor.
+## Related Components
 
-## Other Relevant Claims
+- 1. Knowledge Graph Service. ID: `component.knowledge_graph_service`. Anchor: `libs/knowledge-graph/service.ts`. Supporting claims: `claim.apply_validates_before_writing`.
 
-- `claim.apply_prints_commit_scope_and_counts` (fact, code_verified): proposal apply prints the memory commit ID, scope ID, and created object counts.
+## Related Flows
+
+- 1. Proposal Apply. ID: `flow.proposal_apply`. Supporting claims: `claim.apply_validates_before_writing`.
 ```
 
-The agent gets the relevant file anchors, the decision trail, and the constraints - without reading the whole codebase.
+The agent gets the relevant file anchors, trust metadata, evidence, the decision trail, and the constraints - without reading the whole codebase.
 
 ---
 

--- a/libs/knowledge-graph/graph-context/render.ts
+++ b/libs/knowledge-graph/graph-context/render.ts
@@ -58,14 +58,19 @@ function renderRankedClaims(
 ): string[] {
   if (claims.length === 0) return ["- None."];
   return claims.flatMap((claim, index) => {
+    const trust = `Trust: ${claim.object.kind} | ${claim.object.truth} | ${claim.object.intent}.`;
     const anchors = claim.code_anchors.length === 0 ? "" : ` Anchor: ${claim.code_anchors.map(anchorLabel).join("; ")}.`;
     const about = aboutLabel(claim.about, componentsById, flowsById);
+    const detail = `${anchors}${about}`.trim();
+    const evidence = evidenceLabel(claim.evidence);
     return [
       `### ${index + 1}. ${claim.object.id}`,
       "",
       claim.object.text,
       "",
-      `${anchors}${about}`.trim(),
+      trust,
+      ...(detail.length === 0 ? [] : ["", detail]),
+      ...(evidence.length === 0 ? [] : [evidence]),
       "",
     ];
   });
@@ -94,6 +99,22 @@ function aboutLabel(
     return `flow ${flowsById.get(target.id) ?? target.id}`;
   });
   return ` About: ${labels.join("; ")}.`;
+}
+
+function evidenceLabel(evidence: Extract<RankedGraphContextResult, { type: "claim" }>["evidence"]): string {
+  if (evidence.length === 0) return "";
+  return `Evidence: ${evidence.map(evidenceItemLabel).join("; ")}.`;
+}
+
+function evidenceItemLabel(evidence: Extract<RankedGraphContextResult, { type: "claim" }>["evidence"][number]): string {
+  const label = sourceLabel(evidence.source);
+  const reason = evidence.reason.trim();
+  return reason.length === 0 ? label : `${label} - ${reason}`;
+}
+
+function sourceLabel(source: Extract<RankedGraphContextResult, { type: "claim" }>["evidence"][number]["source"]): string {
+  if (source.title === undefined || source.title === source.ref) return `${source.kind} \`${source.ref}\``;
+  return `${source.kind} ${source.title} (\`${source.ref}\`)`;
 }
 
 function lines(...values: string[]): string {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
+    "test:graph-context-render": "npm run build && node scripts/check-graph-context-render.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",
     "eval:coding-proposal-apply-atomicity": "npm run build && node dist/evals/cases/coding-proposal-apply-atomicity-at-d6ebf80/run.js",
     "eval:curated-doc-bootstrap-vercel-chat": "npm run build && node dist/evals/cases/curated-doc-bootstrap-vercel-chat-at-f3de128/run.js",

--- a/scripts/check-graph-context-render.js
+++ b/scripts/check-graph-context-render.js
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+
+const root = new URL("..", import.meta.url);
+const { renderGraphContextMarkdown } = await import(new URL("dist/libs/knowledge-graph/graph-context/render.js", root));
+
+const signals = {
+  semantic_score: 1,
+  semantic_raw_score: 1,
+  semantic_rank: 1,
+  bm25_score: 0,
+  bm25_raw_score: 0,
+  bm25_rank: null,
+  weighted_score: 1,
+  weighted_raw_score: 1,
+  pre_coherence_score: 1,
+  graph_score: 0,
+  graph_raw_score: 0,
+  graph_sources: [],
+  coherence_score: 1,
+  coherence_raw_score: 1,
+  coherence_sources: [],
+};
+
+const component = {
+  rank: 1,
+  score: 1,
+  context_relation: "primary",
+  direct_score: 1,
+  direct_raw_score: 1,
+  claim_support_score: 1,
+  claim_support_raw_score: 1,
+  signals,
+  object: {
+    id: "component.renderer",
+    name: "Graph context renderer",
+    code_anchor: "libs/knowledge-graph/graph-context/render.ts",
+  },
+  matched_claim_ids: ["claim.render_trust"],
+};
+
+const flow = {
+  rank: 1,
+  score: 1,
+  context_relation: "primary",
+  direct_score: 1,
+  direct_raw_score: 1,
+  claim_support_score: 1,
+  claim_support_raw_score: 1,
+  signals,
+  object: {
+    id: "flow.graph_context",
+    name: "Graph context rendering",
+  },
+  matched_claim_ids: ["claim.render_trust"],
+};
+
+const verifiedClaim = {
+  type: "claim",
+  rank: 1,
+  score: 1,
+  signals,
+  object: {
+    id: "claim.render_trust",
+    kind: "fact",
+    text: "Graph context output includes trust metadata for each retrieved claim.",
+    truth: "code_verified",
+    intent: "intended",
+  },
+  about: [
+    { type: "component", id: "component.renderer" },
+    { type: "flow", id: "flow.graph_context" },
+  ],
+  evidence: [
+    {
+      source: {
+        id: "source.codex_session.abc",
+        kind: "session",
+        ref: "codex-session:abc",
+        title: "Renderer design session",
+      },
+      reason: "captured the user-approved provenance display requirement",
+    },
+  ],
+  code_anchors: [
+    {
+      status: "resolved",
+      file: "libs/knowledge-graph/graph-context/render.ts",
+      symbol: "renderGraphContextMarkdown",
+      start_line: 1,
+      end_line: 12,
+    },
+  ],
+};
+
+const unknownClaim = {
+  type: "claim",
+  rank: 2,
+  score: 0.7,
+  signals,
+  object: {
+    id: "claim.future_work",
+    kind: "question",
+    text: "Should graph context eventually support trust-aware reranking?",
+    truth: "unknown",
+    intent: "unknown",
+  },
+  about: [],
+  evidence: [],
+  code_anchors: [],
+};
+
+const markdown = renderGraphContextMarkdown({
+  query: "trust output",
+  search_config_version: "test",
+  embedding_status: {
+    checked_objects: 0,
+    created: 0,
+    reused: 0,
+  },
+  claims: [verifiedClaim, unknownClaim],
+  components: [component],
+  flows: [flow],
+  ranked_results: [
+    verifiedClaim,
+    unknownClaim,
+    { type: "component", ...component },
+    { type: "flow", ...flow },
+  ],
+  sources: [verifiedClaim.evidence[0].source],
+});
+
+assert.match(markdown, /Trust: fact \| code_verified \| intended\./);
+assert.match(markdown, /Trust: question \| unknown \| unknown\./);
+assert.match(markdown, /Anchor: `libs\/knowledge-graph\/graph-context\/render.ts:1-12#renderGraphContextMarkdown`\./);
+assert.match(markdown, /About: component Graph context renderer; flow Graph context rendering\./);
+assert.match(
+  markdown,
+  /Evidence: session Renderer design session \(`codex-session:abc`\) - captured the user-approved provenance display requirement\./,
+);
+
+console.log("Graph context render checks passed.");


### PR DESCRIPTION
## Summary

Graph context output now carries the trust metadata agents need at recall time: every rendered claim shows its kind, truth, and intent, and claims with evidence include the source title/ref plus the `evidenced_by` reason. This keeps Greplica's existing graph model intact while making retrieved memory easier to trust, verify, or treat as tentative.

## Design Notes

The change follows the project's existing architecture: the context builder already returns claim metadata and evidence, so the renderer exposes those fields compactly instead of adding new storage or retrieval behavior.

## Validation

- `npm run test:graph-context-render`
- `npm run typecheck`
- `npm run test:transcript-bundle`

Closes Autoloops/greplica#60.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
