### PR TITLE
fix: report validation error instead of crashing when a compact relationship field has a missing/invalid id

### DIFF
--- a/libs/knowledge-graph/proposal.ts
+++ b/libs/knowledge-graph/proposal.ts
@@ -89,35 +89,35 @@ export function normalizeProposal(input: unknown, lookup?: ProposalSubjectLookup
 
   for (const component of components) {
     for (const target of asArray(component.contains)) {
-      edges.push(makeEdge("contains", component.id, "component", target, "component"));
+      pushEdge(edges, "contains", component.id, "component", target, "component");
     }
     for (const target of asArray(component.supersedes)) {
-      edges.push(makeEdge("supersedes", component.id, "component", target, "component"));
+      pushEdge(edges, "supersedes", component.id, "component", target, "component");
     }
   }
 
   for (const flow of flows) {
     for (const target of asArray(flow.contains)) {
-      edges.push(makeEdge("contains", flow.id, "flow", target, "flow"));
+      pushEdge(edges, "contains", flow.id, "flow", target, "flow");
     }
     for (const target of asArray(flow.touches)) {
-      edges.push(makeEdge("touches", flow.id, "flow", target, "component"));
+      pushEdge(edges, "touches", flow.id, "flow", target, "component");
     }
     for (const target of asArray(flow.supersedes)) {
-      edges.push(makeEdge("supersedes", flow.id, "flow", target, "flow"));
+      pushEdge(edges, "supersedes", flow.id, "flow", target, "flow");
     }
   }
 
   for (const claim of claims) {
     for (const target of asArray(claim.about)) {
-      const targetType = resolveSubjectType(target, subjectTypes, lookup);
-      edges.push(makeEdge("about", claim.id, "claim", target, targetType ?? "component"));
+      const targetType = typeof target === "string" ? resolveSubjectType(target, subjectTypes, lookup) : undefined;
+      pushEdge(edges, "about", claim.id, "claim", target, targetType ?? "component");
     }
     for (const target of asArray(claim.evidenced_by)) {
-      edges.push(makeEdge("evidenced_by", claim.id, "claim", target, "source"));
+      pushEdge(edges, "evidenced_by", claim.id, "claim", target, "source");
     }
     for (const target of asArray(claim.supersedes)) {
-      edges.push(makeEdge("supersedes", claim.id, "claim", target, "claim"));
+      pushEdge(edges, "supersedes", claim.id, "claim", target, "claim");
     }
   }
 
@@ -152,6 +152,39 @@ export function normalizeProposal(input: unknown, lookup?: ProposalSubjectLookup
       edges: dedupeEdges(edges),
     },
   };
