### PR TITLE
Add GitHub Copilot CLI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Current showcase examples:
 ## Commands
 
 ```bash
-greplica install --platform codex|claude|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica install --platform codex|claude|copilot|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
 greplica config
 greplica doctor [--check-embeddings]
 greplica graph read
@@ -114,7 +114,7 @@ greplica graph context "<query>" [--debug]
 greplica graph audit anchors
 greplica graph view [--out <file>] [--no-open]
 greplica graph export <dir>
-greplica transcript bundle --platform codex|claude --file <path> [--file <path>...] --out <bundle.md>
+greplica transcript bundle --platform codex|claude|copilot --file <path> [--file <path>...] --out <bundle.md>
 greplica proposal validate <proposal.json>
 greplica proposal apply <proposal.json>
 ```
@@ -122,8 +122,8 @@ greplica proposal apply <proposal.json>
 - `greplica graph context "<query>"` - returns Markdown for agent use. Add `--debug` for the full retrieval payload with ranking signals.
 - `greplica graph read` - prints the current graph view: all components, flows, claims, sources, and edges in scope.
 - `greplica graph view` to visualise the current memory in a local HTML, opens in your default browser. Use `--out` to choose where the file is written; by default it goes to a temp path.
-- `greplica transcript bundle` - converts one or more Codex or Claude Code JSONL transcripts into a sanitized Markdown bundle for `greplica-fast-session-bootstrap`.
+- `greplica transcript bundle` - converts one or more Codex, Claude Code, or GitHub Copilot CLI JSONL transcripts into a sanitized Markdown bundle for `greplica-fast-session-bootstrap`.
 - `greplica doctor` - verifies installation and diagnoses configuration failures. Not a required preflight before every command.
 - `greplica install` prepares repo state, local storage, and agent integration; normal repo commands require install first.
 
