### PR TITLE
Add Cursor platform install support

### DIFF
--- a/.cursor/rules/greplica.mdc
+++ b/.cursor/rules/greplica.mdc
@@ -1,0 +1,9 @@
+---
+description: Greplica rule for repo-memory search
+globs: *
+alwaysApply: true
+---
+Greplica provides local, searchable repository memory for this repo.
+- Before broad manual exploration, run `greplica graph context "<question>"` with a focused natural-language query.
+- Greplica installs shared agent skills under `~/.cursor/skills/`; use `greplica-bootstrap` for initial repo memory and `greplica-update-working-memory` near the end of useful sessions.
+- When Greplica provides useful context, mention that you used it and briefly say what it helped with.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p>
   <a href="https://www.npmjs.com/package/greplica"><img alt="npm package" src="https://img.shields.io/npm/v/greplica?color=111111"></a>
-  <img alt="Agents" src="https://img.shields.io/badge/agents-Codex%20%7C%20Claude%20Code-2563eb">
+  <img alt="Agents" src="https://img.shields.io/badge/agents-Codex%20%7C%20Claude%20Code%20%7C%20Copilot%20%7C%20OpenCode%20%7C%20Cursor%20%7C%20OpenHands%20%7C%20Factory%20Droid-2563eb">
   <img alt="Storage" src="https://img.shields.io/badge/storage-local%20SQLite-475569">
   <img alt="Embeddings" src="https://img.shields.io/badge/embeddings-local%20%7C%20OpenAI-16a34a">
   <a href="https://discord.gg/q2R6AYXh9"><img alt="Discord" src="https://img.shields.io/badge/discord-join-5865F2"></a>
@@ -118,7 +118,7 @@ Current showcase rows:
 ## Commands
 
 ```bash
-greplica install --platform codex|claude|copilot|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica install --platform codex|claude|copilot|opencode|openhands|factory-droid|cursor --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
 greplica config
 greplica doctor [--check-embeddings]
 greplica graph read
@@ -138,4 +138,4 @@ greplica proposal apply <proposal.json>
 - `greplica doctor` - verifies installation and diagnoses configuration failures. Not a required preflight before every command.
 - `greplica install` prepares repo state, local storage, and agent integration; normal repo commands require install first.
 
-For **OpenHands**, install is repo-local: skills are written to `.agents/skills/` and the `UserPromptSubmit`/`Stop` hooks to `.openhands/hooks.json` (Claude/Codex/Copilot install to the agent's home config instead). GitHub Copilot CLI installs personal skills under `~/.copilot/skills` (or `$COPILOT_HOME/skills`) and user hooks under `~/.copilot/hooks/greplica.json`. The hooks inject `graph context` guidance and trigger background working-memory updates; OpenHands must trust the repo hooks for the background save to run.
+For **OpenHands**, install is repo-local: skills are written to `.agents/skills/` and the `UserPromptSubmit`/`Stop` hooks to `.openhands/hooks.json` (Claude/Codex/Copilot install to the agent's home config instead). GitHub Copilot CLI installs personal skills under `~/.copilot/skills` (or `$COPILOT_HOME/skills`) and user hooks under `~/.copilot/hooks/greplica.json`. The hooks inject `graph context` guidance and trigger background working-memory updates; OpenHands must trust the repo hooks for the background save to run. For **Cursor**, skills are copied to `~/.cursor/skills/` and project rules are written to `.cursor/rules/greplica.mdc` (Cursor's native rules format, utilizing `alwaysApply: true` so the rule is always active in assistant context). Cursor does not support background command hooks, so working-memory updates remain manual.

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -57,7 +57,7 @@ const cliCommands = [
   {
     key: "install",
     path: ["install"],
-    usage: "install --platform codex|claude|copilot|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
+    usage: "install --platform codex|claude|copilot|opencode|openhands|factory-droid|cursor --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
     handler: runInstallCommand,
     showInTopLevelHelp: true,
   },
@@ -766,7 +766,7 @@ function requireFlagValue(args: string[], index: number, flag: string, usageText
 }
 
 function parseInstallPlatform(value: string): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode" || value === "openhands" || value === "factory-droid") return value;
+  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode" || value === "openhands" || value === "factory-droid" || value === "cursor") return value;
   throw new Error(`Invalid --platform ${value}.\n${usage("install")}`);
 }
 
@@ -784,7 +784,13 @@ function parseEnabledFlag(value: string): boolean {
 function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>): void {
   console.log(`Installed Greplica for ${platformDisplayName(result.platform)}.`);
   console.log(`Skills: ${result.skills.length} installed.`);
-  if (result.hooks !== undefined) {
+  if (result.platform === "cursor") {
+    if (result.hooksRequested) {
+      console.log("Cursor rules: installed to .cursor/rules/greplica.mdc.");
+    } else {
+      console.log("Cursor rules: not installed.");
+    }
+  } else if (result.hooks !== undefined) {
     console.log(`Hooks: installed for ${result.hooks.events.join(", ")}.`);
   } else if (result.hooksRequested) {
     console.log("Hooks: not installed for this platform.");
@@ -798,7 +804,11 @@ function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>)
   console.log("");
   console.log("Next steps:");
   console.log("- Restart your coding agent if the new skills or hooks do not appear immediately.");
-  if (result.hooks !== undefined) {
+  if (result.platform === "cursor") {
+    if (result.hooksRequested) {
+      console.log("- Reload the Cursor window or restart Cursor if the new rule does not take effect.");
+    }
+  } else if (result.hooks !== undefined) {
     console.log("- Accept or trust the installed hooks if your agent asks.");
   } else {
     console.log("- Ask the agent to use greplica-update-working-memory near the end of useful sessions.");

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -38,7 +38,7 @@ Then run:
 
 ```bash
 npm install -g greplica