+}
+
+// Compact relationship fields (component.contains, flow.touches, claim.about,
+// etc.) are declared as string/string[] in the Compact*/Edge types, but this
+// function runs on untrusted proposal JSON before any validation -- the
+// owning subject's id, or an individual target, can be missing or a
+// non-string at runtime despite what the types claim. Building straight into
+// makeEdge/edgeId/slug in that case throws a raw TypeError (the same crash
+// class as #82, just reached via a subject/target id instead of an
+// explicit edge's from_id/to_id). Guard here instead: on a valid pair, build
+// the edge as before; otherwise push a placeholder with no from_type/to_type
+// so validateProposal's existing "missing subject references" check reports
+// it clearly instead of normalizeProposal crashing.
+function pushEdge(
+  edges: Edge[],
+  kind: EdgeKind,
+  fromId: unknown,
+  fromType: GraphObjectType,
+  toId: unknown,
+  toType: GraphObjectType,
+  metadata?: EdgeMetadata,
+): void {
+  if (typeof fromId === "string" && fromId.length > 0 && typeof toId === "string" && toId.length > 0) {
+    edges.push(makeEdge(kind, fromId, fromType, toId, toType, metadata));
+    return;
+  }
+
+  edges.push({
+    id: `edge_invalid_${edges.length}`,
+    kind,
+    from_id: fromId,
+    to_id: toId,
+  } as unknown as Edge);
 }
 
 function makeEdge(

--- a/scripts/check-proposal-validate.js
+++ b/scripts/check-proposal-validate.js
@@ -58,4 +58,38 @@ const compactEdge = {
 const compactResult = validateProposal(normalizeProposal(compactEdge));
 assert.equal(compactResult.valid, true, `compact edge must stay valid, got: ${JSON.stringify(compactResult.errors)}`);
 
+// Same crash class as #82, reached via compact relationship fields instead
+// of an explicit edge: a component/flow/claim missing its own id, or a
+// contains/touches/about/evidenced_by/supersedes target that isn't a
+// string, used to throw inside slug()/edgeId() while deriving edges from
+// those compact fields. These must be reported by validateProposal, not
+// crash normalizeProposal.
+const missingSubjectIdCases = [
+  {
+    name: "component missing id with contains",
+    proposal: { title: "t", creates: { components: [{ contains: ["component.b"] }, { id: "component.b", name: "B" }] } },
+  },
+  {
+    name: "flow missing id with touches",
+    proposal: { title: "t", creates: { flows: [{ touches: ["component.a"] }], components: [{ id: "component.a", name: "A" }] } },
+  },
+  {
+    name: "claim missing id with about",
+    proposal: { title: "t", creates: { claims: [{ about: "component.a" }], components: [{ id: "component.a", name: "A" }] } },
+  },
+  {
+    name: "contains target is not a string",
+    proposal: { title: "t", creates: { components: [{ id: "component.a", name: "A", contains: [123] }] } },
+  },
+];
+
+for (const { name, proposal } of missingSubjectIdCases) {
+  let normalizedCase;
+  assert.doesNotThrow(() => {
+    normalizedCase = normalizeProposal(proposal);
+  }, `normalizeProposal must not throw for: ${name}`);
+  const result = validateProposal(normalizedCase);
+  assert.equal(result.valid, false, `expected invalid for: ${name}, got valid with ${JSON.stringify(normalizedCase)}`);
+}
+
 console.log("check-proposal-validate: ok");


### PR DESCRIPTION
#97 
## What changed

Building on #93 — while testing proposal validation with some more
malformed inputs, I found a related crash reachable through a different
path than the one #93 fixed.

* `normalizeProposal` (`libs/knowledge-graph/proposal.ts`): added a
  `pushEdge()` helper used by the `component.contains`/`supersedes`,
  `flow.contains`/`touches`/`supersedes`, and
  `claim.about`/`evidenced_by`/`supersedes` loops. It validates both ids
  are non-empty strings before calling `makeEdge`/`edgeId`/`slug`. On
  failure (component/flow/claim missing its own `id`, or a target inside
  one of those fields isn't a string), it pushes a placeholder edge with
  no `from_type`/`to_type` instead of crashing — the same shape #93's fix
  already produces for its own case, so it's caught by
  `validateProposal`'s existing "missing subject references" check with
  **no changes to `validate-proposal.ts`** needed.
* Extended the existing `scripts/check-proposal-validate.js` (added by
  #93) with 4 new cases covering this path, rather than adding a parallel
  test file.

## Reproduction (crashes on main before this fix, even after #93)

```js
normalizeProposal({ title: "t", creates: { components: [{ contains: ["component.b"] }] } } })
normalizeProposal({ title: "t", creates: { flows: [{ touches: ["component.a"] }] } } })
normalizeProposal({ title: "t", creates: { claims: [{ about: "component.a" }] } } })
normalizeProposal({ title: "t", creates: { components: [{ id: "component.a", contains: [123] }] } } })
```

Each threw `Cannot read properties of undefined (reading 'replace')` (or
`.replace is not a function` for the non-string-target case) inside
`slug()`, via `edgeId()` <- `makeEdge()` <- the per-loop
`edges.push(makeEdge(...))` call. #93 guarded the `explicitEdges` loop
(edges supplied directly under `creates.edges`); these three loops derive
edges from compact fields on components/flows/claims instead, so they
were a different code path.

## Checks run locally

* `npm run typecheck` — clean
* `npm run build` — clean
* `node scripts/check-proposal-validate.js` — ok (existing #93 cases +
  4 new ones)
* Ran each repro above through `normalizeProposal` → `validateProposal`
  end-to-end — prints a clean validation error instead of crashing, e.g.: