### PR TITLE
refactor: extract hook module interfaces into dedicated types.ts

### DIFF
--- a/libs/hooks/hook-input.ts
+++ b/libs/hooks/hook-input.ts
@@ -1,18 +1,4 @@
-export interface HookInput {
-  session_id?: unknown;
-  sessionId?: unknown;
-  transcript_path?: unknown;
-  transcriptPath?: unknown;
-  cwd?: unknown;
-  hook_event_name?: unknown;
-  hookEventName?: unknown;
-  turn_id?: unknown;
-  prompt?: unknown;
-  // OpenHands variants of hook_event_name / cwd.
-  event_type?: unknown;
-  working_dir?: unknown;
-  message?: unknown;
-}
+import type { HookInput } from "./types.js";
 
 export function readHookInput(stdin: string): HookInput {
   const trimmed = stdin.trim();

--- a/libs/hooks/session-state.ts
+++ b/libs/hooks/session-state.ts
@@ -2,45 +2,7 @@ import type Database from "better-sqlite3";
 import { createHash } from "node:crypto";
 import type { SessionConfig } from "../config/greplica-config.js";
 import type { InstallPlatform } from "../install/paths.js";
-
-export interface AgentSession {
-  platform: InstallPlatform;
-  session_id: string;
-  repo_id: string;
-  transcript_path: string | null;
-  cwd: string | null;
-  guidance_injected_at: string | null;
-  stops_since_memory_current: number;
-  last_seen_at: string;
-  last_memory_current_at: string | null;
-}
-
-export interface RecordHookInput {
-  platform: InstallPlatform;
-  sessionId?: string;
-  repoId: string;
-  transcriptPath?: string;
-  cwd?: string;
-  eventName?: string;
-  now?: Date;
-}
-
-export interface RecordHookResult {
-  session: AgentSession;
-  shouldInjectGuidance: boolean;
-}
-
-export interface ClaimedMemoryUpdateAttempt {
-  session: AgentSession;
-  reason: "stop_threshold" | "time_threshold";
-}
-
-export interface MarkMemoryCurrentInput {
-  repoId: string;
-  platform: InstallPlatform;
-  sessionId?: string;
-  now?: Date;
-}
+import type { AgentSession, ClaimedMemoryUpdateAttempt, MarkMemoryCurrentInput, RecordHookInput, RecordHookResult } from "./types.js";
 
 const defaultStopThreshold = 7;
 const defaultTimeThresholdMinutes = 40;

--- a/libs/hooks/types.ts
+++ b/libs/hooks/types.ts
@@ -1,0 +1,56 @@
+import type { InstallPlatform } from "../install/paths.js";
+
+export interface AgentSession {
+  platform: InstallPlatform;
+  session_id: string;
+  repo_id: string;
+  transcript_path: string | null;
+  cwd: string | null;
+  guidance_injected_at: string | null;
+  stops_since_memory_current: number;
+  last_seen_at: string;
+  last_memory_current_at: string | null;
+}
+
+export interface RecordHookInput {
+  platform: InstallPlatform;
+  sessionId?: string;
+  repoId: string;
+  transcriptPath?: string;
+  cwd?: string;
+  eventName?: string;
+  now?: Date;
+}
+
+export interface RecordHookResult {
+  session: AgentSession;
+  shouldInjectGuidance: boolean;
+}
+
+export interface ClaimedMemoryUpdateAttempt {
+  session: AgentSession;
+  reason: "stop_threshold" | "time_threshold";
+}
+
+export interface MarkMemoryCurrentInput {
+  repoId: string;
+  platform: InstallPlatform;
+  sessionId?: string;
+  now?: Date;
+}
+
+export interface HookInput {
+  session_id?: unknown;
+  sessionId?: unknown;
+  transcript_path?: unknown;
+  transcriptPath?: unknown;
+  cwd?: unknown;
+  hook_event_name?: unknown;
+  hookEventName?: unknown;
+  turn_id?: unknown;
+  prompt?: unknown;
+  // OpenHands variants of hook_event_name / cwd.
+  event_type?: unknown;
+  working_dir?: unknown;
+  message?: unknown;
+}

--- a/libs/hooks/worker.ts
+++ b/libs/hooks/worker.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ClaimedMemoryUpdateAttempt } from "./session-state.js";
+import type { ClaimedMemoryUpdateAttempt } from "./types.js";
 import { HookSessionStore } from "./session-state.js";
 import { WorkerLease } from "../utils/worker-lease.js";
 import { ensureGreplicaConfig, type GreplicaConfig } from "../config/greplica-config.js";

--- a/libs/install/platforms/openhands.ts
+++ b/libs/install/platforms/openhands.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 import { hookCommand, hookEvents, mergeHookConfig, readJsonObject, writeJson } from "../hook-config.js";
 import { copyBundledSkills } from "../skills.js";
 import { runOpenHandsAgent } from "../../agent-runner/openhands.js";
-import { hookSessionId, type HookInput } from "../../hooks/hook-input.js";
+import { hookSessionId } from "../../hooks/hook-input.js";
+import type { HookInput } from "../../hooks/types.js";
 import {
   isRecord,
   parseJsonLine,

--- a/libs/install/platforms/types.ts
+++ b/libs/install/platforms/types.ts
@@ -1,5 +1,5 @@
 import type { InstallPlatform } from "../paths.js";
-import type { HookInput } from "../../hooks/hook-input.js";
+import type { HookInput } from "../../hooks/types.js";
 
 export interface PlatformInstallContext {
   repoRoot: string;


### PR DESCRIPTION
Fixes #94

## Refactor: extract hook module interfaces into dedicated `types.ts`

### Summary

Moves all TypeScript interfaces from `libs/hooks/session-state.ts` and `libs/hooks/hook-input.ts` into a new dedicated `libs/hooks/types.ts` file, following the pattern already established in other modules like `libs/knowledge-graph/graph-context/types.ts` and `libs/install/platforms/types.ts`.

### Changes

| File | Change |
|------|--------|
| `libs/hooks/types.ts` | **New file** — contains all 6 interfaces: `AgentSession`, `RecordHookInput`, `RecordHookResult`, `ClaimedMemoryUpdateAttempt`, `MarkMemoryCurrentInput`, `HookInput` |
| `libs/hooks/session-state.ts` | Removed inline interface definitions, now imports from `./types.js` |
| `libs/hooks/hook-input.ts` | Removed `HookInput` definition, now imports from `./types.js` |
| `libs/hooks/worker.ts` | Updated import for `ClaimedMemoryUpdateAttempt` to `./types.js` |
| `libs/install/platforms/openhands.ts` | Updated import |
| `libs/install/platforms/types.ts` | Updated import |


### Why

- **Follows existing convention** - Other modules already separate types from implementation
- **Better discoverability** - All hook types are now in one place
- **Prevents circular dependencies** - Decouples types from implementation logic
- **Cleaner files** - Implementation files are easier to read without interface definitions mixed in

### Testing

- [x] `npm run typecheck` passes
- [x] `npm run build` compiles successfully