-greplica install --platform <codex|claude|copilot|opencode|openhands|factory-droid> --embedding local <mapped-hook-and-memory-flags>
+greplica install --platform <codex|claude|copilot|opencode|openhands|factory-droid|cursor> --embedding local <mapped-hook-and-memory-flags>
 ```
 
 Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps.
@@ -54,7 +54,7 @@ If I chose "Yes, recent sessions", analyze prior sessions:
 - Candidate locations: Codex `~/.codex/sessions/**/*.jsonl`; Claude Code `~/.claude/projects/**/*.jsonl`; GitHub Copilot CLI paths from `Stop` hook `transcript_path` values or `$COPILOT_HOME/session-state`.
 - Do not require transcript metadata `cwd` to equal the current checkout path. Users may use worktrees, renamed folders, or multiple checkouts of the same repo.
 - Treat a transcript as same-repo when its metadata `cwd` is the current path, or when that `cwd` still exists and Git reports the same `remote.origin.url` or same normalized repo identity as the current repo. If the old path no longer exists, use transcript cwd text, repo name, branch, and recent session content as weaker matching evidence.
-- For OpenCode, tell me transcript backfill is not supported yet and skip this step.
+- For OpenCode and Cursor, tell me transcript backfill is not supported yet and skip this step.
 - Select 1-3 transcripts. Use one if there is a large high-signal session, two by default when multiple sessions are useful, and three only when sessions are smaller or cover distinct work.
 - Show me the selected transcripts before bundling them: title if available, date/time, path, size/turn count if available, and why each matched this repo.
 - Do not ask for confirmation. Continue with a temporary bundle path:

--- a/libs/install/install.ts
+++ b/libs/install/install.ts
@@ -74,6 +74,7 @@ export function platformDisplayName(platform: InstallPlatform): string {
   if (platform === "opencode") return "OpenCode";
   if (platform === "openhands") return "OpenHands";
   if (platform === "factory-droid") return "Factory Droid";
+  if (platform === "cursor") return "Cursor";
   return "Claude Code";
 }
 

--- a/libs/install/paths.ts
+++ b/libs/install/paths.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid" | "copilot";
+export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid" | "copilot" | "cursor";
 export type InstallEmbedding = "local" | "openai";
 
 export const skillNames = ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"] as const;

--- a/libs/install/platforms/cursor.ts
+++ b/libs/install/platforms/cursor.ts
@@ -1,0 +1,63 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { copyBundledSkills } from "../skills.js";
+import { greplicaHookGuidance, greplicaContextMarker } from "../../hooks/guidance.js";
+import type {
+  PlatformInstallContext,
+  PlatformInstallResult,
+  PlatformInstaller,
+  WorkingMemoryUpdateInput,
+} from "./types.js";
+
+export const cursorInstaller: PlatformInstaller = {
+  platform: "cursor",
+  install(context: PlatformInstallContext): PlatformInstallResult {
+    const cursorHome = process.env.CURSOR_HOME ?? join(homedir(), ".cursor");
+    const skills = copyBundledSkills(join(cursorHome, "skills"));
+    if (!context.hooks) return { skills };
+
+    const rulesDir = join(context.repoRoot, ".cursor", "rules");
+    const rulePath = join(rulesDir, "greplica.mdc");
+
+    const frontmatter = `---
+description: Greplica rule for repo-memory search
+globs: *
+alwaysApply: true
+---
+`;
+    const cursorGuidance = `Greplica provides local, searchable repository memory for this repo.
+- Before broad manual exploration, run \`greplica graph context "<question>"\` with a focused natural-language query.
+- Greplica installs shared agent skills under \`~/.cursor/skills/\`; use \`greplica-bootstrap\` for initial repo memory and \`greplica-update-working-memory\` near the end of useful sessions.
+- When Greplica provides useful context, mention that you used it and briefly say what it helped with.`;
+
+    const ruleContent = `${frontmatter}${cursorGuidance}\n`;
+
+    if (!existsSync(rulePath)) {
+      mkdirSync(rulesDir, { recursive: true });
+      writeFileSync(rulePath, ruleContent, "utf8");
+    } else {
+      const existing = readFileSync(rulePath, "utf8");
+      if (!existing.includes("Greplica provides local, searchable repository memory")) {
+        // Append safely avoiding destructive overwrites
+        writeFileSync(rulePath, `${existing.trim()}\n\n${cursorGuidance}\n`, "utf8");
+      }
+    }
+
+    return {
+      skills,
+    };
+  },
+  sessionSourceRef(_sessionId: string): string {
+    throw new Error("Cursor session source refs are not supported yet.");
+  },
+  sessionIdFromSourceRef(_ref: string): string | undefined {
+    return undefined;
+  },
+  transcriptToMarkdown(_transcript: string): string {
+    throw new Error("Cursor transcript projection is not supported yet.");
+  },
+  async runWorkingMemoryUpdate(_input: WorkingMemoryUpdateInput): Promise<void> {
+    throw new Error("Cursor background working-memory updates are not supported yet.");
+  },
+};