-For **OpenHands**, install is repo-local: skills are written to `.agents/skills/` and the `UserPromptSubmit`/`Stop` hooks to `.openhands/hooks.json` (Claude/Codex install to the agent's home config instead). The hooks inject `graph context` guidance and trigger background working-memory updates the same way; OpenHands must trust the repo hooks for the background save to run.
+For **OpenHands**, install is repo-local: skills are written to `.agents/skills/` and the `UserPromptSubmit`/`Stop` hooks to `.openhands/hooks.json` (Claude/Codex/Copilot install to the agent's home config instead). GitHub Copilot CLI installs personal skills under `~/.copilot/skills` (or `$COPILOT_HOME/skills`) and user hooks under `~/.copilot/hooks/greplica.json`. The hooks inject `graph context` guidance and trigger background working-memory updates; OpenHands must trust the repo hooks for the background save to run.

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -57,7 +57,7 @@ const cliCommands = [
   {
     key: "install",
     path: ["install"],
-    usage: "install --platform codex|claude|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
+    usage: "install --platform codex|claude|copilot|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
     handler: runInstallCommand,
     showInTopLevelHelp: true,
   },
@@ -142,14 +142,14 @@ const cliCommands = [
   {
     key: "transcriptBundle",
     path: ["transcript", "bundle"],
-    usage: "transcript bundle --platform codex|claude --file <path> [--file <path>...] --out <bundle.md>",
+    usage: "transcript bundle --platform codex|claude|copilot --file <path> [--file <path>...] --out <bundle.md>",
     handler: runTranscriptBundle,
     showInTopLevelHelp: true,
   },
   {
     key: "hookIngest",
     path: ["hook", "ingest"],
-    usage: "hook ingest --platform codex|claude|openhands|factory-droid",
+    usage: "hook ingest --platform codex|claude|copilot|openhands|factory-droid",
     handler: runHookIngest,
   },
   {
@@ -422,9 +422,9 @@ function runHookIngest(args: string[]): void {
   }
 }
 
-// OpenHands injects via top-level additionalContext; Claude/Codex use hookSpecificOutput.
+// OpenHands and Copilot inject via top-level additionalContext; Claude/Codex use hookSpecificOutput.
 function hookGuidanceOutput(platform: InstallPlatform, additionalContext: string): Record<string, unknown> {
-  if (platform === "openhands") return { additionalContext };
+  if (platform === "openhands" || platform === "copilot") return { additionalContext };
   return {
     hookSpecificOutput: {
       hookEventName: "UserPromptSubmit",
@@ -519,7 +519,7 @@ function parseHookIngestPlatform(args: string[]): InstallPlatform {
 }
 
 function parseHookPlatform(value: string | undefined): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "openhands" || value === "factory-droid") return value;
+  if (value === "codex" || value === "claude" || value === "copilot" || value === "openhands" || value === "factory-droid") return value;
   throw new Error(usage("hookIngest"));
 }
 
@@ -755,7 +755,7 @@ function parseTranscriptBundleArgs(args: string[]): TranscriptBundleOptions {
 }
 
 function parseTranscriptBundlePlatform(value: string): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "opencode") return value;
+  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode") return value;
   throw new Error(`Invalid --platform ${value}.\n${usage("transcriptBundle")}`);
 }
 
@@ -766,7 +766,7 @@ function requireFlagValue(args: string[], index: number, flag: string, usageText
 }
 
 function parseInstallPlatform(value: string): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "opencode" || value === "openhands" || value === "factory-droid") return value;
+  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode" || value === "openhands" || value === "factory-droid") return value;
   throw new Error(`Invalid --platform ${value}.\n${usage("install")}`);
 }
 

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -38,7 +38,7 @@ Then run:
 
 ```bash
 npm install -g greplica
-greplica install --platform <codex|claude|opencode|openhands|factory-droid> --embedding local <mapped-hook-and-memory-flags>
+greplica install --platform <codex|claude|copilot|opencode|openhands|factory-droid> --embedding local <mapped-hook-and-memory-flags>
 ```
 
 Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps.
@@ -51,7 +51,7 @@ Then bootstrap shallow memory for this repo:
 
 If I chose "Yes, recent sessions", analyze prior sessions:
 - Find recent prior sessions for this same repo and platform, preferring work from the last 1-2 days.
-- Candidate locations: Codex `~/.codex/sessions/**/*.jsonl`; Claude Code `~/.claude/projects/**/*.jsonl`.
+- Candidate locations: Codex `~/.codex/sessions/**/*.jsonl`; Claude Code `~/.claude/projects/**/*.jsonl`; GitHub Copilot CLI paths from `Stop` hook `transcript_path` values or `$COPILOT_HOME/session-state`.
 - Do not require transcript metadata `cwd` to equal the current checkout path. Users may use worktrees, renamed folders, or multiple checkouts of the same repo.
 - Treat a transcript as same-repo when its metadata `cwd` is the current path, or when that `cwd` still exists and Git reports the same `remote.origin.url` or same normalized repo identity as the current repo. If the old path no longer exists, use transcript cwd text, repo name, branch, and recent session content as weaker matching evidence.
 - For OpenCode, tell me transcript backfill is not supported yet and skip this step.
@@ -60,7 +60,7 @@ If I chose "Yes, recent sessions", analyze prior sessions:
 - Do not ask for confirmation. Continue with a temporary bundle path:
 
 ```bash
-greplica transcript bundle --platform <codex-or-claude> --file <path-1> [--file <path-2>] [--file <path-3>] --out <greplica-transcript-backfill.md>
+greplica transcript bundle --platform <codex-or-claude-or-copilot> --file <path-1> [--file <path-2>] [--file <path-3>] --out <greplica-transcript-backfill.md>
 ```
 
 - Then use the `greplica-fast-session-bootstrap` skill on `<greplica-transcript-backfill.md>` and include its final value summary naturally in the final answer.

--- a/libs/hooks/hook-input.ts
+++ b/libs/hooks/hook-input.ts
@@ -1,8 +1,11 @@
 export interface HookInput {
   session_id?: unknown;
+  sessionId?: unknown;
   transcript_path?: unknown;
+  transcriptPath?: unknown;
   cwd?: unknown;
   hook_event_name?: unknown;
+  hookEventName?: unknown;
   turn_id?: unknown;
   prompt?: unknown;
   // OpenHands variants of hook_event_name / cwd.
@@ -26,7 +29,7 @@ export function readHookInput(stdin: string): HookInput {
 }
 
 export function hookEventName(hook: HookInput): string | undefined {
-  return stringField(hook.hook_event_name) ?? stringField(hook.event_type);
+  return stringField(hook.hook_event_name) ?? stringField(hook.hookEventName) ?? stringField(hook.event_type);
 }
 
 export function hookCwd(hook: HookInput): string | undefined {
@@ -34,11 +37,11 @@ export function hookCwd(hook: HookInput): string | undefined {
 }
 
 export function hookSessionId(hook: HookInput): string | undefined {
-  return stringField(hook.session_id);
+  return stringField(hook.session_id) ?? stringField(hook.sessionId);
 }
 
 export function hookTranscriptPath(hook: HookInput): string | undefined {
-  return stringField(hook.transcript_path);
+  return stringField(hook.transcript_path) ?? stringField(hook.transcriptPath);
 }
 
 function stringField(value: unknown): string | undefined {

--- a/libs/hooks/session-state.ts
+++ b/libs/hooks/session-state.ts
@@ -56,7 +56,7 @@ export class HookSessionStore {
     const now = iso(input.now);
     const sessionId = input.sessionId ?? fallbackSessionId(input);
     const existing = this.find(input.platform, sessionId);
-    const shouldInjectGuidance = input.eventName === "UserPromptSubmit" && existing?.guidance_injected_at == null;
+    const shouldInjectGuidance = isGuidanceEvent(input.platform, input.eventName) && existing?.guidance_injected_at == null;
     const incrementStop = input.eventName === "Stop" ? 1 : 0;
 
     if (existing === undefined) {
@@ -197,6 +197,11 @@ function fallbackSessionId(input: RecordHookInput): string {
   const identity = `${input.platform}:${input.repoId}:${input.transcriptPath ?? ""}:${input.cwd ?? ""}`;
   const hash = createHash("sha1").update(identity).digest("hex").slice(0, 16);
   return `unknown_${hash}`;
+}
+
+function isGuidanceEvent(platform: InstallPlatform, eventName: string | undefined): boolean {
+  if (platform === "copilot") return eventName === "SessionStart";
+  return eventName === "UserPromptSubmit";
 }
 
 function iso(date: Date | undefined): string {

--- a/libs/install/install.ts
+++ b/libs/install/install.ts
@@ -70,6 +70,7 @@ export async function installGreplica(options: InstallOptions): Promise<InstallR
 
 export function platformDisplayName(platform: InstallPlatform): string {
   if (platform === "codex") return "Codex";
+  if (platform === "copilot") return "GitHub Copilot CLI";
   if (platform === "opencode") return "OpenCode";
   if (platform === "openhands") return "OpenHands";
   if (platform === "factory-droid") return "Factory Droid";

--- a/libs/install/paths.ts
+++ b/libs/install/paths.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid";
+export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid" | "copilot";
 export type InstallEmbedding = "local" | "openai";
 
 export const skillNames = ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"] as const;

--- a/libs/install/platforms/copilot.ts
+++ b/libs/install/platforms/copilot.ts
@@ -1,0 +1,232 @@
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { hookCommand, readJsonObject, writeJson } from "../hook-config.js";
+import { copyBundledSkills } from "../skills.js";
+import {
+  copyStringField,
+  isRecord,
+  parseJsonLine,
+  renderSessionTranscriptMarkdown,
+  sanitizeTranscriptMessage,
+  type SessionTranscriptMessage,
+} from "../../session-transcript/markdown.js";
+import type { PlatformInstallContext, PlatformInstallResult, PlatformInstaller, WorkingMemoryUpdateInput } from "./types.js";
+
+const copilotSessionRefPrefix = "copilot-session:";
+const copilotHookEvents = ["SessionStart", "Stop"] as const;
+
+export const copilotInstaller: PlatformInstaller = {
+  platform: "copilot",
+  install(context: PlatformInstallContext): PlatformInstallResult {
+    const home = copilotHome();
+    const skills = copyBundledSkills(join(home, "skills"));
+    if (!context.hooks) return { skills };
+
+    const hookConfigPath = join(home, "hooks", "greplica.json");
+    const command = hookCommand("copilot");
+    const hookConfig = mergeCopilotHookConfig(readJsonObject(hookConfigPath), command);
+    writeJson(hookConfigPath, hookConfig);
+
+    return {
+      skills,
+      hooks: {
+        platform: "copilot",
+        configFiles: [hookConfigPath],
+        events: [...copilotHookEvents],
+        command,
+      },
+    };
+  },
+  sessionSourceRef(sessionId: string): string {
+    return `${copilotSessionRefPrefix}${sessionId}`;
+  },
+  sessionIdFromSourceRef(ref: string): string | undefined {
+    return ref.startsWith(copilotSessionRefPrefix) ? ref.slice(copilotSessionRefPrefix.length) : undefined;
+  },
+  transcriptToMarkdown(transcript: string): string {
+    return copilotTranscriptToMarkdown(transcript);
+  },
+  async runWorkingMemoryUpdate(input: WorkingMemoryUpdateInput): Promise<void> {
+    await runCopilot(input);
+  },
+};
+
+function copilotHome(): string {
+  return process.env.COPILOT_HOME ?? join(homedir(), ".copilot");
+}
+
+function mergeCopilotHookConfig(base: Record<string, unknown>, command: string): Record<string, unknown> {
+  const hooks = isRecord(base.hooks) ? { ...base.hooks } : {};
+
+  for (const event of copilotHookEvents) {
+    const existingHooks = Array.isArray(hooks[event]) ? hooks[event] : [];
+    hooks[event] = [
+      ...existingHooks.filter((entry) => !isRecord(entry) || entry.command !== command),
+      copilotCommandHook(command),
+    ];
+  }
+
+  return {
+    ...base,
+    version: typeof base.version === "number" ? base.version : 1,
+    hooks,
+  };
+}
+
+function copilotCommandHook(command: string): Record<string, unknown> {
+  return {
+    type: "command",
+    command,
+    timeoutSec: 5,
+  };
+}
+
+function copilotTranscriptToMarkdown(jsonl: string): string {
+  const metadata: Record<string, string> = {};
+  const messages: SessionTranscriptMessage[] = [];
+
+  for (const line of jsonl.split("\n")) {
+    const event = parseJsonLine(line);
+    if (!isRecord(event)) continue;
+
+    copyStringField(metadata, event, "sessionId", "session_id");
+    copyStringField(metadata, event, "session_id", "session_id");
+    copyStringField(metadata, event, "cwd", "cwd");
+    copyStringField(metadata, event, "model", "model");
+    if (event.type === "session.start" && isRecord(event.data)) {
+      copyStringField(metadata, event.data, "sessionId", "session_id");
+      copyStringField(metadata, event.data, "copilotVersion", "copilot_version");
+      if (isRecord(event.data.context)) {
+        copyStringField(metadata, event.data.context, "cwd", "cwd");
+        copyStringField(metadata, event.data.context, "repository", "repository");
+        copyStringField(metadata, event.data.context, "branch", "branch");
+      }
+    }
+    if (event.type === "session.model_change" && isRecord(event.data)) {
+      copyStringField(metadata, event.data, "newModel", "model");
+    }
+
+    const role = copilotTranscriptRole(event);
+    if (role === undefined) continue;
+
+    const message = copilotTranscriptMessage(event);
+    const sanitizedMessage = sanitizeTranscriptMessage(message);
+    if (sanitizedMessage.length === 0) continue;
+    messages.push({
+      timestamp: stringValue(event.timestamp) ?? numberTimestamp(event.timestamp),
+      role,
+      phase: stringValue(event.phase) ?? stringValue(event.type),
+      message: sanitizedMessage,
+    });
+  }
+
+  return renderSessionTranscriptMarkdown({ metadata, messages });
+}
+
+function copilotTranscriptRole(event: Record<string, unknown>): SessionTranscriptMessage["role"] | undefined {
+  const directRole = stringValue(event.role);
+  if (directRole === "user" || directRole === "human") return "human";
+  if (directRole === "assistant" || directRole === "agent") return "agent";
+
+  if (isRecord(event.data)) {
+    const dataRole = stringValue(event.data.role);
+    if (dataRole === "user" || dataRole === "human") return "human";
+    if (dataRole === "assistant" || dataRole === "agent") return "agent";
+  }
+
+  if (isRecord(event.message)) {
+    const messageRole = stringValue(event.message.role);
+    if (messageRole === "user" || messageRole === "human") return "human";
+    if (messageRole === "assistant" || messageRole === "agent") return "agent";
+  }
+
+  const type = stringValue(event.type) ?? stringValue(event.kind);
+  if (type === "user" || type === "user_message" || type === "user.message" || type === "human") return "human";
+  if (
+    type === "assistant" ||
+    type === "assistant_message" ||
+    type === "assistant.message" ||
+    type === "agent" ||
+    type === "agent_message"
+  ) {
+    return "agent";
+  }
+  return undefined;
+}
+
+function copilotTranscriptMessage(event: Record<string, unknown>): string {
+  const direct = extractTextContent(event.content) || extractTextContent(event.text) || extractTextContent(event.message);
+  if (direct.length > 0) return direct;
+  if (isRecord(event.data)) return extractTextContent(event.data.content) || extractTextContent(event.data.text);
+  if (isRecord(event.message)) return extractTextContent(event.message.content) || extractTextContent(event.message.text);
+  return "";
+}
+
+function extractTextContent(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (Array.isArray(value)) {
+    const parts: string[] = [];
+    for (const item of value) {
+      const extracted = extractTextContent(item);
+      if (extracted.length > 0) parts.push(extracted);
+    }
+    return parts.join("\n\n").trim();
+  }
+  if (!isRecord(value)) return "";
+  if (typeof value.text === "string") return value.text.trim();
+  if (typeof value.content === "string") return value.content.trim();
+  if (Array.isArray(value.content)) return extractTextContent(value.content);
+  return "";
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberTimestamp(value: unknown): string | undefined {
+  return typeof value === "number" ? new Date(value).toISOString() : undefined;
+}
+
+function runCopilot(input: WorkingMemoryUpdateInput): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const sharePath = `${input.transcriptPath}.share.md`;
+    const args = [
+      "-s",
+      "--allow-all",
+      "--no-ask-user",
+      `--share=${sharePath}`,
+    ];
+
+    const child = spawn("copilot", args, {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    child.once("error", reject);
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+    });
+    child.stdin.end(input.prompt);
+    child.once("close", (exitCode, signal) => {
+      const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+      writeFileSync(input.finalMessagePath, stdout, "utf8");
+      writeFileSync(
+        input.transcriptPath,
+        `${JSON.stringify({
+          type: "copilot_run",
+          timestamp: new Date().toISOString(),
+          exit_code: exitCode,
+          signal,
+          share_path: sharePath,
+          output: stdout.trim(),
+        })}\n`,
+        "utf8",
+      );
+      resolve();
+    });
+  });
+}

--- a/libs/install/platforms/index.ts
+++ b/libs/install/platforms/index.ts
@@ -1,5 +1,6 @@
 import type { InstallPlatform } from "../paths.js";
 import { claudeInstaller } from "./claude.js";
+import { copilotInstaller } from "./copilot.js";
 import { codexInstaller } from "./codex.js";
 import { droidInstaller } from "./droid.js";
 import { opencodeInstaller } from "./opencode.js";
@@ -9,6 +10,7 @@ import type { HookInstallResult, PlatformInstallContext, PlatformInstaller, Plat
 const platformInstallers: Partial<Record<InstallPlatform, PlatformInstaller>> = {
   claude: claudeInstaller,
   codex: codexInstaller,
+  copilot: copilotInstaller,
   opencode: opencodeInstaller,
   openhands: openhandsInstaller,
   "factory-droid": droidInstaller,

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -116,7 +116,7 @@ export class SqliteRepository {
   requireRepo(input: UpsertRepoInput): RepoRecord {
     const repo = this.getRepo(input);
     if (!repo) {
-      throw new Error("Greplica is not installed for this repo. Run greplica install --platform <codex|claude|opencode> --embedding local from the repo you want to use.");
+      throw new Error("Greplica is not installed for this repo. Run greplica install --platform <codex|claude|copilot|opencode> --embedding local from the repo you want to use.");
     }
     return repo;
   }
@@ -190,7 +190,7 @@ export class SqliteRepository {
     const scope = this.db
       .prepare("SELECT * FROM graph_scopes WHERE repo_id = ? AND kind = 'working' AND name = 'working'")
       .get(repoId) as GraphScope | undefined;
-    if (!scope) throw new Error("Working scope is missing. Run 'greplica install --platform <codex|claude|opencode> --embedding local' from this repo.");
+    if (!scope) throw new Error("Working scope is missing. Run 'greplica install --platform <codex|claude|copilot|opencode> --embedding local' from this repo.");
     return scope;
   }
 
@@ -198,7 +198,7 @@ export class SqliteRepository {
     const scope = this.db
       .prepare("SELECT * FROM graph_scopes WHERE repo_id = ? AND kind = 'main' ORDER BY created_at LIMIT 1")
       .get(repoId) as GraphScope | undefined;
-    if (!scope) throw new Error("Main scope is missing. Run 'greplica install --platform <codex|claude|opencode> --embedding local' from this repo.");
+    if (!scope) throw new Error("Main scope is missing. Run 'greplica install --platform <codex|claude|copilot|opencode> --embedding local' from this repo.");
     return scope;
   }
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
+    "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
     "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",

--- a/scripts/check-install-options.js
+++ b/scripts/check-install-options.js
@@ -55,6 +55,13 @@ assert.match(unsupportedHooks.output, /Hooks: not installed for this platform\./
 assert.match(unsupportedHooks.output, /Automatic memory updates: disabled\./);
 assert.equal(readConfig(unsupportedHooks.greplicaHome).session.autoMemoryUpdates, false);
 
+const copilotHooks = installInTempRepo("copilot-hooks", ["--hooks", "enabled", "--auto-memory", "enabled"], "copilot");
+assert.match(copilotHooks.output, /Installed Greplica for GitHub Copilot CLI\./);
+assert.match(copilotHooks.output, /Hooks: installed for SessionStart, Stop\./);
+assert.match(copilotHooks.output, /Automatic memory updates: enabled\./);
+assert.ok(existsSync(join(copilotHooks.copilotHome, "hooks", "greplica.json")));
+assert.equal(readConfig(copilotHooks.greplicaHome).session.autoMemoryUpdates, true);
+
 const invalid = spawnSync(
   process.execPath,
   [
@@ -96,6 +103,7 @@ function installInTempRepo(name, flags, platform = "codex") {
   const repo = join(tmp, name, "repo");
   const greplicaHome = join(tmp, name, "greplica-home");
   const codexHome = join(tmp, name, "codex-home");
+  const copilotHome = join(tmp, name, "copilot-home");
   mkdirSync(repo, { recursive: true });
   execFileSync("git", ["init", "--quiet"], { cwd: repo, encoding: "utf8" });
 
@@ -103,6 +111,7 @@ function installInTempRepo(name, flags, platform = "codex") {
     ...process.env,
     GREPLICA_HOME: greplicaHome,
     CODEX_HOME: codexHome,
+    COPILOT_HOME: copilotHome,
     XDG_CONFIG_HOME: join(tmp, name, "xdg-config-home"),
     GREPLICA_INSTALL_SKIP_PREWARM: "1",
   };
@@ -120,7 +129,7 @@ function installInTempRepo(name, flags, platform = "codex") {
     encoding: "utf8",
     env,
   });
-  return { repo, greplicaHome, codexHome, output, env };
+  return { repo, greplicaHome, codexHome, copilotHome, output, env };
 }
 
 function readConfig(greplicaHome) {

--- a/scripts/check-transcript-bundle.js
+++ b/scripts/check-transcript-bundle.js
@@ -11,8 +11,10 @@ const tmp = mkdtempSync(join(tmpdir(), "greplica-transcript-bundle-test-"));
 const codexOne = join(tmp, "codex-one.jsonl");
 const codexTwo = join(tmp, "codex-two.jsonl");
 const claudeOne = join(tmp, "claude-one.jsonl");
+const copilotOne = join(tmp, "copilot-one.jsonl");
 const codexOut = join(tmp, "codex-bundle.md");
 const claudeOut = join(tmp, "claude-bundle.md");
+const copilotOut = join(tmp, "copilot-bundle.md");
 const opencodeOut = join(tmp, "opencode-bundle.md");
 
 writeFileSync(
@@ -82,6 +84,47 @@ writeFileSync(
   "utf8",
 );
 
+writeFileSync(
+  copilotOne,
+  [
+    JSON.stringify({
+      type: "session.start",
+      data: {
+        sessionId: "copilot-session-one",
+        copilotVersion: "1.0.66",
+        context: {
+          cwd: "/repo/example",
+          repository: "Autoloops/greplica",
+          branch: "copilot-test",
+        },
+      },
+      timestamp: "2026-06-25T00:03:30.000Z",
+    }),
+    JSON.stringify({
+      type: "session.model_change",
+      data: {
+        newModel: "claude-haiku-4.5",
+      },
+      timestamp: "2026-06-25T00:03:45.000Z",
+    }),
+    JSON.stringify({
+      session_id: "copilot-session-one",
+      cwd: "/repo/example",
+      timestamp: "2026-06-25T00:04:00.000Z",
+      role: "user",
+      content: "Remember this durable Copilot insight. <system_instruction>remove this</system_instruction>",
+    }),
+    JSON.stringify({
+      session_id: "copilot-session-one",
+      cwd: "/repo/example",
+      timestamp: "2026-06-25T00:05:00.000Z",
+      role: "assistant",
+      content: [{ type: "text", text: "A Copilot assistant fact." }],
+    }),
+  ].join("\n"),
+  "utf8",
+);
+
 const codexOutput = execFileSync(
   process.execPath,
   [
@@ -130,6 +173,30 @@ const claudeBundle = readFileSync(claudeOut, "utf8");
 assert.match(claudeOutput, /claude-code-session:claude-session-one/);
 assert.match(claudeBundle, /session_ref: claude-code-session:claude-session-one/);
 assert.match(claudeBundle, /Remember this durable Claude insight/);
+
+const copilotOutput = execFileSync(
+  process.execPath,
+  [
+    cli.pathname,
+    "transcript",
+    "bundle",
+    "--platform",
+    "copilot",
+    "--file",
+    copilotOne,
+    "--out",
+    copilotOut,
+  ],
+  { encoding: "utf8" },
+);
+const copilotBundle = readFileSync(copilotOut, "utf8");
+assert.match(copilotOutput, /copilot-session:copilot-session-one/);
+assert.match(copilotBundle, /session_ref: copilot-session:copilot-session-one/);
+assert.match(copilotBundle, /repository: Autoloops\/greplica/);
+assert.match(copilotBundle, /branch: copilot-test/);
+assert.match(copilotBundle, /Remember this durable Copilot insight/);
+assert.match(copilotBundle, /A Copilot assistant fact/);
+assert.doesNotMatch(copilotBundle, /remove this/);
 
 assert.throws(
   () =>

--- a/scripts/smoke-copilot-install.mjs
+++ b/scripts/smoke-copilot-install.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// Focused smoke check for `greplica install --platform copilot`.
+//
+// Verifies user-level Copilot CLI skills + hooks under COPILOT_HOME, guidance
+// output shape for SessionStart, non-destructive hook reinstall, and Stop hook
+// session tracking with a sample transcript path.
+
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = findRepoRoot(scriptDir);
+const cli = resolve(repoRoot, "dist/apps/cli/main.js");
+const command = "greplica hook ingest --platform copilot";
+
+const tempDir = mkdtempSync(resolve(tmpdir(), "greplica-copilot-smoke-"));
+const workspace = resolve(tempDir, "repo");
+const greplicaHome = resolve(tempDir, "greplica-home");
+const copilotHome = resolve(tempDir, "copilot-home");
+const transcriptPath = resolve(tempDir, "copilot-session.jsonl");
+
+const env = {
+  ...process.env,
+  COPILOT_HOME: copilotHome,
+  GREPLICA_HOME: greplicaHome,
+  GREPLICA_INSTALL_SKIP_PREWARM: "1",
+};
+delete env.GREPLICA_HOOK_DISABLE;
+
+try {
+  assert.ok(existsSync(cli), `Built CLI not found at ${cli}. Run "npm run build" first.`);
+  runOrThrow(["git", "init", "-q", workspace], repoRoot);
+
+  const installOutput = runOrThrow([
+    process.execPath,
+    cli,
+    "install",
+    "--platform",
+    "copilot",
+    "--embedding",
+    "local",
+  ], workspace);
+  assert.match(installOutput.stdout, /Installed Greplica for GitHub Copilot CLI\./);
+  assert.match(installOutput.stdout, /Hooks: installed for SessionStart, Stop\./);
+
+  checkSkills();
+  checkHooks();
+  checkGuidanceOutput();
+  checkStopSessionTracking();
+  checkNonDestructiveReinstall();
+
+  console.log(`OK: Copilot skills + hooks installed under ${copilotHome}`);
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+function checkSkills() {
+  for (const skill of ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"]) {
+    assert.ok(existsSync(resolve(copilotHome, "skills", skill, "SKILL.md")), `missing skill ${skill}`);
+  }
+}
+
+function checkHooks() {
+  const hooksPath = resolve(copilotHome, "hooks", "greplica.json");
+  assert.ok(existsSync(hooksPath), "greplica.json hook file was not created");
+  const hooks = JSON.parse(readFileSync(hooksPath, "utf8")).hooks ?? {};
+  for (const event of ["SessionStart", "Stop"]) {
+    assert.ok(commandPresent(hooks[event], command), `${event} hook missing command "${command}"`);
+  }
+}
+
+function checkGuidanceOutput() {
+  const hookInput = JSON.stringify({
+    hook_event_name: "SessionStart",
+    session_id: "copilot-smoke-session",
+    cwd: workspace,
+  });
+  const result = run([process.execPath, cli, "hook", "ingest", "--platform", "copilot"], workspace, hookInput);
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout.trim());
+  assert.equal(typeof payload.additionalContext, "string");
+  assert.match(payload.additionalContext, /Greplica hook guidance/);
+  assert.equal(payload.hookSpecificOutput, undefined);
+}
+
+function checkStopSessionTracking() {
+  writeFileSync(
+    transcriptPath,
+    [
+      JSON.stringify({
+        session_id: "copilot-smoke-session",
+        cwd: workspace,
+        role: "user",
+        content: "Remember this Copilot transcript fact.",
+      }),
+      JSON.stringify({
+        session_id: "copilot-smoke-session",
+        cwd: workspace,
+        role: "assistant",
+        content: "Stored Copilot transcript context.",
+      }),
+    ].join("\n"),
+    "utf8",
+  );
+
+  const stopInput = JSON.stringify({
+    hook_event_name: "Stop",
+    session_id: "copilot-smoke-session",
+    cwd: workspace,
+    transcript_path: transcriptPath,
+  });
+  const stopResult = run([process.execPath, cli, "hook", "ingest", "--platform", "copilot"], workspace, stopInput);
+  assert.equal(stopResult.status, 0, stopResult.stderr);
+
+  const markResult = run([
+    process.execPath,
+    cli,
+    "session",
+    "mark-memory-current",
+    "--session-ref",
+    "copilot-session:copilot-smoke-session",
+  ], workspace);
+  assert.equal(markResult.status, 0, markResult.stderr);
+  assert.match(markResult.stdout, /Marked session memory current\./);
+}
+
+function checkNonDestructiveReinstall() {
+  const hooksPath = resolve(copilotHome, "hooks", "greplica.json");
+  const hooks = JSON.parse(readFileSync(hooksPath, "utf8"));
+  hooks.hooks.SessionStart.push({ type: "command", command: "echo user-custom-hook", timeoutSec: 3 });
+  hooks.hooks.preToolUse = [{ type: "command", command: "echo user-pretool", timeoutSec: 3 }];
+  writeFileSync(hooksPath, `${JSON.stringify(hooks, null, 2)}\n`);
+
+  runOrThrow([
+    process.execPath,
+    cli,
+    "install",
+    "--platform",
+    "copilot",
+    "--embedding",
+    "local",
+  ], workspace);
+
+  const after = readFileSync(hooksPath, "utf8");
+  assert.match(after, /user-custom-hook/, "user's SessionStart hook was dropped on reinstall");
+  assert.match(after, /user-pretool/, "user's unrelated preToolUse hook was dropped on reinstall");
+  const occurrences = after.split(command).length - 1;
+  assert.equal(occurrences, 2, `expected greplica command exactly twice after reinstall, found ${occurrences}`);
+}
+
+function commandPresent(entries, value) {
+  return Array.isArray(entries) && entries.some((entry) => entry?.command === value);
+}
+
+function run(commandArgs, cwd, input) {
+  return spawnSync(commandArgs[0], commandArgs.slice(1), { cwd, env, input, encoding: "utf8" });
+}
+
+function runOrThrow(commandArgs, cwd) {
+  const result = run(commandArgs, cwd);
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status}): ${commandArgs.join(" ")}\n${result.stderr ?? ""}`);
+  }
+  return result;
+}
+
+function findRepoRoot(startDir) {
+  let current = startDir;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (existsSync(resolve(current, "package.json")) && existsSync(resolve(current, "libs/install/platforms/copilot.ts"))) return current;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Could not find repo root from ${startDir}`);
+}


### PR DESCRIPTION
## Summary
- add GitHub Copilot CLI as a first-class Greplica install platform
- install Copilot skills and user hooks under COPILOT_HOME/~/.copilot
- support Copilot hook ingest, transcript bundling, and background memory updates
- document Copilot setup and add hermetic smoke/test coverage

## Validation
- npm run smoke:copilot
- npm run test:transcript-bundle
- npm test
- npm run typecheck
- live Copilot CLI validation with real SessionStart/Stop hooks and transcript bundle