### PR TITLE
Add MCP server for Greplica tools and graph resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,35 @@ greplica proposal apply <proposal.json>
 - `greplica install` prepares repo state, local storage, and agent integration; normal repo commands require install first.
 
 For **OpenHands**, install is repo-local: skills are written to `.agents/skills/` and the `UserPromptSubmit`/`Stop` hooks to `.openhands/hooks.json` (Claude/Codex/Copilot install to the agent's home config instead). GitHub Copilot CLI installs personal skills under `~/.copilot/skills` (or `$COPILOT_HOME/skills`) and user hooks under `~/.copilot/hooks/greplica.json`. The hooks inject `graph context` guidance and trigger background working-memory updates; OpenHands must trust the repo hooks for the background save to run.
+
+---
+
+## MCP Server
+
+Agents that speak the [Model Context Protocol](https://modelcontextprotocol.io) (Claude Desktop, Cursor, and others) can talk to Greplica's memory as native tools and a resource, instead of shelling out to the CLI. The server runs locally over stdio, calls the Greplica library in-process (no subprocess per request), and keeps the local embedding model warm between calls.
+
+Add it to your MCP client config (e.g. `claude_desktop_config.json`). Point `GREPLICA_REPO_ROOT` at the repository whose memory you want to expose:
+
+```json
+{
+  "mcpServers": {
+    "greplica": {
+      "command": "npx",
+      "args": ["-y", "greplica-mcp"],
+      "env": { "GREPLICA_REPO_ROOT": "/absolute/path/to/your/repo" }
+    }
+  }
+}
+```
+
+The repository must already be set up with `greplica install`. The server exposes:
+
+| Kind | Name | What it does |
+| --- | --- | --- |
+| Tool | `query_graph_context` | Retrieve memory for a natural-language query (`greplica graph context`). Read-only. Pass `debug: true` for ranking signals. |
+| Tool | `validate_proposal` | Validate a memory proposal (schema, edge rules, code-anchor audit) without writing it. Read-only. |
+| Tool | `apply_proposal` | Validate and apply a memory proposal as a new memory commit. |
+| Tool | `audit_anchors` | Check every `code_verified` claim's anchors against the current files. Read-only. |
+| Resource | `greplica://graph/read` | The current merged graph view (components, flows, claims, sources, edges) as JSON. |
+
+Every tool accepts an optional `repo_root` argument that overrides `GREPLICA_REPO_ROOT` for that call, so a single server can serve multiple checkouts. Logs are structured JSON on stderr (`GREPLICA_MCP_LOG_LEVEL=silent|error|warn|info|debug`); stdout carries only the MCP protocol.

--- a/apps/mcp/container.ts
+++ b/apps/mcp/container.ts
@@ -1,0 +1,117 @@
+import { detectRepoContext } from "../cli/repo-context.js";
+import { ensureGreplicaConfig } from "../../libs/config/greplica-config.js";
+import { loadRepoEnv } from "../../libs/env/load-local-env.js";
+import { graphContextConfigFromGreplicaConfig } from "../../libs/knowledge-graph/graph-context/config.js";
+import { createLocalKnowledgeGraphService } from "../../libs/knowledge-graph/service.js";
+import type { GraphReadResult, KnowledgeGraphService, RepoRef } from "../../libs/knowledge-graph/service.js";
+import { repoNotInstalled } from "./errors.js";
+import type { Logger } from "./logger.js";
+
+export interface InstalledRepo {
+  readonly repo: RepoRef;
+  readonly service: KnowledgeGraphService;
+  readonly repoId: string;
+}
+
+interface CachedService {
+  readonly repo: RepoRef;
+  readonly service: KnowledgeGraphService;
+}
+
+interface CachedGraph {
+  readonly at: number;
+  readonly graph: GraphReadResult;
+}
+
+const defaultGraphTtlMs = 3_000;
+
+/**
+ * Dependency container for the MCP server. Because the server is long-lived it
+ * caches one KnowledgeGraphService per repository root (keeping the SQLite handle
+ * and the local embedding model warm across calls) and serves graph reads through
+ * a short-TTL cache-aside layer. The TTL bounds staleness from other writers
+ * (the CLI, the background hook worker) that share the same database file.
+ */
+export class McpContainer {
+  private readonly services = new Map<string, CachedService>();
+  private readonly graphCache = new Map<string, CachedGraph>();
+  private readonly graphGeneration = new Map<string, number>();
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly graphTtlMs: number = defaultGraphTtlMs,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  resolveRepo(explicitRoot?: string): RepoRef {
+    const root = explicitRoot ?? process.env.GREPLICA_REPO_ROOT ?? process.cwd();
+    return detectRepoContext(root);
+  }
+
+  getInstalled(explicitRoot?: string): InstalledRepo {
+    const repo = this.resolveRepo(explicitRoot);
+    const service = this.serviceFor(repo);
+    try {
+      const initialized = service.requireRepo(repo);
+      return { repo, service, repoId: initialized.repo_id };
+    } catch (error) {
+      throw repoNotInstalled(repo.repo_root, error);
+    }
+  }
+
+  readGraph(installed: InstalledRepo): GraphReadResult {
+    const cached = this.graphCache.get(installed.repoId);
+    if (cached !== undefined && this.now() - cached.at < this.graphTtlMs) {
+      return cached.graph;
+    }
+    // Capture the generation before reading so a concurrent invalidateGraph()
+    // (e.g. from apply_proposal) prevents this read from re-caching stale data.
+    const generation = this.graphGeneration.get(installed.repoId) ?? 0;
+    const graph = installed.service.readGraph(installed.repo);
+    if ((this.graphGeneration.get(installed.repoId) ?? 0) === generation) {
+      this.graphCache.set(installed.repoId, { at: this.now(), graph });
+    }
+    return graph;
+  }
+
+  invalidateGraph(repoId: string): void {
+    this.graphCache.delete(repoId);
+    this.graphGeneration.set(repoId, (this.graphGeneration.get(repoId) ?? 0) + 1);
+  }
+
+  private serviceFor(repo: RepoRef): KnowledgeGraphService {
+    // detectRepoContext always resolves a root; fail fast rather than fall back
+    // to repo_name, which could route two different checkouts to one database.
+    const key = repo.repo_root;
+    if (key === undefined) {
+      throw new Error(`Could not resolve a repository root for ${repo.repo_name}.`);
+    }
+    const cached = this.services.get(key);
+    if (cached !== undefined) return cached.service;
+
+    // NOTE: this cache-miss path must stay fully synchronous. An await between
+    // the get() above and the set() below would let concurrent calls open (and
+    // leak) duplicate SQLite handles for the same repository root.
+    const config = ensureGreplicaConfig();
+    if (config.embedding.provider === "openai") {
+      // Loads OPENAI_* keys from the repo's .env.local/.env into process.env.
+      // Keys already present always win, so in a multi-repo session the first
+      // repo's credentials stick — surface that instead of failing silently.
+      const alreadySet = process.env.OPENAI_API_KEY !== undefined;
+      loadRepoEnv(key);
+      if (alreadySet && this.services.size > 0) {
+        this.logger.warn("container.env_not_overridden", {
+          repo: repo.repo_name,
+          detail: "OPENAI_API_KEY was already set; this repo's .env values are ignored",
+        });
+      }
+    }
+    const service = createLocalKnowledgeGraphService(graphContextConfigFromGreplicaConfig(config));
+    this.services.set(key, { repo, service });
+    this.logger.debug("container.service_created", {
+      repo: repo.repo_name,
+      embedding_provider: config.embedding.provider,
+    });
+    return service;
+  }
+}

--- a/apps/mcp/controllers/apply-proposal.ts
+++ b/apps/mcp/controllers/apply-proposal.ts
@@ -1,0 +1,32 @@
+import type { ToolHandler } from "../middleware/compose.js";
+import type { ProposalInput } from "../schemas.js";
+
+export const applyProposal: ToolHandler<ProposalInput> = async (input, context) => {
+  const installed = context.container.getInstalled(input.repo_root);
+
+  // Validation happens once, inside service.applyProposal. Its "Proposal is
+  // invalid" throw is classified to PROPOSAL_INVALID by the error middleware.
+  const result = await installed.service.applyProposal(installed.repo, input.proposal);
+  context.container.invalidateGraph(installed.repoId);
+
+  const { created } = result;
+  const summary = [
+    "Applied proposal to working memory.",
+    `commit=${result.memory_commit_id}`,
+    `components=${created.components}`,
+    `flows=${created.flows}`,
+    `claims=${created.claims}`,
+    `sources=${created.sources}`,
+    `edges=${created.edges}`,
+  ].join(" ");
+
+  return {
+    content: [{ type: "text", text: summary }],
+    structuredContent: {
+      memory_commit_id: result.memory_commit_id,
+      scope_id: result.scope_id,
+      created: result.created,
+      embedding_status: result.embedding_status,
+    },
+  };
+};

--- a/apps/mcp/controllers/audit-anchors.ts
+++ b/apps/mcp/controllers/audit-anchors.ts
@@ -1,0 +1,54 @@
+import type {
+  ClaimAnchorAuditIssue,
+  ClaimAnchorAuditResult,
+} from "../../../libs/knowledge-graph/code-anchors/types.js";
+import type { ToolHandler } from "../middleware/compose.js";
+import type { AuditAnchorsOutput, RepoScopedInput } from "../schemas.js";
+
+export const auditAnchors: ToolHandler<RepoScopedInput> = async (input, context) => {
+  const installed = context.container.getInstalled(input.repo_root);
+  const result = await installed.service.auditCodeAnchors(installed.repo);
+  const output = toOutput(result);
+
+  return {
+    content: [{ type: "text", text: renderText(output) }],
+    structuredContent: output,
+  };
+};
+
+function toOutput(result: ClaimAnchorAuditResult): AuditAnchorsOutput {
+  const missing_anchors = mapIssues(result.missing_anchors);
+  const missing_files = mapIssues(result.missing_files);
+  const missing_symbols = mapIssues(result.missing_symbols);
+  const ambiguous_symbols = mapIssues(result.ambiguous_symbols);
+  const unsupported_languages = mapIssues(result.unsupported_languages);
+
+  const issue_count =
+    missing_anchors.length +
+    missing_files.length +
+    missing_symbols.length +
+    ambiguous_symbols.length +
+    unsupported_languages.length;
+
+  return {
+    issue_count,
+    missing_anchors,
+    missing_files,
+    missing_symbols,
+    ambiguous_symbols,
+    unsupported_languages,
+  };
+}
+
+function mapIssues(issues: readonly ClaimAnchorAuditIssue[]): AuditAnchorsOutput["missing_files"] {
+  return issues.map((issue) => ({
+    claim_id: issue.claim_id,
+    file: issue.anchor?.file,
+    symbol: issue.anchor?.symbol,
+  }));
+}
+
+function renderText(output: AuditAnchorsOutput): string {
+  if (output.issue_count === 0) return "Code anchor audit: no issues.";
+  return `Code anchor audit: ${output.issue_count} issue(s) found. See structured output for details.`;
+}

--- a/apps/mcp/controllers/query-context.ts
+++ b/apps/mcp/controllers/query-context.ts
@@ -1,0 +1,18 @@
+import { renderGraphContextMarkdown } from "../../../libs/knowledge-graph/graph-context/render.js";
+import type { ToolHandler } from "../middleware/compose.js";
+import type { QueryContextInput } from "../schemas.js";
+
+export const queryContext: ToolHandler<QueryContextInput> = async (input, context) => {
+  const installed = context.container.getInstalled(input.repo_root);
+  const result = await installed.service.contextGraph(installed.repo, input.query);
+  const markdown = renderGraphContextMarkdown(result);
+
+  const content = input.debug
+    ? [
+        { type: "text" as const, text: markdown },
+        { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ]
+    : [{ type: "text" as const, text: markdown }];
+
+  return { content, structuredContent: { markdown } };
+};

--- a/apps/mcp/controllers/read-graph.ts
+++ b/apps/mcp/controllers/read-graph.ts
@@ -1,0 +1,33 @@
+import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import type { McpContainer } from "../container.js";
+import { classifyError } from "../errors.js";
+import type { Logger } from "../logger.js";
+
+/**
+ * Resource controller for `greplica://graph/read`. The repo is resolved from
+ * GREPLICA_REPO_ROOT (resources carry no arguments). Resources signal failure by
+ * throwing a protocol error, so we rethrow a clean, code-prefixed message.
+ */
+export function readGraphResource(container: McpContainer, logger: Logger, uri: URL): ReadResourceResult {
+  try {
+    const installed = container.getInstalled();
+    const graph = container.readGraph(installed);
+    return {
+      contents: [
+        {
+          uri: uri.toString(),
+          mimeType: "application/json",
+          text: JSON.stringify(graph, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const mapped = classifyError(error);
+    if (mapped.code === "INTERNAL") {
+      logger.error("resource.error", mapped.cause ?? mapped, { code: mapped.code });
+    } else {
+      logger.warn("resource.rejected", { code: mapped.code, message: mapped.message });
+    }
+    throw new Error(`[${mapped.code}] ${mapped.message}`);
+  }
+}

--- a/apps/mcp/controllers/validate-proposal.ts
+++ b/apps/mcp/controllers/validate-proposal.ts
@@ -1,0 +1,16 @@
+import type { ToolHandler } from "../middleware/compose.js";
+import type { ProposalInput } from "../schemas.js";
+
+export const validateProposal: ToolHandler<ProposalInput> = async (input, context) => {
+  const installed = context.container.getInstalled(input.repo_root);
+  const result = await installed.service.validateProposal(installed.repo, input.proposal);
+
+  const text = result.valid
+    ? "Proposal is valid."
+    : `Proposal is invalid:\n${result.errors.map((error) => `- ${error}`).join("\n")}`;
+
+  return {
+    content: [{ type: "text", text }],
+    structuredContent: { valid: result.valid, errors: result.errors },
+  };
+};

--- a/apps/mcp/errors.ts
+++ b/apps/mcp/errors.ts
@@ -1,0 +1,49 @@
+export type ToolErrorCode = "REPO_NOT_INSTALLED" | "INPUT_INVALID" | "PROPOSAL_INVALID" | "INTERNAL";
+
+/**
+ * Domain error carrying a stable, client-facing code. The error middleware maps
+ * these onto MCP tool errors so raw stack traces never cross the boundary.
+ */
+export class McpToolError extends Error {
+  constructor(
+    readonly code: ToolErrorCode,
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "McpToolError";
+  }
+}
+
+export function repoNotInstalled(repoRoot: string | undefined, cause?: unknown): McpToolError {
+  const where = repoRoot === undefined ? "" : ` for ${repoRoot}`;
+  return new McpToolError(
+    "REPO_NOT_INSTALLED",
+    `Greplica memory is not initialized${where}. Run \`greplica install --platform <agent> --embedding local\` in the repository first.`,
+    cause,
+  );
+}
+
+export function inputInvalid(message: string, cause?: unknown): McpToolError {
+  return new McpToolError("INPUT_INVALID", message, cause);
+}
+
+/**
+ * Normalizes any thrown value into an McpToolError. Known domain errors pass
+ * through unchanged; everything else becomes an opaque INTERNAL error whose
+ * detail is logged but not returned to the client.
+ */
+export function classifyError(error: unknown): McpToolError {
+  if (error instanceof McpToolError) return error;
+  // KnowledgeGraphService.applyProposal throws a plain Error with this prefix
+  // when its internal validation rejects the proposal (service.ts:149).
+  if (error instanceof Error && error.message.startsWith("Proposal is invalid")) {
+    return new McpToolError("PROPOSAL_INVALID", error.message, error);
+  }
+  return new McpToolError("INTERNAL", "Unexpected error while handling the request.", error);
+}
+
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/apps/mcp/logger.ts
+++ b/apps/mcp/logger.ts
@@ -1,0 +1,75 @@
+import { stderr } from "node:process";
+
+export type LogLevel = "silent" | "error" | "warn" | "info" | "debug";
+
+type LogFields = Readonly<Record<string, unknown>>;
+
+const levelRank: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+export interface Logger {
+  child(bindings: LogFields): Logger;
+  debug(message: string, fields?: LogFields): void;
+  info(message: string, fields?: LogFields): void;
+  warn(message: string, fields?: LogFields): void;
+  error(message: string, error?: unknown, fields?: LogFields): void;
+}
+
+export function logLevelFromEnv(value = process.env.GREPLICA_MCP_LOG_LEVEL): LogLevel {
+  const candidate = value?.toLowerCase();
+  if (candidate !== undefined && candidate in levelRank) {
+    return candidate as LogLevel;
+  }
+  return "info";
+}
+
+/**
+ * Structured JSON logger that writes to stderr only. stdout is reserved for the
+ * MCP JSON-RPC stream, so nothing here may ever touch it.
+ */
+export function createLogger(level: LogLevel = "info", bindings: LogFields = {}): Logger {
+  const threshold = levelRank[level];
+
+  function write(entryLevel: LogLevel, message: string, fields?: LogFields): void {
+    if (levelRank[entryLevel] > threshold) return;
+    const entry = {
+      ts: new Date().toISOString(),
+      level: entryLevel,
+      msg: message,
+      ...bindings,
+      ...fields,
+    };
+    stderr.write(`${JSON.stringify(entry)}\n`);
+  }
+
+  return {
+    child(childBindings) {
+      return createLogger(level, { ...bindings, ...childBindings });
+    },
+    debug(message, fields) {
+      write("debug", message, fields);
+    },
+    info(message, fields) {
+      write("info", message, fields);
+    },
+    warn(message, fields) {
+      write("warn", message, fields);
+    },
+    error(message, error, fields) {
+      write("error", message, { ...fields, ...errorFields(error) });
+    },
+  };
+}
+
+function errorFields(error: unknown): Record<string, unknown> {
+  if (error === undefined) return {};
+  if (error instanceof Error) {
+    return { error: error.message, stack: error.stack };
+  }
+  return { error: String(error) };
+}

--- a/apps/mcp/main.ts
+++ b/apps/mcp/main.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpContainer } from "./container.js";
+import { createLogger, logLevelFromEnv, type Logger } from "./logger.js";
+import { createGreplicaMcpServer } from "./server.js";
+
+async function main(): Promise<void> {
+  const logger = createLogger(logLevelFromEnv());
+  installProcessGuards(logger);
+
+  const container = new McpContainer(logger);
+  const server = createGreplicaMcpServer({ container, logger });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  logger.info("server.ready", { pid: process.pid });
+}
+
+function installProcessGuards(logger: Logger): void {
+  process.on("uncaughtException", (error) => {
+    logger.error("process.uncaught_exception", error);
+    process.exit(1);
+  });
+  process.on("unhandledRejection", (reason) => {
+    logger.error("process.unhandled_rejection", reason);
+    process.exit(1);
+  });
+}
+
+main().catch((error) => {
+  // Startup failure before the logger is guaranteed usable: write once to stderr only.
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${JSON.stringify({ level: "error", msg: "server.start_failed", error: message })}\n`);
+  process.exit(1);
+});

--- a/apps/mcp/middleware/compose.ts
+++ b/apps/mcp/middleware/compose.ts
@@ -1,0 +1,21 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { McpContainer } from "../container.js";
+import type { Logger } from "../logger.js";
+
+export interface RequestContext {
+  readonly requestId: string;
+  readonly logger: Logger;
+  readonly container: McpContainer;
+}
+
+export type ToolHandler<Input> = (input: Input, context: RequestContext) => Promise<CallToolResult>;
+
+/**
+ * Middleware wraps a type-erased handler. Concrete controllers keep their typed
+ * input; the transport-facing pipeline only cares that a result comes back.
+ */
+export type ToolMiddleware = (next: ToolHandler<unknown>) => ToolHandler<unknown>;
+
+export function compose(...middleware: readonly ToolMiddleware[]): ToolMiddleware {
+  return (handler) => middleware.reduceRight<ToolHandler<unknown>>((next, mw) => mw(next), handler);
+}

--- a/apps/mcp/middleware/with-error.ts
+++ b/apps/mcp/middleware/with-error.ts
@@ -1,0 +1,36 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { classifyError, type McpToolError } from "../errors.js";
+import type { Logger } from "../logger.js";
+import type { ToolMiddleware } from "./compose.js";
+
+/**
+ * Centralized error boundary: turns thrown domain errors into structured MCP tool
+ * errors. Business failures return `isError: true`; only unexpected faults are
+ * logged with their cause. Raw stack traces never reach the client.
+ */
+export function withError(): ToolMiddleware {
+  return (next) => async (input, context) => {
+    try {
+      return await next(input, context);
+    } catch (error) {
+      const mapped = classifyError(error);
+      logMapped(context.logger, mapped);
+      return toToolError(mapped);
+    }
+  };
+}
+
+function logMapped(logger: Logger, error: McpToolError): void {
+  if (error.code === "INTERNAL") {
+    logger.error("tool.error", error.cause ?? error, { code: error.code });
+    return;
+  }
+  logger.warn("tool.rejected", { code: error.code, message: error.message });
+}
+
+function toToolError(error: McpToolError): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: "text", text: `[${error.code}] ${error.message}` }],
+  };
+}

--- a/apps/mcp/middleware/with-logging.ts
+++ b/apps/mcp/middleware/with-logging.ts
@@ -1,0 +1,30 @@
+import { performance } from "node:perf_hooks";
+import type { ToolMiddleware } from "./compose.js";
+
+/**
+ * Logs the lifecycle of every tool call (start / finish / threw) with a duration.
+ * Placed outermost so it also records results shaped by the error middleware.
+ */
+export function withLogging(): ToolMiddleware {
+  return (next) => async (input, context) => {
+    const start = performance.now();
+    context.logger.info("tool.start");
+    try {
+      const result = await next(input, context);
+      context.logger.info("tool.finish", {
+        duration_ms: elapsedMs(start),
+        is_error: result.isError === true,
+      });
+      return result;
+    } catch (error) {
+      // Unreachable while withError sits inside this middleware (it never
+      // re-throws); kept as a defensive net in case the pipeline order changes.
+      context.logger.warn("tool.threw", { duration_ms: elapsedMs(start) });
+      throw error;
+    }
+  };
+}
+
+function elapsedMs(start: number): number {
+  return Math.round(performance.now() - start);
+}

--- a/apps/mcp/schemas.ts
+++ b/apps/mcp/schemas.ts
@@ -1,0 +1,150 @@
+import { z } from "zod";
+
+/**
+ * Boundary schemas for the MCP tools. These validate the *shape* of agent input
+ * and give clients typed hints. Deep semantic validation (edge direction rules,
+ * code-anchor resolution) stays in KnowledgeGraphService and is not duplicated here.
+ */
+
+const repoRoot = z
+  .string()
+  .min(1)
+  .describe("Absolute path to the target repository. Defaults to GREPLICA_REPO_ROOT, then the working directory.");
+
+const stringOrStringArray = z.union([z.string().min(1), z.array(z.string().min(1))]);
+
+const codeAnchorInput = z.object({
+  file: z.string().min(1).describe("Repository-relative file path. No absolute paths or line numbers."),
+  symbol: z.string().min(1).optional().describe('Optional symbol, e.g. "ClassName.method".'),
+});
+
+const claimKind = z.enum(["fact", "requirement", "decision", "task", "question", "risk"]);
+const claimTruth = z.enum(["code_verified", "source_verified", "unknown"]);
+const claimIntent = z.enum(["intended", "accidental", "unknown"]);
+const edgeKind = z.enum(["about", "contains", "touches", "supersedes", "evidenced_by"]);
+
+const componentInput = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  code_anchor: z.string().min(1).optional(),
+  contains: stringOrStringArray.optional(),
+  supersedes: stringOrStringArray.optional(),
+});
+
+const flowInput = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  contains: stringOrStringArray.optional(),
+  touches: stringOrStringArray.optional(),
+  supersedes: stringOrStringArray.optional(),
+});
+
+const claimInput = z.object({
+  id: z.string().min(1),
+  kind: claimKind,
+  text: z.string().min(1),
+  truth: claimTruth,
+  intent: claimIntent,
+  code_anchors: z.array(codeAnchorInput).max(3).optional(),
+  about: stringOrStringArray.optional(),
+  evidenced_by: stringOrStringArray.optional(),
+  supersedes: stringOrStringArray.optional(),
+});
+
+const sourceInput = z.object({
+  id: z.string().min(1),
+  kind: z.literal("session"),
+  ref: z.string().min(1),
+  title: z.string().min(1).optional(),
+});
+
+const edgeInput = z.object({
+  kind: edgeKind,
+  from: z.string().min(1),
+  to: z.string().min(1),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const proposalSchema = z
+  .object({
+    title: z.string().min(1),
+    summary: z.string().min(1).optional(),
+    creates: z.object({
+      components: z.array(componentInput).optional(),
+      flows: z.array(flowInput).optional(),
+      claims: z.array(claimInput).optional(),
+      sources: z.array(sourceInput).optional(),
+      edges: z.array(edgeInput).optional(),
+    }),
+  })
+  .describe("Greplica memory proposal (compact form). Deep semantic validation runs server-side.");
+
+// ---- Tool input schemas ----
+
+export const queryContextInput = z.object({
+  query: z.string().min(1).describe("Natural-language question to retrieve repository memory for."),
+  repo_root: repoRoot.optional(),
+  debug: z.boolean().default(false).describe("Also return the full retrieval payload with ranking signals."),
+});
+
+export const proposalInput = z.object({
+  proposal: proposalSchema,
+  repo_root: repoRoot.optional(),
+});
+
+export const repoScopedInput = z.object({
+  repo_root: repoRoot.optional(),
+});
+
+export type QueryContextInput = z.infer<typeof queryContextInput>;
+export type ProposalInput = z.infer<typeof proposalInput>;
+export type RepoScopedInput = z.infer<typeof repoScopedInput>;
+
+// ---- Tool output schemas ----
+
+const nonNegativeInt = z.number().int().nonnegative();
+
+const embeddingStatus = z.object({
+  checked_objects: nonNegativeInt,
+  created: nonNegativeInt,
+  reused: nonNegativeInt,
+});
+
+export const queryContextOutput = z.object({
+  markdown: z.string(),
+});
+
+export const validateProposalOutput = z.object({
+  valid: z.boolean(),
+  errors: z.array(z.string()),
+});
+
+export const applyProposalOutput = z.object({
+  memory_commit_id: z.string(),
+  scope_id: z.string(),
+  created: z.object({
+    components: nonNegativeInt,
+    flows: nonNegativeInt,
+    claims: nonNegativeInt,
+    sources: nonNegativeInt,
+    edges: nonNegativeInt,
+  }),
+  embedding_status: embeddingStatus,
+});
+
+const anchorIssue = z.object({
+  claim_id: z.string(),
+  file: z.string().optional(),
+  symbol: z.string().optional(),
+});
+
+export const auditAnchorsOutput = z.object({
+  issue_count: nonNegativeInt,
+  missing_anchors: z.array(anchorIssue),
+  missing_files: z.array(anchorIssue),
+  missing_symbols: z.array(anchorIssue),
+  ambiguous_symbols: z.array(anchorIssue),
+  unsupported_languages: z.array(anchorIssue),
+});
+
+export type AuditAnchorsOutput = z.infer<typeof auditAnchorsOutput>;

--- a/apps/mcp/server.ts
+++ b/apps/mcp/server.ts
@@ -1,0 +1,129 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { McpContainer } from "./container.js";
+import type { Logger } from "./logger.js";
+import { compose, type RequestContext, type ToolHandler } from "./middleware/compose.js";
+import { withError } from "./middleware/with-error.js";
+import { withLogging } from "./middleware/with-logging.js";
+import { applyProposal } from "./controllers/apply-proposal.js";
+import { auditAnchors } from "./controllers/audit-anchors.js";
+import { queryContext } from "./controllers/query-context.js";
+import { readGraphResource } from "./controllers/read-graph.js";
+import { validateProposal } from "./controllers/validate-proposal.js";
+import {
+  applyProposalOutput,
+  auditAnchorsOutput,
+  proposalInput,
+  queryContextInput,
+  queryContextOutput,
+  repoScopedInput,
+  validateProposalOutput,
+} from "./schemas.js";
+
+export const graphReadResourceUri = "greplica://graph/read";
+
+export interface McpServerDeps {
+  readonly container: McpContainer;
+  readonly logger: Logger;
+}
+
+/**
+ * Transport-agnostic composition root: assembles the McpServer, wraps every
+ * controller in the logging + error pipeline, and registers tools and resources.
+ * The entrypoint chooses the transport (stdio today; HTTP later without changes here).
+ */
+export function createGreplicaMcpServer(deps: McpServerDeps): McpServer {
+  const { container, logger } = deps;
+  const server = new McpServer({ name: "greplica", version: greplicaVersion() });
+  const pipeline = compose(withLogging(), withError());
+
+  async function runTool<Input>(name: string, handler: ToolHandler<Input>, input: Input): Promise<CallToolResult> {
+    const requestId = randomUUID();
+    const context: RequestContext = {
+      requestId,
+      logger: logger.child({ tool: name, request_id: requestId }),
+      container,
+    };
+    // Safe erasure: middleware passes the input through untouched, and the
+    // concrete handler is the only party that reads it (already typed as Input).
+    return pipeline(handler as ToolHandler<unknown>)(input, context);
+  }
+
+  server.registerTool(
+    "query_graph_context",
+    {
+      title: "Query graph context",
+      description:
+        "Retrieve relevant repository memory (claims, components, flows) for a natural-language query before broad exploration.",
+      inputSchema: queryContextInput.shape,
+      outputSchema: queryContextOutput.shape,
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    (input) => runTool("query_graph_context", queryContext, input),
+  );
+
+  server.registerTool(
+    "validate_proposal",
+    {
+      title: "Validate memory proposal",
+      description: "Validate a Greplica memory proposal (schema, edge rules, code-anchor audit) without writing it.",
+      inputSchema: proposalInput.shape,
+      outputSchema: validateProposalOutput.shape,
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    (input) => runTool("validate_proposal", validateProposal, input),
+  );
+
+  server.registerTool(
+    "apply_proposal",
+    {
+      title: "Apply memory proposal",
+      description: "Validate and apply a Greplica memory proposal to working memory as a new memory commit.",
+      inputSchema: proposalInput.shape,
+      outputSchema: applyProposalOutput.shape,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    },
+    (input) => runTool("apply_proposal", applyProposal, input),
+  );
+
+  server.registerTool(
+    "audit_anchors",
+    {
+      title: "Audit code anchors",
+      description: "Check every code_verified claim's code anchors against the current repository files.",
+      inputSchema: repoScopedInput.shape,
+      outputSchema: auditAnchorsOutput.shape,
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+    },
+    (input) => runTool("audit_anchors", auditAnchors, input),
+  );
+
+  server.registerResource(
+    "graph",
+    graphReadResourceUri,
+    {
+      title: "Greplica graph view",
+      description: "The current merged graph view (components, flows, claims, sources, edges) as JSON.",
+      mimeType: "application/json",
+    },
+    (uri) => readGraphResource(container, logger.child({ resource: "graph" }), uri),
+  );
+
+  return server;
+}
+
+function greplicaVersion(): string {
+  // dist/apps/mcp/server.js -> ../../../package.json is the package root.
+  try {
+    const raw = readFileSync(new URL("../../../package.json", import.meta.url), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && "version" in parsed && typeof parsed.version === "string") {
+      return parsed.version;
+    }
+  } catch {
+    // Fall through to the unknown-version sentinel below.
+  }
+  return "0.0.0";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "hasInstallScript": true,
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.11.1",
         "tree-sitter-wasms": "^0.1.13",
-        "web-tree-sitter": "^0.24.7"
+        "web-tree-sitter": "^0.24.7",
+        "zod": "^3.25.76"
       },
       "bin": {
-        "greplica": "dist/apps/cli/main.js"
+        "greplica": "dist/apps/cli/main.js",
+        "greplica-mcp": "dist/apps/mcp/main.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -34,6 +37,18 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@huggingface/jinja": {
@@ -529,6 +544,46 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -611,6 +666,19 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
@@ -618,6 +686,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/base64-js": {
@@ -674,6 +775,43 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -705,11 +843,137 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -769,6 +1033,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -783,6 +1056,35 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -811,10 +1113,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -829,6 +1149,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -838,11 +1188,115 @@
         "node": ">=6"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/flatbuffers": {
       "version": "25.9.23",
@@ -850,11 +1304,75 @@
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
@@ -925,6 +1443,75 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -957,6 +1544,57 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -979,6 +1617,61 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-response": {
@@ -1008,11 +1701,26 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-abi": {
       "version": "3.92.0",
@@ -1026,6 +1734,27 @@
         "node": ">=10"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -1033,6 +1762,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -1086,6 +1827,43 @@
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/platform": {
       "version": "1.3.6",
@@ -1144,6 +1922,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -1152,6 +1943,50 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -1183,6 +2018,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -1198,6 +2042,22 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/safe-buffer": {
@@ -1220,6 +2080,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
@@ -1238,6 +2104,32 @@
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "license": "MIT"
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -1252,6 +2144,31 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -1295,6 +2212,99 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/simple-concat": {
@@ -1348,6 +2358,15 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1394,6 +2413,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-sitter-wasms": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
@@ -1434,6 +2462,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1454,11 +2513,29 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/web-tree-sitter": {
       "version": "0.24.7",
@@ -1466,11 +2543,44 @@
       "integrity": "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ==",
       "license": "MIT"
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "git+ssh://git@github.com/Autoloops/greplica.git"
   },
   "bin": {
-    "greplica": "dist/apps/cli/main.js"
+    "greplica": "dist/apps/cli/main.js",
+    "greplica-mcp": "dist/apps/mcp/main.js"
   },
   "engines": {
     "node": ">=22.0.0 <27.0.0"
@@ -21,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-mcp-server.mjs",
+    "test:mcp": "npm run build && node scripts/check-mcp-server.mjs",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",
@@ -56,9 +58,11 @@
   ],
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.11.1",
     "tree-sitter-wasms": "^0.1.13",
-    "web-tree-sitter": "^0.24.7"
+    "web-tree-sitter": "^0.24.7",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/scripts/check-mcp-server.mjs
+++ b/scripts/check-mcp-server.mjs
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+const distRoot = new URL("../dist/", import.meta.url);
+const { createGreplicaMcpServer, graphReadResourceUri } = await import(new URL("apps/mcp/server.js", distRoot));
+const { McpContainer } = await import(new URL("apps/mcp/container.js", distRoot));
+const { createLogger } = await import(new URL("apps/mcp/logger.js", distRoot));
+const { detectRepoContext } = await import(new URL("apps/cli/repo-context.js", distRoot));
+const { KnowledgeGraphService } = await import(new URL("libs/knowledge-graph/service.js", distRoot));
+const { normalizeProposal } = await import(new URL("libs/knowledge-graph/proposal.js", distRoot));
+const { openDatabase } = await import(new URL("libs/storage/sqlite/db.js", distRoot));
+const { SqliteRepository } = await import(new URL("libs/storage/sqlite/repository.js", distRoot));
+
+const home = mkdtempSync(join(tmpdir(), "greplica-mcp-home-"));
+const repoRoot = mkdtempSync(join(tmpdir(), "greplica-mcp-repo-"));
+const uninstalledRoot = mkdtempSync(join(tmpdir(), "greplica-mcp-fresh-"));
+process.env.GREPLICA_HOME = home;
+process.env.GREPLICA_REPO_ROOT = repoRoot;
+process.env.GREPLICA_MCP_LOG_LEVEL = "silent";
+
+try {
+  arrangeFixtureGraph(repoRoot);
+
+  const client = await startClient();
+  try {
+    await checkTools(client);
+    await checkResource(client);
+    await checkValidateProposal(client);
+    await checkApplyInvalidProposal(client);
+    await checkAuditAnchors(client);
+    await checkRepoNotInstalled(client);
+    await checkEmbeddingEndToEnd(client);
+  } finally {
+    await client.close();
+  }
+
+  await checkStdoutHygiene();
+
+  console.log("MCP server checks passed.");
+} finally {
+  rmSync(home, { recursive: true, force: true });
+  rmSync(repoRoot, { recursive: true, force: true });
+  rmSync(uninstalledRoot, { recursive: true, force: true });
+}
+
+/** Seed a small graph directly through the storage layer (no embeddings needed). */
+function arrangeFixtureGraph(root) {
+  const db = openDatabase();
+  try {
+    const repository = new SqliteRepository(db);
+    const service = new KnowledgeGraphService(repository);
+    const repo = detectRepoContext(root);
+    const init = service.initRepo(repo);
+    const working = repository.requireWorkingScope(init.repo_id);
+    const commit = repository.createMemoryCommit({ scope_id: working.id, title: "fixture memory" });
+    const proposal = {
+      title: "fixture memory",
+      creates: {
+        components: [{ id: "component.cli", name: "CLI" }],
+        flows: [{ id: "flow.dispatch", name: "Command dispatch" }],
+        claims: [
+          {
+            id: "claim.cli_entry",
+            kind: "fact",
+            text: "The CLI routes subcommands through a single dispatcher.",
+            truth: "source_verified",
+            intent: "intended",
+            about: ["component.cli"],
+          },
+        ],
+      },
+    };
+    const normalized = normalizeProposal(proposal, repository);
+    repository.createProposalRecords(working.id, commit.id, normalized);
+  } finally {
+    db.close();
+  }
+}
+
+async function startClient() {
+  const logger = createLogger("silent");
+  const server = createGreplicaMcpServer({ container: new McpContainer(logger), logger });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "greplica-mcp-check", version: "0.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function checkTools(client) {
+  const { tools } = await client.listTools();
+  const names = tools.map((tool) => tool.name).sort();
+  assert.deepEqual(names, ["apply_proposal", "audit_anchors", "query_graph_context", "validate_proposal"]);
+
+  const apply = tools.find((tool) => tool.name === "apply_proposal");
+  assert.equal(apply.annotations?.readOnlyHint, false, "apply_proposal must not be read-only");
+  assert.equal(apply.annotations?.idempotentHint, false, "apply_proposal must not be idempotent");
+
+  const query = tools.find((tool) => tool.name === "query_graph_context");
+  assert.equal(query.annotations?.readOnlyHint, true, "query_graph_context must be read-only");
+}
+
+async function checkResource(client) {
+  const { resources } = await client.listResources();
+  assert.ok(
+    resources.some((resource) => resource.uri === graphReadResourceUri),
+    "graph read resource must be registered",
+  );
+
+  const read = await client.readResource({ uri: graphReadResourceUri });
+  const graph = JSON.parse(read.contents[0].text);
+  assert.ok(graph.components.length >= 1, "resource should expose the fixture component");
+  assert.ok(graph.claims.length >= 1, "resource should expose the fixture claim");
+}
+
+async function checkValidateProposal(client) {
+  const invalid = await client.callTool({
+    name: "validate_proposal",
+    arguments: {
+      repo_root: repoRoot,
+      // code_verified claim without any code anchors -> server-side validation must reject.
+      proposal: {
+        title: "invalid",
+        creates: {
+          claims: [
+            { id: "claim.bad", kind: "fact", text: "x", truth: "code_verified", intent: "intended" },
+          ],
+        },
+      },
+    },
+  });
+  assert.equal(invalid.structuredContent.valid, false);
+  assert.ok(invalid.structuredContent.errors.length >= 1, "invalid proposal must report errors");
+
+  const valid = await client.callTool({
+    name: "validate_proposal",
+    arguments: {
+      repo_root: repoRoot,
+      proposal: { title: "ok", creates: { components: [{ id: "component.extra", name: "Extra" }] } },
+    },
+  });
+  assert.equal(valid.structuredContent.valid, true, "well-formed proposal must validate");
+}
+
+async function checkApplyInvalidProposal(client) {
+  // Validation fails inside service.applyProposal (before any embedding work);
+  // the error middleware must surface it as PROPOSAL_INVALID, not INTERNAL.
+  const result = await client.callTool({
+    name: "apply_proposal",
+    arguments: {
+      repo_root: repoRoot,
+      proposal: {
+        title: "invalid apply",
+        creates: {
+          claims: [{ id: "claim.bad_apply", kind: "fact", text: "x", truth: "code_verified", intent: "intended" }],
+        },
+      },
+    },
+  });
+  assert.equal(result.isError, true, "invalid proposal must fail apply");
+  assert.match(result.content[0].text, /PROPOSAL_INVALID/);
+}
+
+async function checkAuditAnchors(client) {
+  const audit = await client.callTool({ name: "audit_anchors", arguments: { repo_root: repoRoot } });
+  assert.equal(audit.structuredContent.issue_count, 0, "fixture has no code_verified claims to fail");
+}
+
+async function checkRepoNotInstalled(client) {
+  const result = await client.callTool({ name: "audit_anchors", arguments: { repo_root: uninstalledRoot } });
+  assert.equal(result.isError, true, "uninitialized repo must produce a tool error");
+  assert.match(result.content[0].text, /REPO_NOT_INSTALLED/);
+}
+
+/** Heavy path: exercises real embeddings. Off by default; opt in for full coverage. */
+async function checkEmbeddingEndToEnd(client) {
+  if (process.env.GREPLICA_MCP_TEST_EMBEDDINGS !== "1") {
+    console.log("(skipping embedding end-to-end: set GREPLICA_MCP_TEST_EMBEDDINGS=1 to run)");
+    return;
+  }
+
+  const applied = await client.callTool({
+    name: "apply_proposal",
+    arguments: {
+      repo_root: repoRoot,
+      proposal: {
+        title: "session insight",
+        creates: {
+          claims: [
+            {
+              id: "claim.dispatch_note",
+              kind: "decision",
+              text: "Command dispatch resolves the repo before running any subcommand.",
+              truth: "source_verified",
+              intent: "intended",
+              about: ["flow.dispatch"],
+            },
+          ],
+        },
+      },
+    },
+  });
+  assert.notEqual(applied.isError, true, "apply_proposal should succeed");
+  assert.ok(applied.structuredContent.memory_commit_id.length > 0);
+
+  const context = await client.callTool({
+    name: "query_graph_context",
+    arguments: { repo_root: repoRoot, query: "command dispatch repo resolution" },
+  });
+  assert.notEqual(context.isError, true, "query_graph_context should succeed");
+  assert.ok(context.structuredContent.markdown.length > 0, "context should return markdown");
+}
+
+/**
+ * The stdio transport uses stdout for JSON-RPC framing, so logs must go to stderr
+ * only. Spawn the real binary and confirm stdout carries valid JSON-RPC.
+ */
+async function checkStdoutHygiene() {
+  const mainPath = fileURLToPath(new URL("apps/mcp/main.js", distRoot));
+  const child = spawn(process.execPath, [mainPath], {
+    env: { ...process.env, GREPLICA_MCP_LOG_LEVEL: "debug" },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  const initialize = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "greplica-mcp-smoke", version: "0.0.0" },
+    },
+  };
+
+  try {
+    // Resolve as soon as a complete line lands on stdout, rather than sleeping a
+    // fixed interval (which is flaky under load).
+    const firstLine = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("timed out waiting for a stdout frame")), 15_000);
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk.toString();
+        const newline = stdout.indexOf("\n");
+        if (newline >= 0) {
+          clearTimeout(timer);
+          resolve(stdout.slice(0, newline));
+        }
+      });
+      child.on("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timer);
+        reject(new Error(`server exited before responding (code ${code})\n${stderr}`));
+      });
+      child.stdin.write(`${JSON.stringify(initialize)}\n`);
+    });
+
+    const parsed = JSON.parse(firstLine.trim()); // throws if a log line leaked onto stdout
+    assert.equal(parsed.jsonrpc, "2.0", "stdout must contain only JSON-RPC frames");
+
+    // Wait for the ready log on stderr instead of sleeping a fixed interval.
+    const readyDeadline = Date.now() + 5_000;
+    while (!/server\.ready/.test(stderr) && Date.now() < readyDeadline) {
+      await delay(25);
+    }
+    assert.match(stderr, /server\.ready/, "structured logs must go to stderr");
+  } finally {
+    child.kill("SIGTERM");
+  }
+}


### PR DESCRIPTION
Adds a local stdio MCP server (greplica-mcp) built on @modelcontextprotocol/sdk so agents like Claude Desktop and Cursor can use Greplica natively instead of shelling out to the CLI.

Surface:
- Tools: query_graph_context, validate_proposal, apply_proposal, audit_anchors (zod input/output schemas, structuredContent, tool annotations)
- Resource: greplica://graph/read (full graph view as JSON)

Architecture (apps/mcp/):
- Transport-agnostic server factory; stdio entrypoint in main.ts
- DI container with per-repo service cache (warm embedding model) and cache-aside graph reads (short TTL + invalidate-on-write with a generation guard)
- Middleware pipeline: structured JSON logging to stderr, centralized domain-error mapping to structured tool errors (stable codes)
- Thin controllers per tool; knowledge-graph core untouched

Repo-root resolution: per-call repo_root arg -> GREPLICA_REPO_ROOT ->
process.cwd().

Tests: scripts/check-mcp-server.mjs runs an in-process client against a fixture repo (tool listing, resource read, invalid-proposal paths, not-installed error, stdout hygiene via real stdio spawn); wired into npm test. Embedding end-to-end path is opt-in via
GREPLICA_MCP_TEST_EMBEDDINGS=1.