### PR TITLE
fix: prevent script injection in graph view via unescaped </script> i…

### DIFF
--- a/libs/knowledge-graph/graph-view/build-graph-view.ts
+++ b/libs/knowledge-graph/graph-view/build-graph-view.ts
@@ -348,6 +348,15 @@ function escapeHtml(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
+// JSON.stringify does not escape "/", so a payload containing the literal
+// substring "</script>" would close the embedding <script> tag early and let
+// the remaining text be parsed as HTML. Escaping "<" keeps the JSON valid
+// (JSON.parse and reading the tag's textContent are unaffected) while making
+// it impossible for the payload to terminate the tag.
+function jsonForScriptTag(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
 function kindColor(kind: string): string {
   return CLAIM_KIND_COLORS[kind] ?? "#cdd2da";
 }
@@ -404,7 +413,7 @@ function renderHtml(data: GraphViewData, title: string): string {
     .join("\n");
 
   const defaultClaimsMeta = `${data.claims.length} active claims · session from evidenced_by source, otherwise from code`;
-  const graphDataJson = JSON.stringify(data);
+  const graphDataJson = jsonForScriptTag(data);
 
   return `<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
#87


## Summary

`buildGraphView()` embedded the graph payload into the generated HTML as raw
`JSON.stringify` output. Since `JSON.stringify` doesn't escape `/`, graph
text containing the literal substring `</script>` (e.g. a claim documenting
`<script src="widget.js"></script>`) would close the embedding `<script>`
tag early, letting the rest of the string be parsed as arbitrary HTML/JS —
regardless of the tag's `type="application/json"` attribute, since the HTML
tokenizer closes on the first `</script>` it sees. `greplica graph view`
auto-opens this file in the browser unless `--no-open` is passed.

Every other interpolation in this file already goes through the local
`escapeHtml()` helper; this was the one spot that was missed.

## Fix

Added `jsonForScriptTag()`, which escapes `<` to `\u003c` in the serialized
JSON before embedding it. This keeps the payload valid JSON — the page reads
it back with `JSON.parse(document.getElementById("graph-data").textContent)`,
which is unaffected by the escaping — while making it impossible for the
payload to terminate the `<script>` tag early.

Other `JSON.stringify` calls in the file (`defaultClaimsMeta`,
`CLAIM_KIND_ORDER`, `CLAIM_KIND_COLORS`) only embed static constants, not
graph content, so they're left as-is.

## Testing

- `npx tsc --noEmit` passes.
- Verified manually: `jsonForScriptTag({ claims: [{ text: "See </script><script>alert(1)</script> for details" }] })` contains no raw `</script>`, the resulting HTML has exactly one real closing `</script>` tag, and `JSON.parse` on the escaped string round-trips to the original text.