--- a/libs/install/platforms/index.ts
+++ b/libs/install/platforms/index.ts
@@ -5,6 +5,7 @@ import { codexInstaller } from "./codex.js";
 import { droidInstaller } from "./droid.js";
 import { opencodeInstaller } from "./opencode.js";
 import { openhandsInstaller } from "./openhands.js";
+import { cursorInstaller } from "./cursor.js";
 import type { HookInstallResult, PlatformInstallContext, PlatformInstaller, PlatformInstallResult } from "./types.js";
 
 const platformInstallers: Partial<Record<InstallPlatform, PlatformInstaller>> = {
@@ -14,6 +15,7 @@ const platformInstallers: Partial<Record<InstallPlatform, PlatformInstaller>> = 
   opencode: opencodeInstaller,
   openhands: openhandsInstaller,
   "factory-droid": droidInstaller,
+  cursor: cursorInstaller,
 };
 
 export type { HookInstallResult };

--- a/scripts/check-install-options.js
+++ b/scripts/check-install-options.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -62,6 +62,44 @@ assert.match(copilotHooks.output, /Automatic memory updates: enabled\./);
 assert.ok(existsSync(join(copilotHooks.copilotHome, "hooks", "greplica.json")));
 assert.equal(readConfig(copilotHooks.greplicaHome).session.autoMemoryUpdates, true);
 
