### PR TITLE
Make transcript backfill output skill-owned

### DIFF
--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -35,23 +35,12 @@ After baseline memory is applied, analyze prior sessions by default:
 greplica transcript bundle --platform <codex-or-claude> --file <path-1> [--file <path-2>] [--file <path-3>] --out <greplica-transcript-backfill.md>
 ```
 
-- Then use the `greplica-fast-session-bootstrap` skill on `<greplica-transcript-backfill.md>`.
-- After apply, preserve this transcript-backfill value section in the final answer. Include the optional correction section only if there is a strong repo-specific user correction or risk/gotcha:
-
-```markdown
-Here is a snippet of what I learned from your sessions:
-
-** About <flow or component name>**
-- <specific workflow/component fact Greplica stored in simple language>
-- <specific constraint, decision, or edge in the flow in simple language>
-
-<Only include this section if there is a strong user correction tied to a repo-specific risk or constraint. Explain what will we considered from the next time.>
-```
+- Then use the `greplica-fast-session-bootstrap` skill on `<greplica-transcript-backfill.md>` and include its final value summary naturally in the final answer.
 
 Final answer rules:
 - Write like you are updating a human, not filling a template.
 - Start by saying Greplica is installed and baseline memory is ready.
-- If transcript backfill ran, include the transcript-backfill value section above, but keep the wording natural.
+- If transcript backfill ran, include the `greplica-fast-session-bootstrap` final value summary naturally.
 - End with a short note that hooks and installed skills might need a restart.
 - Do not include installer output, selected transcript recap, proposal paths, apply counts, command lists, bundle paths, or a long usage guide unless I ask.
 `````

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greplica",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greplica",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "hasInstallScript": true,
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greplica",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "description": "Long-term, searchable AGENTS.md for coding agents.",
   "private": false,
   "type": "module",

--- a/skills/greplica-fast-session-bootstrap/SKILL.md
+++ b/skills/greplica-fast-session-bootstrap/SKILL.md
@@ -81,24 +81,24 @@ Allowed values:
 3. Fix validation errors.
 4. Run `greplica proposal apply <proposal-file>`.
 
+After `greplica proposal apply <proposal-file>` exits successfully, stop. The apply command is the final validation and write gate.
+
+Do not run extra proof or cleanup commands after successful apply, including `greplica proposal validate`, `greplica graph read`, `greplica graph context`, `greplica graph audit anchors`, tests, or a second apply, unless the user explicitly asks. Produce the final value summary from the proposal you just applied.
+
 ## Final Output
 
 Output only this shape:
 
 ```markdown
-Applied transcript backfill to working memory.
+Here is a small snippet of what I learned from your sessions:
 
-What I can now reconstruct without grepping
+** About <flow or component name>**
+- <specific workflow/component fact Greplica stored in simple language>
+- <specific constraint, decision, or edge in the flow in simple language>
 
-**<flow/component name>**
-- <specific fact Greplica stored about the flow/component>
-- <specific decision, constraint, or risk>
+<Only include this section if there is a strong user correction tied to a repo-specific risk or constraint. Explain what will we considered from the next time.>
 
-Stored in my graph. Next time, ask `greplica graph context "<topic>"`; no grep reconstruction needed.
-
-One correction I will remember
-
-<Include only if strong. State what a future agent might get wrong and what this memory will make it consider next time.>
+From next time I will use Greplica to get this context directly, without having to grep all over your files.
 ```
 
 Omit the correction section when it is weak. Do not include evidence lines, apply counts, or a three-memory list.


### PR DESCRIPTION
Updates the Greplica install prompt so it only orchestrates transcript backfill and delegates final value output to the fast-session-bootstrap skill.\n\nAdds an apply-success stop rule to the fast session bootstrap skill so agents stop after a successful proposal apply instead of running extra proof commands.\n\nMoves the corrected transcript-backfill value wording into the skill, keeping it as the single source of truth.\n\nBumps the package to v0.1.8 for publish.