### PR TITLE
Fix graph view for components without code anchors

### DIFF
--- a/libs/knowledge-graph/graph-view/build-graph-view.ts
+++ b/libs/knowledge-graph/graph-view/build-graph-view.ts
@@ -224,8 +224,8 @@ function componentIdsForClaim(claimId: string, edges: Edge[]): string[] {
     .map((edge) => edge.to_id);
 }
 
-function parseAnchors(codeAnchor: string | undefined): string[] {
-  if (codeAnchor === undefined || codeAnchor.trim().length === 0) return [];
+function parseAnchors(codeAnchor: string | null | undefined): string[] {
+  if (codeAnchor === undefined || codeAnchor === null || codeAnchor.trim().length === 0) return [];
   return codeAnchor
     .split(",")
     .map((part) => part.trim())

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -42,6 +42,7 @@ type MembershipRow = {
   subject_id: string;
 };
 
+type ComponentRow = Omit<Component, "code_anchor"> & { code_anchor: string | null };
 type ClaimRow = Omit<Claim, "code_anchors"> & { code_anchors: string | null };
 type EdgeRow = Omit<Edge, "metadata"> & { metadata: string | null };
 type RepoMatch = { repo: RepoRecord; matchedBy: "remote" | "root" };
@@ -404,7 +405,11 @@ export class SqliteRepository {
   }
 
   private loadComponents(ids: string[]): Component[] {
-    return this.loadByIds<Component>("components", ids);
+    return this.loadByIds<ComponentRow>("components", ids).map((row) => ({
+      id: row.id,
+      name: row.name,
+      code_anchor: row.code_anchor ?? undefined,
+    }));
   }
 
   private loadFlows(ids: string[]): Flow[] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greplica",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greplica",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "hasInstallScript": true,
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greplica",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greplica",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "hasInstallScript": true,
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greplica",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greplica",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "hasInstallScript": true,
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greplica",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Long-term, searchable AGENTS.md for coding agents.",
   "private": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greplica",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "description": "Long-term, searchable AGENTS.md for coding agents.",
   "private": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greplica",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Long-term, searchable AGENTS.md for coding agents.",
   "private": false,
   "type": "module",
@@ -20,7 +20,7 @@
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",

--- a/scripts/check-graph-view.js
+++ b/scripts/check-graph-view.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url);
+const { openDatabase } = await import(new URL("dist/libs/storage/sqlite/db.js", root));
+const { SqliteRepository } = await import(new URL("dist/libs/storage/sqlite/repository.js", root));
+const { KnowledgeGraphService } = await import(new URL("dist/libs/knowledge-graph/service.js", root));
+
+const tmp = mkdtempSync(join(tmpdir(), "greplica-graph-view-test-"));
+const db = openDatabase(join(tmp, "graph.db"));
+
+try {
+  const repository = new SqliteRepository(db);
+  const service = new KnowledgeGraphService(repository);
+  const repo = {
+    repo_root: join(tmp, "repo"),
+    repo_name: "graph-view-null-anchor",
+    default_branch: "main",
+  };
+
+  const initialized = service.initRepo(repo);
+  const memoryCommit = repository.createMemoryCommit({
+    scope_id: initialized.working_scope_id,
+    title: "Seed null component anchor",
+  });
+
+  repository.createProposalRecords(initialized.working_scope_id, memoryCommit.id, {
+    title: "Seed null component anchor",
+    creates: {
+      components: [
+        {
+          id: "component.no_anchor",
+          name: "Component Without Anchor",
+        },
+      ],
+    },
+  });
+
+  const html = service.buildGraphView(repo);
+  assert.match(html, /Component Without Anchor/);
+  assert.match(html, /Greplica graph view/);
+} finally {
+  db.close();
+}
+
+console.log("Graph view checks passed.");


### PR DESCRIPTION
## Summary
- Normalize nullable SQLite component code anchors before exposing `Component` rows
- Make graph-view anchor parsing tolerate nullable values defensively
- Add a regression check for rendering graph view when a component has no `code_anchor`
- Bump package version to 0.1.12

## Tests
- `npm test`

## Release notes
After merge, publish from `main`. Remote tags already contain `v0.1.12`/`v0.1.13` on this branch and `v0.1.14` on current `main`, so confirm the intended next tag/version before creating another release tag.