### PR TITLE
Add AgentMemory coding-agent-life-v1 benchmark (MVP)

### DIFF
--- a/evals/cases/agentmemory-coding-life/DOCS.md
+++ b/evals/cases/agentmemory-coding-life/DOCS.md
@@ -1,0 +1,98 @@
+# AgentMemory coding-agent-life-v1 benchmark (MVP)
+
+This benchmark runs the `coding-agent-life-v1` recall corpus as a coding-agent QA task
+and compares two arms:
+
+
+| Arm            | What the agent gets                                                      | Purpose                                      |
+| -------------- | ------------------------------------------------------------------------ | -------------------------------------------- |
+| `full-context` | All 15 session logs pasted into the prompt                               | Ceiling: everything in context, no retrieval |
+| `greplica`     | A seeded greplica memory; the agent runs `greplica graph context` itself | Greplica as an autonomous memory tool        |
+
+
+For every query the agent produces a final answer, and a judge (OpenAI or Anthropic)
+grades that answer against the gold answer (pass/fail). The benchmark records pass rate
+plus token, tool-call, and latency cost per arm.
+
+The answering agent can be either **Codex** (`--agent codex`, default) or **Claude Code**
+(`--agent claude`). In the `greplica` arm the chosen agent runs `greplica graph context`
+itself; greplica is installed for the matching platform (`install --platform codex|claude`).
+
+This uses the dataset purely as a shared question/answer corpus. It does **not** compare
+against AgentMemory's published numbers. (A question-only `cold` floor was dropped: the
+corpus describes a fictional project, so a no-context model trivially scores 0 — it
+confirms the questions aren't guessable but adds no signal about greplica.)
+
+## Prerequisites
+
+- `npm run build` (done automatically by the npm script).
+- The answering-agent CLI installed and authenticated:
+  - `--agent codex` (default): the `codex` CLI (OpenAI models).
+  - `--agent claude`: the `claude` (Claude Code) CLI with `ANTHROPIC_API_KEY` set (or
+  whatever auth the local `claude` CLI is configured with). `ANTHROPIC_API_KEY` is read
+  from `.env.local`/`.env` or the environment.
+- A judge API key: `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. The provider is auto-selected
+(OpenAI preferred when both keys are present); force one with `--judge openai|anthropic`.
+So if you only have `ANTHROPIC_API_KEY`, Claude is used for both answering and judging.
+Without any judge key, answers are still collected but every row is left unjudged
+(`pass = null`). The judge is independent of the answering agent.
+- Greplica retrieval uses **local embeddings by default** (`--embedding local`), so the
+greplica arm needs no OpenAI key for retrieval.
+
+## Run
+
+```bash
+npm run bench:agentmemory-coding-life
+```
+
+Common options (pass after `--`):
+
+```bash
+# only some arms
+npm run bench:agentmemory-coding-life -- --arms greplica
+
+# a quick smoke test on a few queries
+npm run bench:agentmemory-coding-life -- --limit 2
+
+# specific queries, explicit models, openai embeddings
+npm run bench:agentmemory-coding-life -- --queries q-001,q-011 --agent-model gpt-5.4-mini --judge-model gpt-5.4 --embedding openai
+
+# answer with Claude Code instead of Codex
+npm run bench:agentmemory-coding-life -- --agent claude --agent-model sonnet
+
+# Claude for both answering and judging (only an ANTHROPIC_API_KEY available)
+npm run bench:agentmemory-coding-life -- --agent claude --judge anthropic
+```
+
+
+| Flag            | Default                                                                                   | Meaning                                          |
+| --------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `--arms`        | `full-context,greplica`                                                                   | Which arms to run                                |
+| `--agent`       | `codex`                                                                                   | Answering-agent engine: `codex` or `claude`      |
+| `--agent-model` | engine default                                                                            | Model for the answering agent                    |
+| `--judge`       | auto (OpenAI if its key is set, else Anthropic)                                           | Judge provider: `openai` or `anthropic`          |
+| `--judge-model` | `gpt-5.4` (openai) / `claude-sonnet-4-5` (anthropic), or `OPENAI_MODEL`/`ANTHROPIC_MODEL` | Model for the judge                              |
+| `--embedding`   | `local`                                                                                   | greplica embedding provider for the greplica arm |
+| `--queries`     | all                                                                                       | Comma list of query ids                          |
+| `--limit`       | all                                                                                       | Run only the first N selected queries            |
+
+
+## Output
+
+Everything lands in `eval-runs/<timestamp>/agentmemory-coding-life/`:
+
+- `scores.ndjson` — one row per (arm, query): answer, pass, judge reasoning, and agent
+token/tool/latency metrics.
+- `summary.json` — per-arm pass rate and average tokens / tool calls / latency.
+- `run-manifest.json` — arms, models, embedding, query ids, timestamp.
+- `<arm>/<query-id>/` — the Codex transcript and final message for each run.
+- `greplica/seed.proposal.json` — the proposal seeded into greplica memory.
+
+## How to expand past the MVP
+
+- Add more queries/sessions to `data/` (same JSON shape) — no code change needed.
+- Add a retrieval-ranking mode that maps greplica's returned claims back to session ids
+for an IR-style score (P@K / R@K) alongside the QA score.
+- Add a larger corpus (e.g. LongMemEval-S) behind the same arm/judge harness.
+- Add a non-OpenAI agent engine (Cursor SDK / Claude Code) so a non-Codex agent can call
+greplica autonomously.

--- a/evals/cases/agentmemory-coding-life/data/SOURCE.md
+++ b/evals/cases/agentmemory-coding-life/data/SOURCE.md
@@ -1,0 +1,14 @@
+# Dataset source
+
+`sessions.json` and `queries.json` are the `coding-agent-life-v1` corpus, vendored
+verbatim from the AgentMemory project:
+
+- Upstream: https://github.com/rohitg00/agentmemory
+- Path: `eval/data/coding-agent-life-v1/`
+
+The corpus is 15 fictional coding-agent sessions for a fictional Rust CLI project
+(`shipctl`) plus 15 hand-graded recall queries with gold answers and gold session ids.
+
+It is vendored here (rather than fetched at run time) so this benchmark is pinned and
+runs offline. It is used only as a shared question/answer corpus; this benchmark does
+not compare against AgentMemory's published numbers.

--- a/evals/cases/agentmemory-coding-life/data/queries.json
+++ b/evals/cases/agentmemory-coding-life/data/queries.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "q-001",
+    "type": "single-session-bug",
+    "question": "Where did we land the auth env var precedence fix?",
+    "answer": "PR #11 with SHIPCTL_TOKEN > SHIP_TOKEN > SC_TOKEN precedence",
+    "goldSessionIds": ["sess-001"]
+  },
+  {
+    "id": "q-002",
+    "type": "single-session-infra",
+    "question": "What was the multi-arch Docker fix?",
+    "answer": "Added --platform=$BUILDPLATFORM and BUILDX_PLATFORMS for amd64+arm64",
+    "goldSessionIds": ["sess-002"]
+  },
+  {
+    "id": "q-003",
+    "type": "single-session-refactor",
+    "question": "Where did we consolidate the retry logic?",
+    "answer": "src/retry.rs with exponential backoff base=200ms cap=30s full jitter",
+    "goldSessionIds": ["sess-003"]
+  },
+  {
+    "id": "q-004",
+    "type": "single-session-feature",
+    "question": "Which PR introduced helm chart support?",
+    "answer": "PR #14",
+    "goldSessionIds": ["sess-004"]
+  },
+  {
+    "id": "q-005",
+    "type": "single-session-test",
+    "question": "Which test was flaky on macos and how was it fixed?",
+    "answer": "fs-watcher emits_changekind_file_delete; bumped wait to 1500ms + retry: 2",
+    "goldSessionIds": ["sess-005"]
+  },
+  {
+    "id": "q-006",
+    "type": "single-session-perf",
+    "question": "How did we fix the memory leak?",
+    "answer": "Replaced unbounded HashMap with LruCache cap=10k in src/cache.rs (PR #16)",
+    "goldSessionIds": ["sess-006"]
+  },
+  {
+    "id": "q-007",
+    "type": "single-session-api",
+    "question": "How did we handle the github API rate limit?",
+    "answer": "Conditional requests with If-None-Match etag and 304 caching via http-cache",
+    "goldSessionIds": ["sess-007"]
+  },
+  {
+    "id": "q-008",
+    "type": "single-session-db",
+    "question": "What was the schema migration approach for run_history?",
+    "answer": "Three-phase: nullable column + dual-write, backfill + flip reads, drop old column",
+    "goldSessionIds": ["sess-008"]
+  },
+  {
+    "id": "q-009",
+    "type": "single-session-infra",
+    "question": "How is the docs site deployed?",
+    "answer": "GitHub Actions docs.yml workflow + mdbook build + Cloudflare Pages on shipctl.dev",
+    "goldSessionIds": ["sess-009"]
+  },
+  {
+    "id": "q-010",
+    "type": "single-session-release",
+    "question": "Which PR set up the cross-platform release pipeline?",
+    "answer": "PR #19 with cross-rs for linux and native macos/windows builds",
+    "goldSessionIds": ["sess-010"]
+  },
+  {
+    "id": "q-011",
+    "type": "multi-session-causal",
+    "question": "What was the root cause of the staging incident, and where was it fixed?",
+    "answer": "SHIPCTL_TOKEN unset caused fallback to bad SC_TOKEN; fixed in PR #11 (sess-001) with precedence test; documented in post-mortem (sess-014)",
+    "goldSessionIds": ["sess-001", "sess-014"]
+  },
+  {
+    "id": "q-012",
+    "type": "preference",
+    "question": "Which async runtime does the team prefer for new code?",
+    "answer": "async-std (decided in arch review, not tokio)",
+    "goldSessionIds": ["sess-015"]
+  },
+  {
+    "id": "q-013",
+    "type": "preference",
+    "question": "What are the user's formatting preferences?",
+    "answer": "2-space indent in yaml, tab in rust, rust-analyzer over rls, cargo clippy before commit",
+    "goldSessionIds": ["sess-012"]
+  },
+  {
+    "id": "q-014",
+    "type": "multi-session-review",
+    "question": "What was the race condition Aria fixed in the schema migration?",
+    "answer": "Dual-write step had race when two writers hit same row; Aria added per-row advisory lock",
+    "goldSessionIds": ["sess-008", "sess-013"]
+  },
+  {
+    "id": "q-015",
+    "type": "temporal",
+    "question": "What was shipped on April 8th 2026?",
+    "answer": "Auth env-var precedence fix in PR #11, then started docker arm64 work",
+    "goldSessionIds": ["sess-001", "sess-011"]
+  }
+]

--- a/evals/cases/agentmemory-coding-life/data/sessions.json
+++ b/evals/cases/agentmemory-coding-life/data/sessions.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "sess-001",
+    "timestamp": "2026-04-08T09:14:00Z",
+    "content": "[user] auth check broken on staging when SHIPCTL_TOKEN unset, falling back to wrong env var\n[assistant] looked at src/auth.rs:42. precedence is SHIPCTL_TOKEN > SHIP_TOKEN > legacy SC_TOKEN. legacy path didn't validate. fixing precedence + adding length check.\n[user] yeah ship it\n[assistant] PR #11 opened with fix + regression test. covers all three env names."
+  },
+  {
+    "id": "sess-002",
+    "timestamp": "2026-04-08T14:30:00Z",
+    "content": "[user] docker build failing for arm64 on M2 runner\n[assistant] missing target in Dockerfile FROM line. need --platform=$BUILDPLATFORM on builder stage. updated Dockerfile + Makefile to set BUILDX_PLATFORMS=linux/amd64,linux/arm64. tested locally on apple silicon, builds clean."
+  },
+  {
+    "id": "sess-003",
+    "timestamp": "2026-04-09T10:02:00Z",
+    "content": "[user] retry logic is duplicated across handlers. consolidate.\n[assistant] extracted retry_with_backoff into src/retry.rs. exponential backoff base=200ms cap=30s jitter=full. all 4 callsites now use it. cuts ~80 lines."
+  },
+  {
+    "id": "sess-004",
+    "timestamp": "2026-04-10T11:45:00Z",
+    "content": "[user] add helm chart support\n[assistant] new subcommand `shipctl helm install`. wraps helm CLI, threads through --namespace and --values. PR #14 has the changes + 12 integration tests. Aria reviewed and approved."
+  },
+  {
+    "id": "sess-005",
+    "timestamp": "2026-04-11T16:20:00Z",
+    "content": "[user] test flake on macos-22 runner. emits_changekind_file_delete keeps failing\n[assistant] fsevents propagation slower on apple silicon, the 800ms wait isn't enough. bumped to 1500ms + describe-level retry: 2. all 15 fs-watcher tests pass now."
+  },
+  {
+    "id": "sess-006",
+    "timestamp": "2026-04-12T09:50:00Z",
+    "content": "[user] memory leak in long-running daemon. RSS grows 5MB/min.\n[assistant] traced to unbounded HashMap in src/cache.rs. swapped for LruCache with 10k cap. RSS stable at 180MB after 6h soak test. PR #16."
+  },
+  {
+    "id": "sess-007",
+    "timestamp": "2026-04-13T13:15:00Z",
+    "content": "[user] github API rate-limiting us when listing PRs. 5000/hr isn't enough during ci\n[assistant] added conditional requests with If-None-Match etag. cache 304 responses. drops actual API calls by ~70%. used http-cache crate."
+  },
+  {
+    "id": "sess-008",
+    "timestamp": "2026-04-15T10:30:00Z",
+    "content": "[user] schema migration for run_history table needs zero-downtime\n[assistant] three-phase migration. phase 1: add nullable new column + dual-write. phase 2: backfill + flip reads. phase 3: drop old column. avoids ALTER TABLE locks. ran on staging, took 4s for 2M rows."
+  },
+  {
+    "id": "sess-009",
+    "timestamp": "2026-04-16T15:40:00Z",
+    "content": "[user] docs site is stale. set up auto-deploy from main\n[assistant] added .github/workflows/docs.yml. mdbook build + cloudflare pages deploy. domain shipctl.dev wired up. preview deploys on PRs."
+  },
+  {
+    "id": "sess-010",
+    "timestamp": "2026-04-17T11:00:00Z",
+    "content": "[user] release pipeline. cut v0.3.0 with binaries for linux/macos/windows\n[assistant] new .github/workflows/release.yml. cross-rs for static linux, native for macos + windows. uploads to gh release + crates.io publish. tag-triggered. PR #19 has the workflow."
+  },
+  {
+    "id": "sess-011",
+    "timestamp": "2026-04-08T17:00:00Z",
+    "content": "[user] standup notes: shipped #11 auth fix this morning. starting on docker arm64 next."
+  },
+  {
+    "id": "sess-012",
+    "timestamp": "2026-04-10T18:30:00Z",
+    "content": "[user] preferences: I like rust analyzer over rls. always run cargo clippy before commit. prefer 2-space indent in yaml but tab in rust."
+  },
+  {
+    "id": "sess-013",
+    "timestamp": "2026-04-15T19:00:00Z",
+    "content": "[assistant] reviewed Aria's PR #18 (schema migration). flagged race condition in dual-write step when two writers hit same row. Aria added per-row advisory lock. lgtm now."
+  },
+  {
+    "id": "sess-014",
+    "timestamp": "2026-04-16T20:10:00Z",
+    "content": "[user] post-mortem from prod incident last week: SHIPCTL_TOKEN was unset in staging, fell back to bad SC_TOKEN which had wrong perms. delivery delayed 40min. action items: (1) precedence test (done in #11), (2) startup validation, (3) alert on auth fallback."
+  },
+  {
+    "id": "sess-015",
+    "timestamp": "2026-04-17T16:45:00Z",
+    "content": "[user] preferences: stick to async-std not tokio for new code. team agreed in arch review."
+  }
+]

--- a/evals/cases/agentmemory-coding-life/dataset.ts
+++ b/evals/cases/agentmemory-coding-life/dataset.ts
@@ -1,0 +1,28 @@
+import { resolve } from "node:path";
+import { readJson } from "../../lib/common.js";
+
+export interface Session {
+  id: string;
+  timestamp?: string;
+  content: string;
+}
+
+export interface Query {
+  id: string;
+  type: string;
+  question: string;
+  answer: string;
+  goldSessionIds: string[];
+}
+
+export function datasetDir(repoRoot: string): string {
+  return resolve(repoRoot, "evals/cases/agentmemory-coding-life/data");
+}
+
+export function loadSessions(repoRoot: string): Session[] {
+  return readJson<Session[]>(resolve(datasetDir(repoRoot), "sessions.json"));
+}
+
+export function loadQueries(repoRoot: string): Query[] {
+  return readJson<Query[]>(resolve(datasetDir(repoRoot), "queries.json"));
+}

--- a/evals/cases/agentmemory-coding-life/judge.ts
+++ b/evals/cases/agentmemory-coding-life/judge.ts
@@ -1,0 +1,152 @@
+export type JudgeProvider = "openai" | "anthropic";
+
+export interface JudgeVerdict {
+  correct: boolean;
+  reasoning: string;
+}
+
+export interface JudgeRequest {
+  question: string;
+  goldAnswer: string;
+  candidateAnswer: string;
+}
+
+const JUDGE_SYSTEM =
+  "You are grading whether a coding agent's answer to a recall question matches the known correct answer. " +
+  "Return JSON only. Mark correct=true when the candidate answer states the same key fact(s) as the gold answer " +
+  "(PR numbers, file names, identifiers, and decisions must match), allowing for paraphrase and extra correct detail. " +
+  "Mark correct=false when the candidate is wrong, missing the key fact, refuses, or says it does not know.";
+
+const JUDGE_TOOL_NAME = "record_verdict";
+
+function judgeSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      correct: { type: "boolean" },
+      reasoning: { type: "string" },
+    },
+    required: ["correct", "reasoning"],
+  };
+}
+
+function userPayload(request: JudgeRequest): string {
+  return JSON.stringify({
+    question: request.question,
+    gold_answer: request.goldAnswer,
+    candidate_answer: request.candidateAnswer,
+  });
+}
+
+export async function requestJudge(
+  provider: JudgeProvider,
+  apiKey: string,
+  model: string,
+  request: JudgeRequest,
+): Promise<JudgeVerdict> {
+  return provider === "anthropic"
+    ? requestAnthropicJudge(apiKey, model, request)
+    : requestOpenAiJudge(apiKey, model, request);
+}
+
+async function requestOpenAiJudge(apiKey: string, model: string, request: JudgeRequest): Promise<JudgeVerdict> {
+  const response = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      input: [
+        { role: "system", content: JUDGE_SYSTEM },
+        { role: "user", content: userPayload(request) },
+      ],
+      text: {
+        format: {
+          type: "json_schema",
+          name: "coding_life_answer_judge",
+          strict: true,
+          schema: judgeSchema(),
+        },
+      },
+    }),
+  });
+
+  const body = (await response.json()) as Record<string, unknown>;
+  if (!response.ok) {
+    throw new Error(`OpenAI judge request failed: ${JSON.stringify(body)}`);
+  }
+
+  return JSON.parse(extractOpenAiOutputText(body)) as JudgeVerdict;
+}
+
+async function requestAnthropicJudge(apiKey: string, model: string, request: JudgeRequest): Promise<JudgeVerdict> {
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 1024,
+      system: JUDGE_SYSTEM,
+      tools: [
+        {
+          name: JUDGE_TOOL_NAME,
+          description: "Record the grading verdict for the candidate answer.",
+          input_schema: judgeSchema(),
+        },
+      ],
+      tool_choice: { type: "tool", name: JUDGE_TOOL_NAME },
+      messages: [{ role: "user", content: userPayload(request) }],
+    }),
+  });
+
+  const body = (await response.json()) as Record<string, unknown>;
+  if (!response.ok) {
+    throw new Error(`Anthropic judge request failed: ${JSON.stringify(body)}`);
+  }
+
+  return extractAnthropicVerdict(body);
+}
+
+function extractOpenAiOutputText(body: Record<string, unknown>): string {
+  if (typeof body.output_text === "string" && body.output_text.length > 0) return body.output_text;
+
+  const output = body.output;
+  if (Array.isArray(output)) {
+    const parts: string[] = [];
+    for (const item of output) {
+      if (!isRecord(item)) continue;
+      const content = item.content;
+      if (!Array.isArray(content)) continue;
+      for (const piece of content) {
+        if (isRecord(piece) && typeof piece.text === "string") parts.push(piece.text);
+      }
+    }
+    if (parts.length > 0) return parts.join("");
+  }
+
+  throw new Error(`Could not extract judge output text from response: ${JSON.stringify(body)}`);
+}
+
+function extractAnthropicVerdict(body: Record<string, unknown>): JudgeVerdict {
+  const content = body.content;
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (isRecord(block) && block.type === "tool_use" && block.name === JUDGE_TOOL_NAME && isRecord(block.input)) {
+        return block.input as unknown as JudgeVerdict;
+      }
+    }
+  }
+
+  throw new Error(`Could not extract judge verdict from Anthropic response: ${JSON.stringify(body)}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/evals/cases/agentmemory-coding-life/run.ts
+++ b/evals/cases/agentmemory-coding-life/run.ts
@@ -1,0 +1,446 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  type CommandResult,
+  findRepoRoot,
+  round,
+  run,
+  runOrThrow,
+  timestamp,
+  valueAfter,
+  writeJson,
+} from "../../lib/common.js";
+import { loadRepoEnv } from "../../../libs/env/load-local-env.js";
+import { runCodexAgent } from "../../../libs/agent-runner/codex.js";
+import { runClaudeAgent } from "../../../libs/agent-runner/claude.js";
+import type { AgentRunInput, AgentRunResult } from "../../../libs/agent-runner/types.js";
+import { loadQueries, loadSessions, type Query, type Session } from "./dataset.js";
+import { buildSeedProposal } from "./seed.js";
+import { requestJudge, type JudgeProvider, type JudgeVerdict } from "./judge.js";
+
+const caseId = "agentmemory-coding-life";
+
+type Arm = "full-context" | "greplica";
+const ALL_ARMS: Arm[] = ["full-context", "greplica"];
+
+type Engine = "codex" | "claude";
+
+interface Args {
+  arms: Arm[];
+  engine: Engine;
+  agentModel: string | undefined;
+  judgeProvider: JudgeProvider | undefined;
+  judgeModel: string | undefined;
+  embedding: "local" | "openai";
+  queryIds: string[] | undefined;
+  limit: number | undefined;
+}
+
+interface Judge {
+  provider: JudgeProvider;
+  apiKey: string;
+  model: string;
+}
+
+interface RunContext {
+  repoRoot: string;
+  runDir: string;
+  greplicaCommand: string[];
+  embedding: "local" | "openai";
+}
+
+interface ScoreRow {
+  arm: Arm;
+  query_id: string;
+  type: string;
+  question: string;
+  gold_answer: string;
+  gold_session_ids: string[];
+  answer: string;
+  pass: boolean | null;
+  judge: { model: string | null; correct: boolean | null; reasoning: string | null };
+  agent: {
+    model: string;
+    exit_code: number | null;
+    elapsed_ms: number;
+    tool_calls: number;
+    input_tokens: number | null;
+    output_tokens: number | null;
+    total_tokens: number | null;
+    error?: string;
+  };
+  transcript_path: string;
+  final_message_path: string;
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const context = prepareRun(args);
+
+  const sessions = loadSessions(context.repoRoot);
+  const queries = selectQueries(loadQueries(context.repoRoot), args);
+
+  const judge = resolveJudge(args);
+  if (judge === undefined) {
+    console.warn(
+      "No judge API key found (set OPENAI_API_KEY or ANTHROPIC_API_KEY): answers will be collected but not judged (pass = null).",
+    );
+  } else {
+    console.log(`Judge: ${judge.provider} (${judge.model})`);
+  }
+  if (args.engine === "claude" && !process.env.ANTHROPIC_API_KEY) {
+    console.warn("ANTHROPIC_API_KEY not set: the claude engine will rely on whatever auth the local claude CLI has.");
+  }
+
+  const ndjsonPath = resolve(context.runDir, "scores.ndjson");
+  writeFileSync(ndjsonPath, "");
+
+  const rows: ScoreRow[] = [];
+  for (const arm of args.arms) {
+    console.log(`\n== arm: ${arm} (engine: ${args.engine}) ==`);
+    const armSetup = prepareArm(context, arm, sessions, args.engine);
+    for (const query of queries) {
+      const row = await runQuery(context, arm, armSetup, query, sessions, args.engine, args.agentModel, judge);
+      rows.push(row);
+      appendFileSync(ndjsonPath, `${JSON.stringify(row)}\n`);
+      const mark = row.pass === null ? "?" : row.pass ? "+" : "-";
+      console.log(`  ${mark} ${query.id} [${query.type}] tokens=${row.agent.total_tokens ?? "?"} tools=${row.agent.tool_calls}`);
+    }
+  }
+
+  const summary = summarize(rows, args.arms);
+  writeJson(resolve(context.runDir, "summary.json"), summary);
+  writeJson(resolve(context.runDir, "run-manifest.json"), {
+    case_id: caseId,
+    dataset: "coding-agent-life-v1",
+    run_dir: context.runDir,
+    arms: args.arms,
+    agent_engine: args.engine,
+    agent_model: args.agentModel ?? `${args.engine}-default`,
+    judge_model: judge?.model ?? null,
+    embedding: context.embedding,
+    query_ids: queries.map((query) => query.id),
+    greplica_command: context.greplicaCommand,
+    generated_at: new Date().toISOString(),
+  });
+
+  printSummary(summary);
+  console.log(`\nRun directory: ${context.runDir}`);
+}
+
+function prepareRun(args: Args): RunContext {
+  const repoRoot = findRepoRoot(import.meta.url);
+  loadRepoEnv(repoRoot);
+  const runDir = resolve(repoRoot, "eval-runs", timestamp(), caseId);
+  mkdirSync(runDir, { recursive: true });
+  return {
+    repoRoot,
+    runDir,
+    greplicaCommand: ["node", resolve(repoRoot, "dist/apps/cli/main.js")],
+    embedding: args.embedding,
+  };
+}
+
+interface ArmSetup {
+  cwd: string;
+  greplicaHome: string | undefined;
+  setupCommands: CommandResult[];
+}
+
+function prepareArm(context: RunContext, arm: Arm, sessions: Session[], engine: Engine): ArmSetup {
+  const armDir = resolve(context.runDir, arm);
+  const cwd = resolve(armDir, "workspace");
+  mkdirSync(cwd, { recursive: true });
+  runOrThrow(["git", "init"], cwd, process.env, { stdio: "pipe" });
+  writeFileSync(resolve(cwd, "README.md"), `# coding-agent-life-v1 ${arm} arm workspace\n`);
+
+  if (arm !== "greplica") {
+    return { cwd, greplicaHome: undefined, setupCommands: [] };
+  }
+
+  const greplicaHome = resolve(armDir, "greplica-home");
+  mkdirSync(greplicaHome, { recursive: true });
+  const seedPath = resolve(armDir, "seed.proposal.json");
+  writeJson(seedPath, buildSeedProposal(sessions));
+
+  const setupCommands = [
+    runGreplica(context, greplicaHome, cwd, "install", "--platform", engine, "--embedding", context.embedding),
+    runGreplica(context, greplicaHome, cwd, "proposal", "validate", seedPath),
+    runGreplica(context, greplicaHome, cwd, "proposal", "apply", seedPath),
+  ];
+  for (const command of setupCommands) {
+    if (command.exit_code !== 0) {
+      throw new Error(
+        `greplica arm setup failed: ${command.command.join(" ")}\n${command.stderr ?? command.stdout ?? ""}`,
+      );
+    }
+  }
+  return { cwd, greplicaHome, setupCommands };
+}
+
+async function runQuery(
+  context: RunContext,
+  arm: Arm,
+  setup: ArmSetup,
+  query: Query,
+  sessions: Session[],
+  engine: Engine,
+  agentModel: string | undefined,
+  judge: Judge | undefined,
+): Promise<ScoreRow> {
+  const queryDir = resolve(context.runDir, arm, query.id);
+  mkdirSync(queryDir, { recursive: true });
+  const transcriptPath = resolve(queryDir, "transcript.jsonl");
+  const finalMessagePath = resolve(queryDir, "final-message.txt");
+
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (setup.greplicaHome !== undefined) env.GREPLICA_HOME = setup.greplicaHome;
+
+  const agentInput: AgentRunInput = {
+    cwd: setup.cwd,
+    env,
+    model: agentModel,
+    prompt: buildPrompt(context, arm, query, sessions),
+    transcriptPath,
+    finalMessagePath,
+  };
+
+  let generation: AgentRunResult | undefined;
+  let agentError: string | undefined;
+  try {
+    generation = engine === "claude" ? await runClaudeAgent(agentInput) : await runCodexAgent(agentInput);
+  } catch (error: unknown) {
+    agentError = error instanceof Error ? error.message : String(error);
+  }
+
+  const answer = existsSync(finalMessagePath) ? readFileSync(finalMessagePath, "utf8").trim() : "";
+
+  let verdict: JudgeVerdict | undefined;
+  let judgeError: string | undefined;
+  if (judge !== undefined && answer.length > 0) {
+    try {
+      verdict = await requestJudge(judge.provider, judge.apiKey, judge.model, {
+        question: query.question,
+        goldAnswer: query.answer,
+        candidateAnswer: answer,
+      });
+    } catch (error: unknown) {
+      judgeError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const pass = judge === undefined ? null : verdict?.correct ?? false;
+
+  return {
+    arm,
+    query_id: query.id,
+    type: query.type,
+    question: query.question,
+    gold_answer: query.answer,
+    gold_session_ids: query.goldSessionIds,
+    answer,
+    pass,
+    judge: {
+      model: judge?.model ?? null,
+      correct: verdict?.correct ?? null,
+      reasoning: verdict?.reasoning ?? judgeError ?? null,
+    },
+    agent: {
+      model: generation?.model ?? agentModel ?? `${engine}-default`,
+      exit_code: generation?.exit_code ?? null,
+      elapsed_ms: generation?.elapsed_ms ?? 0,
+      tool_calls: generation?.tool_calls ?? 0,
+      input_tokens: generation?.input_tokens ?? null,
+      output_tokens: generation?.output_tokens ?? null,
+      total_tokens: generation?.total_tokens ?? null,
+      ...(agentError === undefined ? {} : { error: agentError }),
+    },
+    transcript_path: transcriptPath,
+    final_message_path: finalMessagePath,
+  };
+}
+
+function buildPrompt(context: RunContext, arm: Arm, query: Query, sessions: Session[]): string {
+  const question = query.question;
+  if (arm === "full-context") {
+    const logs = sessions
+      .map((session) => `### ${session.id}${session.timestamp ? ` (${session.timestamp})` : ""}\n${session.content}`)
+      .join("\n\n");
+    return [
+      "You are answering a recall question about a software project's past work.",
+      "Below are all past coding-agent session logs. Use only these logs.",
+      "Answer in one or two sentences, citing the relevant session id(s) or PR number(s).",
+      "",
+      "<session_logs>",
+      logs,
+      "</session_logs>",
+      "",
+      `Question: ${question}`,
+    ].join("\n");
+  }
+
+  const greplica = context.greplicaCommand.join(" ");
+  return [
+    "You are answering a recall question about a software project's past work.",
+    "This repository has greplica memory of past coding-agent sessions.",
+    `Before answering, recall relevant sessions by running: ${greplica} graph context "${question}"`,
+    "You may run that command more than once with different phrasings if needed.",
+    "Then answer in one or two sentences, citing the relevant session id(s) or PR number(s).",
+    "If greplica returns nothing useful, say you do not know.",
+    "",
+    `Question: ${question}`,
+  ].join("\n");
+}
+
+function runGreplica(context: RunContext, greplicaHome: string, cwd: string, ...args: string[]): CommandResult {
+  return run([...context.greplicaCommand, ...args], cwd, { ...process.env, GREPLICA_HOME: greplicaHome });
+}
+
+interface ArmSummary {
+  arm: Arm;
+  n: number;
+  judged: number;
+  pass_count: number;
+  pass_rate: number | null;
+  avg_total_tokens: number | null;
+  avg_input_tokens: number | null;
+  avg_output_tokens: number | null;
+  avg_tool_calls: number;
+  avg_elapsed_ms: number;
+}
+
+function summarize(rows: ScoreRow[], arms: Arm[]): { case_id: string; by_arm: ArmSummary[] } {
+  const byArm = arms.map((arm) => {
+    const armRows = rows.filter((row) => row.arm === arm);
+    const judged = armRows.filter((row) => row.pass !== null);
+    const passCount = judged.filter((row) => row.pass === true).length;
+    return {
+      arm,
+      n: armRows.length,
+      judged: judged.length,
+      pass_count: passCount,
+      pass_rate: judged.length === 0 ? null : round(passCount / judged.length, 4),
+      avg_total_tokens: averageOrNull(armRows.map((row) => row.agent.total_tokens)),
+      avg_input_tokens: averageOrNull(armRows.map((row) => row.agent.input_tokens)),
+      avg_output_tokens: averageOrNull(armRows.map((row) => row.agent.output_tokens)),
+      avg_tool_calls: round(average(armRows.map((row) => row.agent.tool_calls)), 2),
+      avg_elapsed_ms: Math.round(average(armRows.map((row) => row.agent.elapsed_ms))),
+    };
+  });
+  return { case_id: caseId, by_arm: byArm };
+}
+
+function printSummary(summary: { by_arm: ArmSummary[] }): void {
+  console.log("\n=== Summary ===");
+  for (const arm of summary.by_arm) {
+    const rate = arm.pass_rate === null ? "n/a" : `${(arm.pass_rate * 100).toFixed(1)}%`;
+    console.log(
+      `  ${arm.arm.padEnd(14)} pass ${arm.pass_count}/${arm.judged} (${rate})  ` +
+        `avg_tokens=${arm.avg_total_tokens ?? "?"}  avg_tools=${arm.avg_tool_calls}  avg_ms=${arm.avg_elapsed_ms}`,
+    );
+  }
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function averageOrNull(values: Array<number | null>): number | null {
+  const present = values.filter((value): value is number => value !== null);
+  if (present.length === 0) return null;
+  return Math.round(average(present));
+}
+
+function selectQueries(queries: Query[], args: Args): Query[] {
+  let selected = queries;
+  if (args.queryIds !== undefined) {
+    const byId = new Map(queries.map((query) => [query.id, query]));
+    selected = args.queryIds.map((id) => {
+      const query = byId.get(id);
+      if (query === undefined) throw new Error(`Query ${id} not found in dataset.`);
+      return query;
+    });
+  }
+  return args.limit === undefined ? selected : selected.slice(0, args.limit);
+}
+
+function resolveJudge(args: Args): Judge | undefined {
+  const openAiKey = process.env.OPENAI_API_KEY;
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  // Explicit --judge wins; otherwise prefer OpenAI when its key is present, else fall
+  // back to Anthropic so an ANTHROPIC_API_KEY alone is enough to get judged results.
+  const provider: JudgeProvider | undefined =
+    args.judgeProvider ?? (openAiKey ? "openai" : anthropicKey ? "anthropic" : undefined);
+  if (provider === undefined) return undefined;
+
+  if (provider === "anthropic") {
+    if (!anthropicKey) throw new Error("--judge anthropic requires ANTHROPIC_API_KEY.");
+    const model = args.judgeModel ?? process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-5";
+    return { provider, apiKey: anthropicKey, model };
+  }
+
+  if (!openAiKey) throw new Error("--judge openai requires OPENAI_API_KEY.");
+  const model = args.judgeModel ?? process.env.OPENAI_MODEL ?? "gpt-5.4";
+  return { provider, apiKey: openAiKey, model };
+}
+
+function parseArgs(argv: string[]): Args {
+  return {
+    arms: parseArms(valueAfter(argv, "--arms")),
+    engine: parseEngine(valueAfter(argv, "--agent")),
+    agentModel: valueAfter(argv, "--agent-model"),
+    judgeProvider: parseJudgeProvider(valueAfter(argv, "--judge")),
+    judgeModel: valueAfter(argv, "--judge-model"),
+    embedding: parseEmbedding(valueAfter(argv, "--embedding")),
+    queryIds: parseList(valueAfter(argv, "--queries")),
+    limit: parseOptionalPositiveInteger(valueAfter(argv, "--limit"), "--limit"),
+  };
+}
+
+function parseEngine(value: string | undefined): Engine {
+  if (value === undefined || value.trim().length === 0) return "codex";
+  if (value === "codex" || value === "claude") return value;
+  throw new Error("--agent must be codex or claude");
+}
+
+function parseJudgeProvider(value: string | undefined): JudgeProvider | undefined {
+  if (value === undefined || value.trim().length === 0) return undefined;
+  if (value === "openai" || value === "anthropic") return value;
+  throw new Error("--judge must be openai or anthropic");
+}
+
+function parseArms(value: string | undefined): Arm[] {
+  if (value === undefined || value.trim().length === 0) return ALL_ARMS;
+  const arms = value.split(",").map((arm) => arm.trim()).filter(Boolean);
+  for (const arm of arms) {
+    if (!ALL_ARMS.includes(arm as Arm)) {
+      throw new Error(`--arms must be a comma list of: ${ALL_ARMS.join(", ")}`);
+    }
+  }
+  return arms as Arm[];
+}
+
+function parseEmbedding(value: string | undefined): "local" | "openai" {
+  if (value === undefined || value.trim().length === 0) return "local";
+  if (value === "local" || value === "openai") return value;
+  throw new Error("--embedding must be local or openai");
+}
+
+function parseList(value: string | undefined): string[] | undefined {
+  if (value === undefined || value.trim().length === 0) return undefined;
+  return value.split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+function parseOptionalPositiveInteger(value: string | undefined, flag: string): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}

--- a/evals/cases/agentmemory-coding-life/seed.ts
+++ b/evals/cases/agentmemory-coding-life/seed.ts
@@ -1,0 +1,54 @@
+import type { Session } from "./dataset.js";
+
+const PROJECT_COMPONENT_ID = "component.shipctl_project";
+
+export interface SeedProposal {
+  title: string;
+  summary: string;
+  creates: {
+    components: Array<{ id: string; name: string }>;
+    flows: never[];
+    claims: Array<{
+      id: string;
+      kind: "fact";
+      text: string;
+      truth: "source_verified";
+      intent: "intended";
+      about: string[];
+    }>;
+    sources: never[];
+    edges: never[];
+  };
+}
+
+function claimIdFor(sessionId: string): string {
+  return `claim.${sessionId.replace(/[^a-z0-9]+/gi, "_")}`;
+}
+
+// Each session becomes one source-verified claim attached to a single umbrella
+// component, so greplica's retrieval has per-session memory to rank and return.
+// The session id and timestamp are kept in the claim text so a retrieving agent
+// can cite which session an answer came from.
+export function buildSeedProposal(sessions: Session[]): SeedProposal {
+  const claims = sessions.map((session) => ({
+    id: claimIdFor(session.id),
+    kind: "fact" as const,
+    text: `Session ${session.id}${session.timestamp ? ` (${session.timestamp})` : ""}: ${session.content}`,
+    truth: "source_verified" as const,
+    intent: "intended" as const,
+    about: [PROJECT_COMPONENT_ID],
+  }));
+
+  return {
+    title: "AgentMemory coding-agent-life-v1 session memory",
+    summary:
+      "Per-session memory for the fictional shipctl CLI project, seeded from the coding-agent-life-v1 corpus so greplica retrieval can answer recall queries.",
+    creates: {
+      components: [{ id: PROJECT_COMPONENT_ID, name: "shipctl CLI project" }],
+      flows: [],
+      claims,
+      sources: [],
+      edges: [],
+    },
+  };
+}

--- a/libs/agent-runner/claude.ts
+++ b/libs/agent-runner/claude.ts
@@ -1,0 +1,127 @@
+import { createWriteStream, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import type { AgentRunInput, AgentRunResult } from "./types.js";
+
+// Runs Claude Code in headless print mode (`claude -p`), streaming newline-delimited
+// JSON events. Authentication uses ANTHROPIC_API_KEY from the provided env (or whatever
+// auth the local `claude` CLI is configured with). Tool use is allowed without prompts
+// via --dangerously-skip-permissions so the agent can run greplica commands itself.
+export async function runClaudeAgent(input: AgentRunInput): Promise<AgentRunResult> {
+  const startedAt = Date.now();
+  const transcript = createWriteStream(input.transcriptPath, { flags: "w" });
+  const { exitCode, signal, stdout } = await runClaudeProcess(input, transcript);
+  transcript.end();
+  const elapsedMs = Date.now() - startedAt;
+
+  const parsed = parseClaudeStream(stdout);
+  writeFileSync(input.finalMessagePath, parsed.finalMessage, "utf8");
+
+  return {
+    agent: "claude",
+    model: input.model ?? "default",
+    elapsed_ms: elapsedMs,
+    tool_calls: parsed.tool_calls,
+    input_tokens: parsed.input_tokens,
+    output_tokens: parsed.output_tokens,
+    total_tokens: parsed.total_tokens,
+    transcript_path: input.transcriptPath,
+    final_message_path: input.finalMessagePath,
+    exit_code: exitCode,
+    signal,
+  };
+}
+
+function runClaudeProcess(
+  input: AgentRunInput,
+  transcript: NodeJS.WritableStream,
+): Promise<{ exitCode: number | null; signal: string | null; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const args = ["-p", "--output-format", "stream-json", "--verbose", "--dangerously-skip-permissions"];
+    if (input.model !== undefined) args.push("--model", input.model);
+
+    const child = spawn("claude", args, {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+
+    let stdout = "";
+    child.once("error", reject);
+    child.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      transcript.write(text);
+    });
+    child.stdin.end(input.prompt);
+    child.once("close", (exitCode, signal) => {
+      resolve({ exitCode, signal, stdout });
+    });
+  });
+}
+
+interface ParsedClaudeStream {
+  finalMessage: string;
+  tool_calls: number;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+}
+
+function parseClaudeStream(stdout: string): ParsedClaudeStream {
+  let finalMessage = "";
+  let toolCalls = 0;
+  let inputTokens: number | null = null;
+  let outputTokens: number | null = null;
+
+  for (const line of stdout.split("\n")) {
+    const event = parseJsonLine(line);
+    if (!isRecord(event)) continue;
+
+    if (event.type === "assistant" && isRecord(event.message) && Array.isArray(event.message.content)) {
+      for (const block of event.message.content) {
+        if (isRecord(block) && block.type === "tool_use") toolCalls += 1;
+      }
+    }
+
+    if (event.type === "result") {
+      if (typeof event.result === "string") finalMessage = event.result;
+      if (isRecord(event.usage)) {
+        inputTokens = sumTokens(
+          event.usage.input_tokens,
+          event.usage.cache_read_input_tokens,
+          event.usage.cache_creation_input_tokens,
+        );
+        outputTokens = typeof event.usage.output_tokens === "number" ? event.usage.output_tokens : null;
+      }
+    }
+  }
+
+  const totalTokens = inputTokens === null || outputTokens === null ? null : inputTokens + outputTokens;
+  return { finalMessage, tool_calls: toolCalls, input_tokens: inputTokens, output_tokens: outputTokens, total_tokens: totalTokens };
+}
+
+function sumTokens(...values: unknown[]): number | null {
+  let sum = 0;
+  let seen = false;
+  for (const value of values) {
+    if (typeof value === "number") {
+      sum += value;
+      seen = true;
+    }
+  }
+  return seen ? sum : null;
+}
+
+function parseJsonLine(line: string): unknown | undefined {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return undefined;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/libs/agent-runner/types.ts
+++ b/libs/agent-runner/types.ts
@@ -1,4 +1,4 @@
-export type AgentKind = "codex";
+export type AgentKind = "codex" | "claude";
 
 export interface AgentRunInput {
   cwd: string;

--- a/libs/env/load-local-env.ts
+++ b/libs/env/load-local-env.ts
@@ -26,7 +26,7 @@ export type EnvVarSource =
 
 export function loadRepoEnv(repoRoot: string): LoadedRepoEnv {
   const initialEnvKeys = new Set(Object.keys(process.env).filter(hasEnvValue));
-  const repoEnvKeys = new Set(["OPENAI_API_KEY", "OPENAI_MODEL"]);
+  const repoEnvKeys = new Set(["OPENAI_API_KEY", "OPENAI_MODEL", "ANTHROPIC_API_KEY", "ANTHROPIC_MODEL"]);
   const files = [".env.local", ".env"]
     .map((file) => loadEnvFile(resolve(repoRoot, file), repoEnvKeys))
     .filter((file): file is LoadedEnvFile => file !== undefined);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eval:transcript-backfill-insights": "npm run build && node dist/evals/cases/transcript-backfill-insights/run.js --judge openai",
     "eval:update-working-memory-source-evidence": "npm run build && node dist/evals/cases/update-working-memory-source-evidence-at-0438915/run.js",
     "bench:contextbench": "npm run build && node dist/evals/cases/contextbench-retrieval-from-sqlite/run.js",
+    "bench:agentmemory-coding-life": "npm run build && node dist/evals/cases/agentmemory-coding-life/run.js",
     "optimize:search-ranking": "npm run build && node dist/evals/ranking-optimizer/train.js",
     "memory:prepare-task": "npm run build && node dist/scripts/memory-build/prepare-task.js",
     "memory:collect-repo": "npm run build && node dist/scripts/memory-build/collect-repo-snapshot.js",


### PR DESCRIPTION
Closes #37.

## Summary

Adds an agent-QA benchmark that uses the `coding-agent-life-v1` recall corpus to compare greplica's autonomous memory retrieval against a full-context ceiling. The dataset is vendored verbatim from [`rohitg00/agentmemory`](https://github.com/rohitg00/agentmemory) (`eval/data/coding-agent-life-v1/`) so the benchmark is pinned and runs offline. It uses the corpus purely as a shared Q/A set — it does **not** compare against AgentMemory's published numbers.

## How it works

For each of the 15 hand-graded recall queries, an agent produces an answer and a judge grades it pass/fail against the gold answer. Two arms:

| Arm | What the agent gets | Purpose |
| --- | --- | --- |
| `full-context` | All 15 session logs pasted into the prompt | Ceiling: everything in context, no retrieval |
| `greplica` | A seeded greplica memory; the agent runs `greplica graph context` itself | Greplica as an autonomous memory tool |

- **Answering agent** is pluggable: `--agent codex` (default) or `--agent claude` (Claude Code), each running greplica via the matching `install --platform`.
- **Judge** is pluggable too: OpenAI or Anthropic, auto-selected from whichever API key is present (`--judge` to force one). A single `ANTHROPIC_API_KEY` can drive both answering and judging.
- Each arm runs in an isolated workspace + `GREPLICA_HOME`; greplica retrieval defaults to local embeddings (no API key needed).

A question-only `cold` floor was intentionally dropped: the corpus describes a fictional project, so a no-context model trivially scores 0 — it confirms the questions aren't guessable but adds no signal about greplica.

## Results (MVP, Claude agent + Claude judge)

| Arm | Pass | Avg tokens | Avg latency |
| --- | --- | --- | --- |
| full-context | 15/15 (100%) | ~20.8k | ~6.1s |
| greplica | 15/15 (100%) | ~60.7k | ~14.8s |

Greplica reaches the full-context ceiling autonomously (~2 retrieval calls/query), including the multi-session/causal/temporal/preference queries. At this corpus size full-context is cheaper; greplica's value is in the regime where the corpus doesn't fit in context. The benchmark is currently saturated at 100% — see follow-ups.

## Changes

- `evals/cases/agentmemory-coding-life/` — new case: vendored `data/` (sessions, queries, `SOURCE.md`), `dataset.ts`, `seed.ts` (builds a greplica proposal: one umbrella component + per-session claims), `judge.ts` (OpenAI + Anthropic judges), `run.ts` (orchestration/CLI/scoring), `DOCS.md`.
- `libs/agent-runner/claude.ts` — new Claude Code runner; `types.ts` extends `AgentKind` with `"claude"`.
- `libs/env/load-local-env.ts` — loads `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL`.
- `package.json` — adds `bench:agentmemory-coding-life` script.

## How to run

```bash
# default (Codex agent, OpenAI judge)
npm run bench:agentmemory-coding-life

# Claude for both answering and judging
npm run bench:agentmemory-coding-life -- --agent claude
```

Outputs land in `eval-runs/<timestamp>/agentmemory-coding-life/` (`scores.ndjson`, `summary.json`, `run-manifest.json`).

## Test plan

- [x] `npm run typecheck` clean
- [x] Full run with `--agent claude` + Anthropic judge (15/15 both arms)
- [ ] Run with `--agent codex` + OpenAI judge

## Possible follow-ups

- Scale the corpus / add distractor sessions so `full-context` is no longer trivially 100% and retrieval precision matters.
- Add a retrieval-ranking mode (P@K / R@K) mapping returned claims back to session ids.
