### PR TITLE
fix: report validation error instead of crashing on malformed proposal edges

### DIFF
--- a/libs/knowledge-graph/proposal.ts
+++ b/libs/knowledge-graph/proposal.ts
@@ -127,6 +127,15 @@ export function normalizeProposal(input: unknown, lookup?: ProposalSubjectLookup
       continue;
     }
 
+    if (typeof edge.from !== "string" || typeof edge.to !== "string" || typeof edge.kind !== "string") {
+      // Malformed edge (e.g. from_id/to_id without types, or missing kind): pass it
+      // through untouched so validateProposal can report it instead of crashing here.
+      const raw = edge as unknown as Record<string, unknown>;
+      const passthroughId = typeof raw.id === "string" ? raw.id : `edge_invalid_${edges.length}`;
+      edges.push({ ...raw, id: passthroughId } as unknown as Edge);
+      continue;
+    }
+
     const fromType = resolveSubjectType(edge.from, subjectTypes, lookup) ?? "component";
     const toType = resolveSubjectType(edge.to, subjectTypes, lookup) ?? defaultToType(edge.kind);
     edges.push(makeEdge(edge.kind, edge.from, fromType, edge.to, toType, edge.metadata));

--- a/libs/knowledge-graph/validate-proposal.ts
+++ b/libs/knowledge-graph/validate-proposal.ts
@@ -107,6 +107,13 @@ export function validateProposal(
 
     validateSubjectBase("edge", edge.id, ids, existingSubjects, errors);
 
+    if (edge.from_type === undefined || edge.to_type === undefined) {
+      errors.push(
+        `Edge ${stringId(edge.id)} is missing subject references: compact edges use { kind, from, to } (did you mean 'from'/'to' instead of 'from_id'/'to_id'?).`,
+      );
+      continue;
+    }
+
     const fromType = String(edge.from_type) as GraphObjectType;
     const toType = String(edge.to_type) as GraphObjectType;
     const kind = String(edge.kind) as EdgeKind;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit",
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-proposal-validate.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",

--- a/scripts/check-proposal-validate.js
+++ b/scripts/check-proposal-validate.js
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+
+const root = new URL("..", import.meta.url);
+const { normalizeProposal } = await import(new URL("dist/libs/knowledge-graph/proposal.js", root));
+const { validateProposal } = await import(new URL("dist/libs/knowledge-graph/validate-proposal.js", root));
+
+const components = [
+  { id: "component.a", name: "A" },
+  { id: "component.b", name: "B" },
+];
+
+// Edge written with canonical field names but no types (issue #82) must not crash
+// normalization, and must surface as a validation error.
+const malformedEdge = {
+  title: "Malformed edge repro",
+  creates: {
+    components,
+    edges: [{ from_id: "component.a", to_id: "component.b", kind: "contains" }],
+  },
+};
+
+let normalized;
+assert.doesNotThrow(() => {
+  normalized = normalizeProposal(malformedEdge);
+}, "normalizeProposal must not throw on a malformed edge");
+
+const malformedResult = validateProposal(normalized);
+assert.equal(malformedResult.valid, false, "malformed edge proposal must be invalid");
+assert.ok(
+  malformedResult.errors.some((error) => error.includes("from'/'to")),
+  `expected a from/to guidance error, got: ${JSON.stringify(malformedResult.errors)}`,
+);
+
+// Edge missing kind must also be reported, not crash.
+const missingKindEdge = {
+  title: "Missing kind repro",
+  creates: {
+    components,
+    edges: [{ from: "component.a", to: "component.b" }],
+  },
+};
+
+let normalizedMissingKind;
+assert.doesNotThrow(() => {
+  normalizedMissingKind = normalizeProposal(missingKindEdge);
+}, "normalizeProposal must not throw on an edge without kind");
+assert.equal(validateProposal(normalizedMissingKind).valid, false, "edge without kind must be invalid");
+
+// A well-formed compact edge must keep validating cleanly.
+const compactEdge = {
+  title: "Compact edge",
+  creates: {
+    components,
+    edges: [{ kind: "contains", from: "component.a", to: "component.b" }],
+  },
+};
+
+const compactResult = validateProposal(normalizeProposal(compactEdge));
+assert.equal(compactResult.valid, true, `compact edge must stay valid, got: ${JSON.stringify(compactResult.errors)}`);
+
+console.log("check-proposal-validate: ok");


### PR DESCRIPTION
Fixes #82

## What changed

- `normalizeProposal` (libs/knowledge-graph/proposal.ts): explicit edges that are neither canonical (`from_id/from_type/to_id/to_type`) nor well-formed compact (`kind/from/to` strings) no longer reach `makeEdge`/`slug(undefined)`. They are passed through normalization untouched (with a synthetic id when missing) so validation can report them.
- `validateProposal` (libs/knowledge-graph/validate-proposal.ts): such edges now produce a clear validation error instead of a TypeError:

  ```
  Proposal is invalid:
  - Edge edge_invalid_0 is missing subject references: compact edges use { kind, from, to } (did you mean 'from'/'to' instead of 'from_id'/'to_id'?).
  ```

- New smoke test `scripts/check-proposal-validate.js` (wired into `npm test`): covers the #82 repro (`from_id/to_id` edge), an edge missing `kind` (same crash path), and a well-formed compact edge staying valid.

## Checks run locally

- `npm run typecheck` — clean
- `node scripts/check-proposal-validate.js` — ok
- `node scripts/check-repo-context.js`, `check-graph-view.js` — pass
- End-to-end: ran the issue #82 repro JSON through `dist/apps/cli/main.js proposal validate` — prints the validation error above instead of crashing
- `git diff --check` — clean

Note: `check-transcript-bundle.js` and `check-install-options.js` fail on my machine on a clean `main` checkout too (Windows-only: they spawn `node /C:/...` URL-style paths, which resolves to `C:\C:\...`). Unrelated to this change — happy to file that separately.