### PR TITLE
feat: detect stale claims via content-hash tracking on code anchors

### DIFF
--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -350,6 +350,7 @@ function printAnchorAudit(result: ClaimAnchorAuditResult): void {
   printAuditSection("Missing symbols", result.missing_symbols, (issue) => `${issue.claim_id} -> ${formatAuditAnchor(issue.anchor)}`);
   printAuditSection("Ambiguous symbols", result.ambiguous_symbols, (issue) => `${issue.claim_id} -> ${formatAuditAnchor(issue.anchor)}`);
   printAuditSection("Unsupported languages", result.unsupported_languages, (issue) => `${issue.claim_id} -> ${formatAuditAnchor(issue.anchor)}`);
+  printAuditSection("Stale content", result.stale_content, (issue) => `${issue.claim_id} -> ${formatAuditAnchor(issue.anchor)} (code changed since claim was recorded)`);
 }
 
 function anchorAuditIssueCount(result: ClaimAnchorAuditResult): number {
@@ -357,7 +358,8 @@ function anchorAuditIssueCount(result: ClaimAnchorAuditResult): number {
     result.missing_files.length +
     result.missing_symbols.length +
     result.ambiguous_symbols.length +
-    result.unsupported_languages.length;
+    result.unsupported_languages.length +
+    result.stale_content.length;
 }
 
 function printAuditSection<T>(title: string, items: T[], render: (item: T) => string): void {

--- a/libs/knowledge-graph/claim.ts
+++ b/libs/knowledge-graph/claim.ts
@@ -15,6 +15,14 @@ export type ClaimIntent = "intended" | "accidental" | "unknown";
 export interface ClaimCodeAnchor {
   file: string;
   symbol?: string;
+  /**
+   * SHA-256 hex digest of the anchored symbol's source text at the time the
+   * claim was recorded (set automatically on proposal apply; absent for
+   * file-only anchors or anchors that couldn't be resolved). Used by
+   * `graph audit anchors` to detect when the underlying code has changed
+   * since the claim was written, even though the symbol itself still exists.
+   */
+  content_hash?: string;
 }
 
 export interface Claim {

--- a/libs/knowledge-graph/code-anchors/audit.ts
+++ b/libs/knowledge-graph/code-anchors/audit.ts
@@ -13,6 +13,7 @@ export async function auditClaimCodeAnchors(
     missing_symbols: [],
     ambiguous_symbols: [],
     unsupported_languages: [],
+    stale_content: [],
   };
 
   for (const claim of claims) {
@@ -23,7 +24,7 @@ export async function auditClaimCodeAnchors(
     }
 
     const resolvedAnchors = await resolver.resolveMany(repoRoot, claim.code_anchors);
-    for (const anchor of resolvedAnchors) {
+    for (const [index, anchor] of resolvedAnchors.entries()) {
       switch (anchor.status) {
         case "missing_file":
           result.missing_files.push({ claim_id: claim.id, anchor, status: "missing_file" });
@@ -37,7 +38,16 @@ export async function auditClaimCodeAnchors(
         case "unsupported_language":
           result.unsupported_languages.push({ claim_id: claim.id, anchor, status: "unsupported_language" });
           break;
-        case "resolved":
+        case "resolved": {
+          // The symbol still resolves unambiguously, but compare its current
+          // content hash against the one recorded when the claim was
+          // written: same symbol name, possibly different implementation.
+          const recordedHash = claim.code_anchors[index]?.content_hash;
+          if (recordedHash !== undefined && anchor.content_hash !== undefined && anchor.content_hash !== recordedHash) {
+            result.stale_content.push({ claim_id: claim.id, anchor, status: "stale_content" });
+          }
+          break;
+        }
         case "file_only":
           break;
       }

--- a/libs/knowledge-graph/code-anchors/resolver.ts
+++ b/libs/knowledge-graph/code-anchors/resolver.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { extname, join, normalize, relative } from "node:path";
 import Parser from "web-tree-sitter";
@@ -120,11 +121,7 @@ export class CodeAnchorResolver {
     if (symbols === undefined) {
       const fallback = fallbackSymbolForFile(filePath, anchor.symbol);
       if (fallback !== undefined) {
-        return {
-          ...anchor,
-          start_line: fallback.start_line,
-          status: "resolved",
-        };
+        return buildResolvedAnchor(anchor, filePath, fallback);
       }
       return { ...anchor, status: "unsupported_language" };
     }
@@ -133,11 +130,7 @@ export class CodeAnchorResolver {
     if (matches.length === 0) {
       const fallback = fallbackSymbolForFile(filePath, anchor.symbol);
       if (fallback !== undefined) {
-        return {
-          ...anchor,
-          start_line: fallback.start_line,
-          status: "resolved",
-        };
+        return buildResolvedAnchor(anchor, filePath, fallback);
       }
       return { ...anchor, status: "missing_symbol" };
     }
@@ -145,13 +138,7 @@ export class CodeAnchorResolver {
       return { ...anchor, status: "ambiguous_symbol" };
     }
 
-    const match = matches[0];
-    return {
-      ...anchor,
-      start_line: match.start_line,
-      end_line: match.end_line,
-      status: "resolved",
-    };
+    return buildResolvedAnchor(anchor, filePath, matches[0]);
   }
 
   async resolveMany(repoRoot: string | undefined, anchors: ClaimCodeAnchor[] | undefined): Promise<ResolvedCodeAnchor[]> {
@@ -203,6 +190,36 @@ export class CodeAnchorResolver {
       locateFile: () => require.resolve("web-tree-sitter/tree-sitter.wasm"),
     });
     return this.parserReady;
+  }
+}
+
+function buildResolvedAnchor(
+  anchor: ClaimCodeAnchor,
+  filePath: string,
+  candidate: SymbolCandidate,
+): ResolvedCodeAnchor {
+  return {
+    ...anchor,
+    start_line: candidate.start_line,
+    end_line: candidate.end_line,
+    content_hash: hashLines(filePath, candidate.start_line, candidate.end_line),
+    status: "resolved",
+  };
+}
+
+// Hashes the exact source text currently backing a resolved symbol so callers
+// can later detect drift: the symbol may still exist and still be
+// unambiguous, but its implementation may have changed underneath a claim
+// that was written against the old text. Returns undefined (rather than
+// throwing) if the file can't be read, since a hashing failure shouldn't
+// block anchor resolution itself.
+function hashLines(filePath: string, startLine: number, endLine: number): string | undefined {
+  try {
+    const lines = readFileSync(filePath, "utf8").split(/\r?\n/);
+    const slice = lines.slice(Math.max(0, startLine - 1), Math.max(startLine, endLine)).join("\n");
+    return createHash("sha256").update(slice).digest("hex");
+  } catch {
+    return undefined;
   }
 }
 

--- a/libs/knowledge-graph/code-anchors/types.ts
+++ b/libs/knowledge-graph/code-anchors/types.ts
@@ -18,7 +18,7 @@ export interface ResolvedCodeAnchor extends ClaimCodeAnchor {
 export interface ClaimAnchorAuditIssue {
   claim_id: ClaimId;
   anchor?: ClaimCodeAnchor;
-  status: "missing_anchors" | "missing_file" | "missing_symbol" | "ambiguous_symbol" | "unsupported_language";
+  status: "missing_anchors" | "missing_file" | "missing_symbol" | "ambiguous_symbol" | "unsupported_language" | "stale_content";
 }
 
 export interface ClaimAnchorAuditResult {
@@ -27,4 +27,11 @@ export interface ClaimAnchorAuditResult {
   missing_symbols: ClaimAnchorAuditIssue[];
   ambiguous_symbols: ClaimAnchorAuditIssue[];
   unsupported_languages: ClaimAnchorAuditIssue[];
+  /**
+   * Anchors that still resolve to an existing, unambiguous symbol, but whose
+   * source text no longer matches the content_hash recorded when the claim
+   * was written — i.e. the symbol wasn't renamed or deleted, its
+   * implementation changed underneath the claim.
+   */
+  stale_content: ClaimAnchorAuditIssue[];
 }

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -8,6 +8,7 @@ import { graphContextConfig, type GraphContextConfig } from "./graph-context/con
 import type { EmbeddingStatus, GraphContextResult } from "./graph-context/types.js";
 import { buildGraphViewHtml } from "./graph-view/build-graph-view.js";
 import { auditClaimCodeAnchors } from "./code-anchors/audit.js";
+import { CodeAnchorResolver } from "./code-anchors/resolver.js";
 import type { ClaimAnchorAuditResult } from "./code-anchors/types.js";
 import { defaultDatabasePath, openDatabase } from "../storage/sqlite/db.js";
 import type { SqliteRepository } from "../storage/sqlite/repository.js";
@@ -57,6 +58,7 @@ export class KnowledgeGraphService {
     private readonly repository: SqliteRepository,
     private readonly contextConfig: GraphContextConfig = graphContextConfig,
     private readonly contextBuilder = new GraphContextBuilder(repository),
+    private readonly anchorResolver = new CodeAnchorResolver(),
   ) {}
 
   initRepo(input: RepoRef): InitRepoResult {
@@ -122,7 +124,11 @@ export class KnowledgeGraphService {
 
   async auditCodeAnchors(input: RepoRef): Promise<ClaimAnchorAuditResult> {
     const initialized = this.requireRepo(input);
-    return auditClaimCodeAnchors(input.repo_root, this.repository.readGraphView(initialized.repo_id).claims);
+    return auditClaimCodeAnchors(
+      input.repo_root,
+      this.repository.readGraphView(initialized.repo_id).claims,
+      this.anchorResolver,
+    );
   }
 
   async validateProposal(input: RepoRef, proposal: unknown): Promise<ProposalValidationResult> {
@@ -132,7 +138,7 @@ export class KnowledgeGraphService {
     if (!validation.valid) return validation;
 
     const anchorErrors = anchorAuditErrors(
-      await auditClaimCodeAnchors(input.repo_root, normalizedProposal.creates.claims ?? []),
+      await auditClaimCodeAnchors(input.repo_root, normalizedProposal.creates.claims ?? [], this.anchorResolver),
     );
     if (anchorErrors.length === 0) return validation;
 
@@ -148,6 +154,13 @@ export class KnowledgeGraphService {
     if (!validation.valid) {
       throw new Error(`Proposal is invalid:\n${validation.errors.map((error) => `- ${error}`).join("\n")}`);
     }
+
+    // Record a content fingerprint for every resolvable anchor at the moment
+    // the claim is written, so a later `graph audit anchors` can tell whether
+    // the anchored code has changed since. The resolver's file/symbol cache
+    // is shared with validateProposal's audit above, so this doesn't re-parse
+    // files that were just resolved.
+    await this.attachAnchorContentHashes(input.repo_root, normalizedProposal.creates.claims);
 
     const initialized = this.requireRepo(input);
     const working = this.repository.requireWorkingScope(initialized.repo_id);
@@ -176,6 +189,20 @@ export class KnowledgeGraphService {
         edges: normalizedProposal.creates.edges?.length ?? 0,
       },
     };
+  }
+
+  private async attachAnchorContentHashes(repoRoot: string | undefined, claims: Claim[] | undefined): Promise<void> {
+    for (const claim of claims ?? []) {
+      if (claim.code_anchors === undefined || claim.code_anchors.length === 0) continue;
+
+      const resolved = await this.anchorResolver.resolveMany(repoRoot, claim.code_anchors);
+      claim.code_anchors = claim.code_anchors.map((anchor, index) => {
+        const contentHash = resolved[index]?.content_hash;
+        return resolved[index]?.status === "resolved" && contentHash !== undefined
+          ? { ...anchor, content_hash: contentHash }
+          : anchor;
+      });
+    }
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit",
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-code-anchor-staleness.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",

--- a/scripts/check-code-anchor-staleness.js
+++ b/scripts/check-code-anchor-staleness.js
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Each greplica CLI invocation constructs its own CodeAnchorResolver, so a
+// fresh resolver per "pass" here mirrors real usage. (The resolver caches
+// parsed symbols per file path for its own lifetime as a performance
+// optimization within a single command -- reusing one resolver instance
+// across the file mutations below would read stale cached symbols, which is
+// a test-harness concern, not something a real CLI invocation hits.)
+const root = new URL("..", import.meta.url);
+const { CodeAnchorResolver } = await import(new URL("dist/libs/knowledge-graph/code-anchors/resolver.js", root));
+const { auditClaimCodeAnchors } = await import(new URL("dist/libs/knowledge-graph/code-anchors/audit.js", root));
+
+const tmp = mkdtempSync(join(tmpdir(), "greplica-code-anchor-resolver-test-"));
+mkdirSync(join(tmp, "src"), { recursive: true });
+const targetFile = join(tmp, "src", "foo.js");
+
+writeFileSync(
+  targetFile,
+  ["function computeTotal(items) {", "  return items.length;", "}", ""].join("\n"),
+);
+
+const anchor = { file: "src/foo.js", symbol: "computeTotal" };
+
+const first = await new CodeAnchorResolver().resolve(tmp, anchor);
+assert.equal(first.status, "resolved");
+assert.equal(typeof first.content_hash, "string");
+assert.ok(first.content_hash.length > 0);
+
+const second = await new CodeAnchorResolver().resolve(tmp, anchor);
+assert.equal(second.content_hash, first.content_hash, "hash must be deterministic for unchanged content");
+
+// A brand-new claim with no recorded content_hash yet must not be reported
+// stale (nothing to compare against).
+const freshAudit = await auditClaimCodeAnchors(
+  tmp,
+  [{ id: "claim.fresh", kind: "fact", text: "t", truth: "code_verified", intent: "intended", code_anchors: [anchor] }],
+  new CodeAnchorResolver(),
+);
+assert.equal(freshAudit.stale_content.length, 0, "a claim with no recorded hash must not be flagged stale");
+assert.equal(freshAudit.missing_symbols.length, 0);
+
+// A claim whose recorded hash matches current content must be healthy.
+const healthyClaim = {
+  id: "claim.healthy",
+  kind: "fact",
+  text: "computeTotal returns the number of items",
+  truth: "code_verified",
+  intent: "intended",
+  code_anchors: [{ ...anchor, content_hash: first.content_hash }],
+};
+const healthyAudit = await auditClaimCodeAnchors(tmp, [healthyClaim], new CodeAnchorResolver());
+assert.equal(healthyAudit.stale_content.length, 0, "matching content_hash must not be flagged stale");
+
+// Change the implementation but keep the same symbol name and file: the
+// symbol still resolves (so it's not missing_symbol), but the content
+// hash now differs from what the claim recorded.
+writeFileSync(
+  targetFile,
+  ["function computeTotal(items) {", "  return items.reduce((sum, item) => sum + item.price, 0);", "}", ""].join("\n"),
+);
+
+const staleAudit = await auditClaimCodeAnchors(tmp, [healthyClaim], new CodeAnchorResolver());
+assert.equal(staleAudit.missing_symbols.length, 0, "symbol still exists, so it must not be reported missing");
+assert.equal(staleAudit.stale_content.length, 1, "changed implementation must be reported stale");
+assert.equal(staleAudit.stale_content[0].claim_id, "claim.healthy");
+
+const driftedHash = await new CodeAnchorResolver().resolve(tmp, anchor);
+assert.notEqual(driftedHash.content_hash, first.content_hash, "hash must change when implementation changes");
+
+// Renaming/deleting the symbol should still surface as missing_symbol, not
+// stale_content -- the two failure modes stay distinct.
+writeFileSync(targetFile, ["function computeGrandTotal(items) {", "  return items.length;", "}", ""].join("\n"));
+const missingAudit = await auditClaimCodeAnchors(tmp, [healthyClaim], new CodeAnchorResolver());
+assert.equal(missingAudit.missing_symbols.length, 1);
+assert.equal(missingAudit.stale_content.length, 0);
+
+console.log("Code anchor resolver/staleness checks passed.");


### PR DESCRIPTION
#91
## Summary

Claims had no way to detect when the code behind them changed while the
anchored symbol's name stayed the same. `graph audit anchors` only checked
structural resolution (file/symbol exists, unambiguous) and the "Freshness"
chart in `graph view` only reflects explicit supersession — neither one
detects silent code drift. An agent could be served a claim whose text no
longer matches the code, with every health signal reporting green.

## Change

- `ClaimCodeAnchor` gains an optional `content_hash`.
- `CodeAnchorResolver` now computes a SHA-256 hash of a resolved symbol's
  exact source lines on every resolution (`resolved` status only).
- `KnowledgeGraphService.applyProposal` stamps each claim's anchors with this
  hash before persisting — reusing the same resolver instance (and its
  file/symbol cache) that `validateProposal`'s anchor audit already warmed,
  so this adds no extra file parsing in the common case.
- `auditClaimCodeAnchors` compares the freshly resolved hash against the
  claim's recorded hash and reports a new `stale_content` status when they
  differ. This is distinct from `missing_symbol` — a rename/deletion is a
  different failure mode from a same-named symbol whose body changed.
- No DB schema or migration change needed: `code_anchors` is already
  persisted as a JSON blob, so the new field round-trips for free.
- `graph audit anchors` now prints a "Stale content" section and fails
  (non-zero exit) when drift is detected.

## Out of scope for this pass

- `file_only` anchors (no specific symbol) aren't hashed — a whole-file hash
  would flag on any unrelated edit, which is too noisy for an MVP.
- Whitespace-only/formatting changes will trigger `stale_content` too, since
  the hash is over raw source text. Worth revisiting (e.g. normalize
  whitespace before hashing) if this proves noisy in practice.
- The "Freshness" chart in `graph view` still only reflects supersession
  state, not code drift. Feeding `stale_content` into that chart (or adding
  a distinct visual signal) is a natural follow-up but is a UI-layer change
  I've left out here to keep this PR to the detection mechanism itself.