+const cursorHooks = installInTempRepo("cursor-hooks", ["--hooks", "enabled", "--auto-memory", "disabled"], "cursor");
+assert.match(cursorHooks.output, /Installed Greplica for Cursor\./);
+assert.match(cursorHooks.output, /Cursor rules: installed to \.cursor\/rules\/greplica\.mdc\./);
+assert.match(cursorHooks.output, /Automatic memory updates: disabled\./);
+assert.ok(existsSync(join(cursorHooks.cursorHome, "skills", "greplica-bootstrap", "SKILL.md")));
+assert.ok(existsSync(join(cursorHooks.repo, ".cursor", "rules", "greplica.mdc")));
+
+// Test non-destructive behavior for Cursor rules
+const customRepo = join(tmp, "cursor-non-destructive", "repo");
+const customGreplicaHome = join(tmp, "cursor-non-destructive", "greplica-home");
+const customCursorHome = join(tmp, "cursor-non-destructive", "cursor-home");
+mkdirSync(join(customRepo, ".cursor", "rules"), { recursive: true });
+const existingRuleContent = "My custom rule content\n";
+const ruleFilePath = join(customRepo, ".cursor", "rules", "greplica.mdc");
+writeFileSync(ruleFilePath, existingRuleContent, "utf8");
+
+const customEnv = {
+  ...process.env,
+  GREPLICA_HOME: customGreplicaHome,
+  CURSOR_HOME: customCursorHome,
+  GREPLICA_INSTALL_SKIP_PREWARM: "1",
+};
+
+execFileSync("git", ["init", "--quiet"], { cwd: customRepo, encoding: "utf8" });
+execFileSync(
+  process.execPath,
+  [cli.pathname, "install", "--platform", "cursor", "--embedding", "local"],
+  {
+    cwd: customRepo,
+    encoding: "utf8",
+    env: customEnv,
+  },
+);
+
+const updatedRuleContent = readFileSync(ruleFilePath, "utf8");
+assert.ok(updatedRuleContent.includes("My custom rule content"));
+assert.ok(updatedRuleContent.includes("Greplica provides local, searchable repository memory"));
+
 const invalid = spawnSync(
   process.execPath,
   [
@@ -104,6 +142,7 @@ function installInTempRepo(name, flags, platform = "codex") {
   const greplicaHome = join(tmp, name, "greplica-home");
   const codexHome = join(tmp, name, "codex-home");
   const copilotHome = join(tmp, name, "copilot-home");
+  const cursorHome = join(tmp, name, "cursor-home");
   mkdirSync(repo, { recursive: true });
   execFileSync("git", ["init", "--quiet"], { cwd: repo, encoding: "utf8" });
 
@@ -112,6 +151,7 @@ function installInTempRepo(name, flags, platform = "codex") {
     GREPLICA_HOME: greplicaHome,
     CODEX_HOME: codexHome,
     COPILOT_HOME: copilotHome,
+    CURSOR_HOME: cursorHome,
     XDG_CONFIG_HOME: join(tmp, name, "xdg-config-home"),
     GREPLICA_INSTALL_SKIP_PREWARM: "1",
   };
@@ -129,7 +169,7 @@ function installInTempRepo(name, flags, platform = "codex") {
     encoding: "utf8",
     env,
   });
-  return { repo, greplicaHome, codexHome, copilotHome, output, env };
+  return { repo, greplicaHome, codexHome, copilotHome, cursorHome, output, env };
 }
 
 function readConfig(greplicaHome) {


### PR DESCRIPTION
We added "cursor" as an option. Now, you can run greplica install --platform cursor in the terminal.
We copy Greplica's AI instruction files (skills) directly into Cursor's global settings folder on your computer.
We create a rule file in your project at .cursor/rules/greplica.mdc. This file tells Cursor's AI agent exactly how to use Greplica.
If you already have rules written in greplica.mdc, we do not delete them. We safely add our new instructions to the bottom of the file.
When installation finishes, it prints a clear message on the screen telling you where files were saved and reminding you to reload Cursor.
We wrote automatic tests to double-check that the installation code copies the skills and updates the rule files correctly. All tests pass successfully.
