### PR TITLE
feat: add greplica graph gc command for knowledge graph cleanup

### DIFF
--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -5,7 +5,7 @@ import { isatty } from "node:tty";
 import { basename, dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { createLocalKnowledgeGraphService, KnowledgeGraphService } from "../../libs/knowledge-graph/service.js";
-import type { ClaimAnchorAuditResult, RepoRef } from "../../libs/knowledge-graph/service.js";
+import type { ClaimAnchorAuditResult, GcApplyResult, GcScanResult, RepoRef } from "../../libs/knowledge-graph/service.js";
 import { envVarSource, loadRepoEnv, type LoadedRepoEnv } from "../../libs/env/load-local-env.js";
 import {
   ensureGreplicaConfig,
@@ -96,6 +96,13 @@ const cliCommands = [
     handler: runGraphContextCommand,
     showInTopLevelHelp: true,
     helpMode: "query-aware",
+  },
+  {
+    key: "graphGc",
+    path: ["graph", "gc"],
+    usage: "graph gc [--dry-run]",
+    handler: runGraphGcCommand,
+    showInTopLevelHelp: true,
   },
   {
     key: "graphAuditAnchors",
@@ -271,6 +278,25 @@ async function runGraphContextCommand(args: string[]): Promise<void> {
   }
 }
 
+async function runGraphGcCommand(args: string[]): Promise<void> {
+  const dryRun = args.includes("--dry-run");
+  const { repo, service } = createCommandContext();
+  const result = service.gcGraph(repo, dryRun);
+  if (dryRun) {
+    printGcDryRun((result as { scan: GcScanResult }).scan);
+  } else {
+    printGcApply(result as GcApplyResult);
+  }
+  const scan = dryRun ? (result as { scan: GcScanResult }).scan : (result as GcApplyResult).scan;
+  const totalIssues =
+    scan.stale_components.length +
+    scan.orphaned_components.length +
+    scan.orphaned_claims.length +
+    scan.orphaned_flows.length +
+    scan.dangling_edges.length;
+  if (totalIssues > 0) process.exitCode = 1;
+}
+
 async function runGraphAuditAnchorsCommand(_args: string[]): Promise<void> {
   const { repo, service } = createCommandContext();
   const result = await service.auditCodeAnchors(repo);
@@ -373,6 +399,55 @@ function printAuditSection<T>(title: string, items: T[], render: (item: T) => st
 function formatAuditAnchor(anchor: { file: string; symbol?: string } | undefined): string {
   if (anchor === undefined) return "<missing>";
   return anchor.symbol === undefined ? anchor.file : `${anchor.file}#${anchor.symbol}`;
+}
+
+function printGcDryRun(scan: GcScanResult): void {
+  console.log("Graph GC scan (--dry-run): no changes made.");
+  console.log("");
+  printGcSection("Stale components", scan.stale_components, (item) => `${item.name} (anchor: ${item.code_anchor})`);
+  printGcSection("Orphaned components", scan.orphaned_components, (item) => `${item.name ?? item.id}`);
+  printGcSection("Orphaned claims", scan.orphaned_claims, (item) => `${item.id}: ${item.name ?? ""}`);
+  printGcSection("Orphaned flows", scan.orphaned_flows, (item) => `${item.name ?? item.id}`);
+  printGcSection("Dangling edges", scan.dangling_edges, (item) =>
+    `${item.from_type}:${item.from_id} -[${item.kind}]-> ${item.to_type}:${item.to_id} (broken ${item.broken_end}: ${item.missing_type}:${item.missing_id})`,
+  );
+
+  const staleCount = scan.stale_components.length;
+  const orphanedComponentCount = scan.orphaned_components.length;
+  const orphanedClaimCount = scan.orphaned_claims.length;
+  const orphanedFlowCount = scan.orphaned_flows.length;
+  const danglingEdgeCount = scan.dangling_edges.length;
+  const total = staleCount + orphanedComponentCount + orphanedClaimCount + orphanedFlowCount + danglingEdgeCount;
+
+  console.log("Summary totals:");
+  console.log(`  Stale components:   ${staleCount}`);
+  console.log(`  Orphaned components: ${orphanedComponentCount}`);
+  console.log(`  Orphaned claims:    ${orphanedClaimCount}`);
+  console.log(`  Orphaned flows:     ${orphanedFlowCount}`);
+  console.log(`  Dangling edges:     ${danglingEdgeCount}`);
+  console.log(`  Total issues:       ${total}`);
+}
+
+function printGcApply(result: GcApplyResult): void {
+  const d = result.deleted;
+  console.log("Graph GC applied.");
+  console.log("Deleted:");
+  console.log(`  Components: ${d.components}`);
+  console.log(`  Claims:     ${d.claims}`);
+  console.log(`  Flows:      ${d.flows}`);
+  console.log(`  Edges:      ${d.edges}`);
+  console.log(`  Memberships: ${d.memberships}`);
+  console.log(`  Embeddings: ${d.embeddings}`);
+}
+
+function printGcSection<T>(title: string, items: T[], format: (item: T) => string): void {
+  console.log(`${title}:`);
+  if (items.length === 0) {
+    console.log("- None.");
+  } else {
+    for (const item of items) console.log(`- ${format(item)}`);
+  }
+  console.log("");
 }
 
 function createCommandContext(): CommandContext {

--- a/libs/knowledge-graph/graph-gc.ts
+++ b/libs/knowledge-graph/graph-gc.ts
@@ -1,0 +1,44 @@
+export interface GcStaleComponent {
+  id: string;
+  name: string;
+  code_anchor: string;
+}
+
+export interface GcOrphanedEntity {
+  id: string;
+  type: "component" | "flow" | "claim";
+  name?: string;
+}
+
+export interface GcDanglingEdge {
+  id: string;
+  from_id: string;
+  from_type: string;
+  to_id: string;
+  to_type: string;
+  kind: string;
+  broken_end: "from" | "to";
+  missing_id: string;
+  missing_type: string;
+}
+
+export interface GcScanResult {
+  stale_components: GcStaleComponent[];
+  orphaned_components: GcOrphanedEntity[];
+  orphaned_claims: GcOrphanedEntity[];
+  orphaned_flows: GcOrphanedEntity[];
+  dangling_edges: GcDanglingEdge[];
+}
+
+export interface GcApplyResult {
+  dry_run: boolean;
+  scan: GcScanResult;
+  deleted: {
+    components: number;
+    claims: number;
+    flows: number;
+    edges: number;
+    memberships: number;
+    embeddings: number;
+  };
+}

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -3,6 +3,7 @@ import { validateProposal, type ProposalValidationResult } from "./validate-prop
 import type { Claim } from "./claim.js";
 import type { Edge } from "./edge.js";
 import type { Component, Flow, Source } from "./schema.js";
+import type { GcApplyResult, GcScanResult } from "./graph-gc.js";
 import { GraphContextBuilder } from "./graph-context/context-builder.js";
 import { graphContextConfig, type GraphContextConfig } from "./graph-context/config.js";
 import type { EmbeddingStatus, GraphContextResult } from "./graph-context/types.js";
@@ -13,6 +14,7 @@ import { defaultDatabasePath, openDatabase } from "../storage/sqlite/db.js";
 import type { SqliteRepository } from "../storage/sqlite/repository.js";
 import { SqliteRepository as SqliteKnowledgeGraphRepository } from "../storage/sqlite/repository.js";
 
+export type { GcApplyResult, GcScanResult } from "./graph-gc.js";
 export type { GraphContextResult } from "./graph-context/types.js";
 export type { ClaimAnchorAuditResult } from "./code-anchors/types.js";
 
@@ -118,6 +120,15 @@ export class KnowledgeGraphService {
       warnOnCreatedEmbeddings: true,
       repoRoot: input.repo_root,
     });
+  }
+
+  gcGraph(input: RepoRef, dryRun: boolean): { scan: GcScanResult } | GcApplyResult {
+    const initialized = this.requireRepo(input);
+    if (dryRun) {
+      const scan = this.repository.scanGc(input.repo_root);
+      return { scan };
+    }
+    return this.repository.applyGc(input.repo_root);
   }
 
   async auditCodeAnchors(input: RepoRef): Promise<ClaimAnchorAuditResult> {

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -1,11 +1,14 @@
 import type Database from "better-sqlite3";
+import { existsSync } from "node:fs";
 import { createHash, randomUUID } from "node:crypto";
+import { join } from "node:path";
 import type { MemoryCommit } from "../../knowledge-graph/commit.js";
 import type { Edge } from "../../knowledge-graph/edge.js";
 import type { MemoryCommitProposal } from "../../knowledge-graph/proposal.js";
 import type { Component, Flow, GraphObjectType, Source } from "../../knowledge-graph/schema.js";
 import type { Claim } from "../../knowledge-graph/claim.js";
 import type { GraphScope, GraphScopeKind } from "../../knowledge-graph/scope.js";
+import type { GcScanResult, GcStaleComponent, GcOrphanedEntity, GcDanglingEdge, GcApplyResult } from "../../knowledge-graph/graph-gc.js";
 
 export interface RepoRecord {
   id: string;
@@ -329,6 +332,205 @@ export class SqliteRepository {
     });
 
     write();
+  }
+
+  scanGc(repoRoot: string | undefined): GcScanResult {
+    const allComponents = this.db.prepare("SELECT id, name, code_anchor FROM components").all() as ComponentRow[];
+    const allFlows = this.db.prepare("SELECT id, name FROM flows").all() as Flow[];
+    const allClaims = this.db.prepare("SELECT id, text FROM claims").all() as { id: string; text: string }[];
+    const allEdges = this.db.prepare("SELECT id, from_id, from_type, to_id, to_type, kind FROM edges").all() as Pick<Edge, "id" | "from_id" | "from_type" | "to_id" | "to_type" | "kind">[];
+
+    const existingComponentIds = new Set(allComponents.map((c) => c.id));
+    const existingFlowIds = new Set(allFlows.map((f) => f.id));
+    const existingClaimIds = new Set(allClaims.map((c) => c.id));
+
+    const entityExists = (type: string, id: string): boolean => {
+      if (type === "component") return existingComponentIds.has(id);
+      if (type === "flow") return existingFlowIds.has(id);
+      if (type === "claim") return existingClaimIds.has(id);
+      if (type === "edge") return allEdges.some((e) => e.id === id);
+      if (type === "source") return true;
+      return false;
+    };
+
+    const staleComponents: GcStaleComponent[] = [];
+    const orphanedComponents: GcOrphanedEntity[] = [];
+    const orphanedClaims: GcOrphanedEntity[] = [];
+    const orphanedFlows: GcOrphanedEntity[] = [];
+    const danglingEdges: GcDanglingEdge[] = [];
+
+    for (const component of allComponents) {
+      if (component.code_anchor !== null && repoRoot !== undefined) {
+        const filePath = join(repoRoot, component.code_anchor);
+        if (!existsSync(filePath)) {
+          staleComponents.push({
+            id: component.id,
+            name: component.name,
+            code_anchor: component.code_anchor,
+          });
+        }
+      }
+    }
+
+    const staleComponentIds = new Set(staleComponents.map((c) => c.id));
+
+    const edgeEntities = new Set<string>();
+    const edgeTypes = new Map<string, string>();
+    for (const edge of allEdges) {
+      edgeEntities.add(subjectKey(edge.from_type, edge.from_id));
+      edgeTypes.set(subjectKey(edge.from_type, edge.from_id), edge.from_type);
+      edgeEntities.add(subjectKey(edge.to_type, edge.to_id));
+      edgeTypes.set(subjectKey(edge.to_type, edge.to_id), edge.to_type);
+
+      if (!entityExists(edge.from_type, edge.from_id)) {
+        danglingEdges.push({
+          id: edge.id,
+          from_id: edge.from_id,
+          from_type: edge.from_type,
+          to_id: edge.to_id,
+          to_type: edge.to_type,
+          kind: edge.kind,
+          broken_end: "from",
+          missing_id: edge.from_id,
+          missing_type: edge.from_type,
+        });
+      } else if (!entityExists(edge.to_type, edge.to_id) && edge.to_type !== "source") {
+        danglingEdges.push({
+          id: edge.id,
+          from_id: edge.from_id,
+          from_type: edge.from_type,
+          to_id: edge.to_id,
+          to_type: edge.to_type,
+          kind: edge.kind,
+          broken_end: "to",
+          missing_id: edge.to_id,
+          missing_type: edge.to_type,
+        });
+      }
+    }
+
+    const danglingEdgeToIds = new Set(danglingEdges.map((e) => e.id));
+    const danglingEntityKeys = new Set<string>();
+    for (const edge of danglingEdges) {
+      danglingEntityKeys.add(subjectKey(edge.missing_type as GraphObjectType, edge.missing_id));
+    }
+
+    for (const component of allComponents) {
+      const key = subjectKey("component", component.id);
+      if (staleComponentIds.has(component.id)) continue;
+      if (danglingEntityKeys.has(key)) continue;
+      if (!edgeEntities.has(key)) {
+        orphanedComponents.push({ id: component.id, name: component.name, type: "component" });
+      }
+    }
+
+    for (const flow of allFlows) {
+      const key = subjectKey("flow", flow.id);
+      if (danglingEntityKeys.has(key)) continue;
+      if (!edgeEntities.has(key)) {
+        orphanedFlows.push({ id: flow.id, name: flow.name, type: "flow" });
+      }
+    }
+
+    for (const claim of allClaims) {
+      const key = subjectKey("claim", claim.id);
+      if (danglingEntityKeys.has(key)) continue;
+      if (!edgeEntities.has(key)) {
+        orphanedClaims.push({ id: claim.id, name: claim.text.slice(0, 80), type: "claim" });
+      }
+    }
+
+    return {
+      stale_components: staleComponents,
+      orphaned_components: orphanedComponents,
+      orphaned_claims: orphanedClaims,
+      orphaned_flows: orphanedFlows,
+      dangling_edges: danglingEdges,
+    };
+  }
+
+  applyGc(repoRoot: string | undefined): GcApplyResult {
+    const scan = this.scanGc(repoRoot);
+
+    const deleteEdgeStmt = this.db.prepare("DELETE FROM edges WHERE id = ?");
+    const deleteMembershipStmt = this.db.prepare("DELETE FROM graph_memberships WHERE subject_type = ? AND subject_id = ?");
+    const deleteEmbeddingStmt = this.db.prepare("DELETE FROM graph_object_embeddings WHERE object_type = ? AND object_id = ?");
+    const deleteComponentStmt = this.db.prepare("DELETE FROM components WHERE id = ?");
+    const deleteFlowStmt = this.db.prepare("DELETE FROM flows WHERE id = ?");
+    const deleteClaimStmt = this.db.prepare("DELETE FROM claims WHERE id = ?");
+    const edgesByFrom = this.db.prepare("SELECT id FROM edges WHERE from_type = ? AND from_id = ?");
+    const edgesByTo = this.db.prepare("SELECT id FROM edges WHERE to_type = ? AND to_id = ?");
+    const allEdges = this.db.prepare("SELECT id FROM edges");
+
+    const cleanup = this.db.transaction(() => {
+      let deletedComponents = 0;
+      let deletedClaims = 0;
+      let deletedFlows = 0;
+      let deletedEdges = 0;
+      let deletedMemberships = 0;
+      let deletedEmbeddings = 0;
+
+      const allIdsToDelete = new Set<string>();
+      const remainingEdgeIds = new Set((allEdges.all() as { id: string }[]).map((r) => r.id));
+
+      const queueDelete = (type: string, id: string): void => {
+        const key = `${type}:${id}`;
+        if (allIdsToDelete.has(key)) return;
+        allIdsToDelete.add(key);
+
+        const cascadeEdges = new Set<string>();
+        for (const row of edgesByFrom.all(type, id) as { id: string }[]) cascadeEdges.add(row.id);
+        for (const row of edgesByTo.all(type, id) as { id: string }[]) cascadeEdges.add(row.id);
+
+        for (const edgeId of cascadeEdges) {
+          if (!remainingEdgeIds.has(edgeId)) continue;
+          remainingEdgeIds.delete(edgeId);
+          deletedMemberships += deleteMembershipStmt.run("edge", edgeId).changes;
+          deleteEdgeStmt.run(edgeId);
+          deletedEdges += 1;
+        }
+
+        deletedMemberships += deleteMembershipStmt.run(type, id).changes;
+        deletedEmbeddings += deleteEmbeddingStmt.run(type, id).changes;
+
+        switch (type) {
+          case "component": deleteComponentStmt.run(id); deletedComponents += 1; break;
+          case "flow": deleteFlowStmt.run(id); deletedFlows += 1; break;
+          case "claim": deleteClaimStmt.run(id); deletedClaims += 1; break;
+        }
+      };
+
+      for (const component of scan.stale_components) {
+        queueDelete("component", component.id);
+      }
+
+      for (const edge of scan.dangling_edges) {
+        const key = `edge:${edge.id}`;
+        if (!remainingEdgeIds.has(edge.id)) continue;
+        remainingEdgeIds.delete(edge.id);
+        allIdsToDelete.add(key);
+        deletedMemberships += deleteMembershipStmt.run("edge", edge.id).changes;
+        deleteEdgeStmt.run(edge.id);
+        deletedEdges += 1;
+      }
+
+      for (const entity of scan.orphaned_components) {
+        queueDelete("component", entity.id);
+      }
+
+      for (const entity of scan.orphaned_flows) {
+        queueDelete("flow", entity.id);
+      }
+
+      for (const entity of scan.orphaned_claims) {
+        queueDelete("claim", entity.id);
+      }
+
+      return { components: deletedComponents, claims: deletedClaims, flows: deletedFlows, edges: deletedEdges, memberships: deletedMemberships, embeddings: deletedEmbeddings };
+    });
+
+    const deleted = cleanup();
+    return { dry_run: false, scan, deleted };
   }
 
   subjectExists(type: GraphObjectType, id: string): boolean {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit",
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-graph-gc.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",

--- a/scripts/check-graph-gc.js
+++ b/scripts/check-graph-gc.js
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url);
+const { openDatabase } = await import(new URL("dist/libs/storage/sqlite/db.js", root));
+const { SqliteRepository } = await import(new URL("dist/libs/storage/sqlite/repository.js", root));
+const { KnowledgeGraphService } = await import(new URL("dist/libs/knowledge-graph/service.js", root));
+
+const tmp = mkdtempSync(join(tmpdir(), "greplica-graph-gc-test-"));
+const db = openDatabase(join(tmp, "graph.db"));
+
+try {
+  const repository = new SqliteRepository(db);
+  const service = new KnowledgeGraphService(repository);
+  const repoRoot = join(tmp, "repo");
+  mkdirSync(repoRoot, { recursive: true });
+
+  const repo = {
+    repo_root: repoRoot,
+    repo_name: "graph-gc-test",
+    default_branch: "main",
+  };
+
+  const initialized = service.initRepo(repo);
+
+  // Create a working proposal with various entities
+  const memoryCommit = repository.createMemoryCommit({
+    scope_id: initialized.working_scope_id,
+    title: "Seed test data",
+  });
+
+  repository.createProposalRecords(initialized.working_scope_id, memoryCommit.id, {
+    title: "Seed test data",
+    creates: {
+      components: [
+        { id: "comp.valid", name: "Valid Component" },
+        { id: "comp.stale_anchor", name: "Stale Anchor Component", code_anchor: "nonexistent-file.ts" },
+        { id: "comp.orphaned", name: "Orphaned Component" },
+      ],
+      flows: [
+        { id: "flow.valid", name: "Valid Flow" },
+        { id: "flow.orphaned", name: "Orphaned Flow" },
+      ],
+      claims: [
+        { id: "claim.valid", name: "Valid Claim", kind: "fact", text: "Valid claim text", truth: "unknown", intent: "unknown" },
+        { id: "claim.orphaned", name: "Orphaned Claim", kind: "fact", text: "Orphaned claim text", truth: "unknown", intent: "unknown" },
+      ],
+      sources: [{ id: "src.test", kind: "session", ref: "test-session" }],
+      edges: [
+        { id: "edge.valid_about", from_id: "claim.valid", from_type: "claim", to_id: "comp.valid", to_type: "component", kind: "about" },
+        { id: "edge.valid_touches", from_id: "flow.valid", from_type: "flow", to_id: "comp.valid", to_type: "component", kind: "touches" },
+        { id: "edge.valid_evidenced", from_id: "claim.valid", from_type: "claim", to_id: "src.test", to_type: "source", kind: "evidenced_by" },
+        { id: "edge.orphaned_dangling", from_id: "flow.valid", from_type: "flow", to_id: "comp.nonexistent", to_type: "component", kind: "touches" },
+      ],
+    },
+  });
+
+  // Add an edge from stale_anchor to comp.orphaned so they're connected to each other but isolated
+  const mc2 = repository.createMemoryCommit({ scope_id: initialized.working_scope_id, title: "Seed more data" });
+  repository.createProposalRecords(initialized.working_scope_id, mc2.id, {
+    title: "Seed more data",
+    creates: {
+      components: [
+        { id: "comp.stale_connected", name: "Stale Connected", code_anchor: "missing-too.ts" },
+      ],
+      edges: [
+        { id: "edge.comp_to_stale", from_id: "comp.stale_connected", from_type: "component", to_id: "comp.stale_anchor", to_type: "component", kind: "contains" },
+      ],
+    },
+  });
+
+  // Also add an embedding to verify cleanup
+  repository.insertGraphObjectEmbeddings([
+    {
+      repo_id: initialized.repo_id,
+      object_type: "component",
+      object_id: "comp.stale_anchor",
+      provider: "test",
+      model: "test-model",
+      dimensions: 128,
+      embedding: Buffer.from([0, 1, 2, 3]),
+    },
+    {
+      repo_id: initialized.repo_id,
+      object_type: "component",
+      object_id: "comp.stale_connected",
+      provider: "test",
+      model: "test-model",
+      dimensions: 128,
+      embedding: Buffer.from([0, 1, 2, 3]),
+    },
+  ]);
+
+  // Test dry-run
+  const dryResult = service.gcGraph(repo, true);
+  const scan = dryResult.scan;
+  assert.equal(scan.stale_components.length, 2, "Should detect 2 stale components");
+  assert.equal(scan.dangling_edges.length, 1, "Should detect 1 dangling edge");
+  assert.equal(scan.orphaned_components.length, 1, "Should detect 1 orphaned component");
+  assert.equal(scan.orphaned_claims.length, 1, "Should detect 1 orphaned claim");
+  assert.equal(scan.orphaned_flows.length, 1, "Should detect 1 orphaned flow");
+
+  // Verify dry-run did not modify the database (check raw tables directly)
+  const rawComponentsBefore = db.prepare("SELECT id FROM components").all();
+  assert.equal(rawComponentsBefore.length, 4, "Dry run should not remove components from DB");
+  const rawEdgesBefore = db.prepare("SELECT id FROM edges").all();
+  assert.equal(rawEdgesBefore.length, 5, "Dry run should not remove edges from DB");
+
+  // Test apply - one pass should clean everything including cascading
+  const applyResult = service.gcGraph(repo, false);
+  // Expected: 2 stale comps, 1 orphan comp = 3 component deletes
+  // 1 orphan claim, 1 orphan flow = 5 entity deletes total
+  // Plus: 1 dangling edge + 1 connected edge (comp_to_stale) = 2 edge deletes
+  assert.equal(applyResult.deleted.components, 3, "Should delete 3 components");
+  assert.equal(applyResult.deleted.claims, 1, "Should delete 1 claim");
+  assert.equal(applyResult.deleted.flows, 1, "Should delete 1 flow");
+  assert.equal(applyResult.deleted.edges, 2, "Should delete 2 edges");
+
+  // Verify the database was cleaned
+  const graphAfterApply = service.readGraph(repo);
+  assert.equal(graphAfterApply.components.length, 1, "Should have 1 component remaining");
+  assert.equal(graphAfterApply.components[0].id, "comp.valid", "Valid component should remain");
+  assert.equal(graphAfterApply.claims.length, 1, "Should have 1 claim remaining");
+  assert.equal(graphAfterApply.claims[0].id, "claim.valid", "Valid claim should remain");
+  assert.equal(graphAfterApply.flows.length, 1, "Should have 1 flow remaining");
+  assert.equal(graphAfterApply.flows[0].id, "flow.valid", "Valid flow should remain");
+
+  // Verify DB is fully clean on next scan
+  const finalScan = service.gcGraph(repo, true).scan;
+  assert.equal(
+    finalScan.stale_components.length + finalScan.orphaned_components.length + finalScan.orphaned_claims.length + finalScan.orphaned_flows.length + finalScan.dangling_edges.length,
+    0,
+    "All issues resolved in a single pass",
+  );
+
+  // Verify stale anchor files do not exist
+  assert.equal(existsSync(join(repoRoot, "nonexistent-file.ts")), false, "Stale anchor file should not exist");
+  assert.equal(existsSync(join(repoRoot, "missing-too.ts")), false, "Stale anchor file should not exist");
+
+  console.log("Graph GC checks passed.");
+} finally {
+  db.close();
+}


### PR DESCRIPTION
- scanGc() detects stale code anchors, orphaned entities, and dangling edges
- applyGc() removes them in a single transaction with cascade edge cleanup
- --dry-run flag for preview without modifications
- Memberships and embeddings cleaned alongside entity deletions

Closes #24