### PR TITLE
feat(opencode): add full OpenCode platform support with transcript projection and working-memory updates

### DIFF
--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -142,14 +142,14 @@ const cliCommands = [
   {
     key: "transcriptBundle",
     path: ["transcript", "bundle"],
-    usage: "transcript bundle --platform codex|claude|copilot --file <path> [--file <path>...] --out <bundle.md>",
+    usage: "transcript bundle --platform codex|claude|copilot|opencode --file <path> [--file <path>...] --out <bundle.md>",
     handler: runTranscriptBundle,
     showInTopLevelHelp: true,
   },
   {
     key: "hookIngest",
     path: ["hook", "ingest"],
-    usage: "hook ingest --platform codex|claude|copilot|openhands|factory-droid",
+    usage: "hook ingest --platform codex|claude|copilot|opencode|openhands|factory-droid",
     handler: runHookIngest,
   },
   {
@@ -519,7 +519,7 @@ function parseHookIngestPlatform(args: string[]): InstallPlatform {
 }
 
 function parseHookPlatform(value: string | undefined): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "copilot" || value === "openhands" || value === "factory-droid") return value;
+  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode" || value === "openhands" || value === "factory-droid") return value;
   throw new Error(usage("hookIngest"));
 }
 

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -51,16 +51,15 @@ Then bootstrap shallow memory for this repo:
 
 If I chose "Yes, recent sessions", analyze prior sessions:
 - Find recent prior sessions for this same repo and platform, preferring work from the last 1-2 days.
-- Candidate locations: Codex `~/.codex/sessions/**/*.jsonl`; Claude Code `~/.claude/projects/**/*.jsonl`; GitHub Copilot CLI paths from `Stop` hook `transcript_path` values or `$COPILOT_HOME/session-state`.
+- Candidate locations: Codex `~/.codex/sessions/**/*.jsonl`; Claude Code `~/.claude/projects/**/*.jsonl`; GitHub Copilot CLI paths from `Stop` hook `transcript_path` values or `$COPILOT_HOME/session-state`; OpenCode `~/.local/share/opencode/storage/session/*.json` with messages under `storage/message/<sessionId>/`.
 - Do not require transcript metadata `cwd` to equal the current checkout path. Users may use worktrees, renamed folders, or multiple checkouts of the same repo.
 - Treat a transcript as same-repo when its metadata `cwd` is the current path, or when that `cwd` still exists and Git reports the same `remote.origin.url` or same normalized repo identity as the current repo. If the old path no longer exists, use transcript cwd text, repo name, branch, and recent session content as weaker matching evidence.
-- For OpenCode, tell me transcript backfill is not supported yet and skip this step.
 - Select 1-3 transcripts. Use one if there is a large high-signal session, two by default when multiple sessions are useful, and three only when sessions are smaller or cover distinct work.
 - Show me the selected transcripts before bundling them: title if available, date/time, path, size/turn count if available, and why each matched this repo.
 - Do not ask for confirmation. Continue with a temporary bundle path:
 
 ```bash
-greplica transcript bundle --platform <codex-or-claude-or-copilot> --file <path-1> [--file <path-2>] [--file <path-3>] --out <greplica-transcript-backfill.md>
+greplica transcript bundle --platform <codex-or-claude-or-copilot-or-opencode> --file <path-1> [--file <path-2>] [--file <path-3>] --out <greplica-transcript-backfill.md>
 ```
 
 - Then use the `greplica-fast-session-bootstrap` skill on `<greplica-transcript-backfill.md>` and include its final value summary naturally in the final answer.

--- a/libs/agent-runner/opencode.ts
+++ b/libs/agent-runner/opencode.ts
@@ -1,0 +1,53 @@
+import { createWriteStream, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { collectAgentMetrics } from "./metrics.js";
+import type { AgentRunInput, AgentRunResult } from "./types.js";
+
+export async function runOpenCodeAgent(input: AgentRunInput): Promise<AgentRunResult> {
+  const startedAt = Date.now();
+  const transcript = createWriteStream(input.transcriptPath, { flags: "w" });
+  const result = await runOpenCodeProcess(input, transcript);
+  transcript.end();
+
+  const elapsedMs = Date.now() - startedAt;
+  const metrics = collectAgentMetrics({
+    transcriptPath: input.transcriptPath,
+  });
+
+  return {
+    agent: "opencode",
+    model: input.model ?? "default",
+    elapsed_ms: elapsedMs,
+    transcript_path: input.transcriptPath,
+    final_message_path: input.finalMessagePath,
+    exit_code: result.exitCode,
+    signal: result.signal,
+    ...metrics,
+  };
+}
+
+function runOpenCodeProcess(
+  input: AgentRunInput,
+  transcript: NodeJS.WritableStream,
+): Promise<{ exitCode: number | null; signal: string | null }> {
+  return new Promise((resolve, reject) => {
+    const args = ["-p", input.prompt, "-f", "json", "-q"];
+
+    const child = spawn("opencode", args, {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+
+    child.once("error", reject);
+    child.stdout.pipe(transcript);
+    child.once("close", (exitCode, signal) => {
+      writeFileSync(
+        input.finalMessagePath,
+        `OpenCode update runner exited with code ${exitCode ?? "null"} and signal ${signal ?? "null"}.\n`,
+        "utf8",
+      );
+      resolve({ exitCode, signal });
+    });
+  });
+}

--- a/libs/agent-runner/types.ts
+++ b/libs/agent-runner/types.ts
@@ -1,4 +1,4 @@
-export type AgentKind = "codex" | "openhands";
+export type AgentKind = "codex" | "openhands" | "opencode";
 
 export interface AgentRunInput {
   cwd: string;

--- a/libs/install/platforms/opencode.ts
+++ b/libs/install/platforms/opencode.ts
@@ -1,26 +1,235 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import Database from "better-sqlite3";
+import { hookCommand, hookEvents, mergeHookConfig, readJsonObject, writeJson } from "../hook-config.js";
 import { copyBundledSkills } from "../skills.js";
-import type { PlatformInstallContext, PlatformInstallResult, PlatformInstaller, WorkingMemoryUpdateInput } from "./types.js";
+import { runOpenCodeAgent } from "../../agent-runner/opencode.js";
+import { hookSessionId, type HookInput } from "../../hooks/hook-input.js";
+import {
+  isRecord,
+  parseJsonLine,
+  renderSessionTranscriptMarkdown,
+  sanitizeTranscriptMessage,
+  type SessionTranscriptMessage,
+} from "../../session-transcript/markdown.js";
+import type {
+  PlatformInstallContext,
+  PlatformInstallResult,
+  PlatformInstaller,
+  WorkingMemoryUpdateInput,
+} from "./types.js";
+
+const sessionRefPrefix = "opencode-session:";
 
 export const opencodeInstaller: PlatformInstaller = {
   platform: "opencode",
-  install(_context: PlatformInstallContext): PlatformInstallResult {
+
+  install(context: PlatformInstallContext): PlatformInstallResult {
     const configHome = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+    const skills = copyBundledSkills(join(configHome, "opencode", "skills"));
+    if (!context.hooks) return { skills };
+
+    const hookConfigPath = join(configHome, "opencode", "hooks.json");
+    const command = hookCommand("opencode");
+    const hookConfig = mergeHookConfig(readJsonObject(hookConfigPath), "opencode", command);
+    writeJson(hookConfigPath, hookConfig);
+
     return {
-      skills: copyBundledSkills(join(configHome, "opencode", "skills")),
+      skills,
+      hooks: {
+        platform: "opencode",
+        configFiles: [hookConfigPath],
+        events: [...hookEvents],
+        command,
+      },
     };
   },
-  sessionSourceRef(_sessionId: string): string {
-    throw new Error("OpenCode session source refs are not supported yet.");
+
+  sessionSourceRef(sessionId: string): string {
+    return `${sessionRefPrefix}${sessionId}`;
   },
-  sessionIdFromSourceRef(_ref: string): string | undefined {
-    return undefined;
+
+  sessionIdFromSourceRef(ref: string): string | undefined {
+    return ref.startsWith(sessionRefPrefix) ? ref.slice(sessionRefPrefix.length) : undefined;
   },
-  transcriptToMarkdown(_transcript: string): string {
-    throw new Error("OpenCode transcript projection is not supported yet.");
+
+  transcriptPathFromHook(hook: HookInput): string | undefined {
+    const sessionId = hookSessionId(hook);
+    if (sessionId === undefined) return undefined;
+    return resolveOpenCodeSessionPath(sessionId);
   },
-  async runWorkingMemoryUpdate(_input: WorkingMemoryUpdateInput): Promise<void> {
-    throw new Error("OpenCode background working-memory updates are not supported yet.");
+
+  loadTranscript(transcriptPath: string): string {
+    return loadOpenCodeTranscript(transcriptPath);
+  },
+
+  transcriptToMarkdown(transcript: string): string {
+    return opencodeTranscriptToMarkdown(transcript);
+  },
+
+  async runWorkingMemoryUpdate(input: WorkingMemoryUpdateInput): Promise<void> {
+    await runOpenCodeAgent(input);
   },
 };
+
+function opencodeDataHome(): string {
+  const xdg = process.env.XDG_DATA_HOME;
+  const base = xdg ?? join(homedir(), ".local", "share");
+  return join(base, "opencode");
+}
+
+function resolveOpenCodeSessionPath(sessionId: string): string | undefined {
+  const fileLayout = join(opencodeDataHome(), "storage", "session", `${sessionId}.json`);
+  if (existsSync(fileLayout)) return fileLayout;
+
+  const dbPath = join(opencodeDataHome(), "opencode.db");
+  if (existsSync(dbPath)) return `sqlite:${dbPath}#${sessionId}`;
+
+  return undefined;
+}
+
+function loadOpenCodeTranscript(transcriptPath: string): string {
+  if (transcriptPath.startsWith("sqlite:")) {
+    return loadFromSqlite(transcriptPath);
+  }
+
+  try {
+    const raw = readFileSync(transcriptPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!isRecord(parsed)) return "";
+    return normalizeFileLayoutSession(parsed);
+  } catch {
+    return "";
+  }
+}
+
+function loadFromSqlite(pointer: string): string {
+  const [pathPart, sessionId] = pointer.slice("sqlite:".length).split("#");
+  if (!pathPart || !sessionId) return "";
+  if (!existsSync(pathPart)) return "";
+
+  const db = new Database(pathPart, { readonly: true, fileMustExist: true });
+  try {
+    const rows = db.prepare(
+      `SELECT session_id, role, content, created_at
+       FROM messages
+       WHERE session_id = ?
+       ORDER BY created_at ASC`,
+    ).all(sessionId) as Array<{
+      session_id: string;
+      role: string;
+      content: string;
+      created_at: string | number;
+    }>;
+
+    const lines = rows.map((row) =>
+      JSON.stringify({
+        session_id: row.session_id,
+        role: row.role,
+        content: row.content,
+        timestamp: typeof row.created_at === "number" ? new Date(row.created_at).toISOString() : row.created_at,
+      }),
+    );
+    return lines.join("\n");
+  } catch {
+    return "";
+  } finally {
+    db.close();
+  }
+}
+
+function normalizeFileLayoutSession(session: Record<string, unknown>): string {
+  const sessionId = typeof session.id === "string" ? session.id : undefined;
+  const directory = typeof session.directory === "string" ? session.directory : undefined;
+
+  const lines: string[] = [];
+  lines.push(JSON.stringify({
+    type: "session.header",
+    session_id: sessionId,
+    cwd: directory,
+  }));
+
+  for (const message of tryReadMessages(sessionId)) {
+    lines.push(JSON.stringify(message));
+  }
+
+  return lines.join("\n");
+}
+
+function tryReadMessages(sessionId: string | undefined): Array<{ role: string; content: string; timestamp?: string }> {
+  if (sessionId === undefined) return [];
+  const dir = join(opencodeDataHome(), "storage", "message", sessionId);
+  if (!existsSync(dir)) return [];
+
+  const files = readdirSync(dir).filter((name) => name.endsWith(".json")).sort();
+  const out: Array<{ role: string; content: string; timestamp?: string }> = [];
+  for (const name of files) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(dir, name), "utf8"));
+      if (!isRecord(parsed)) continue;
+      const role = typeof parsed.role === "string" ? parsed.role : undefined;
+      const content = extractMessageContent(parsed);
+      if (role && content) {
+        out.push({
+          role,
+          content,
+          timestamp: typeof parsed.time === "string" ? parsed.time : undefined,
+        });
+      }
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+function extractMessageContent(message: Record<string, unknown>): string {
+  if (typeof message.content === "string") return message.content;
+  if (Array.isArray(message.parts)) {
+    return message.parts
+      .filter(isRecord)
+      .map((part) => (typeof part.text === "string" ? part.text : ""))
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  return "";
+}
+
+function opencodeTranscriptToMarkdown(jsonl: string): string {
+  const metadata: Record<string, string> = {};
+  const messages: SessionTranscriptMessage[] = [];
+
+  for (const line of jsonl.split("\n")) {
+    const event = parseJsonLine(line);
+    if (!isRecord(event)) continue;
+
+    if (event.type === "session.header") {
+      if (typeof event.session_id === "string") metadata.session_id = event.session_id;
+      if (typeof event.cwd === "string") metadata.cwd = event.cwd;
+      continue;
+    }
+
+    const role = opencodeRole(event.role);
+    if (role === undefined) continue;
+
+    const content = typeof event.content === "string" ? event.content : "";
+    const sanitized = sanitizeTranscriptMessage(content);
+    if (sanitized.length === 0) continue;
+
+    messages.push({
+      timestamp: typeof event.timestamp === "string" ? event.timestamp : undefined,
+      role,
+      phase: undefined,
+      message: sanitized,
+    });
+  }
+
+  return renderSessionTranscriptMarkdown({ metadata, messages });
+}
+
+function opencodeRole(role: unknown): SessionTranscriptMessage["role"] | undefined {
+  if (role === "user" || role === "human") return "human";
+  if (role === "assistant" || role === "agent") return "agent";
+  return undefined;
+}

--- a/libs/session-transcript/bundle.ts
+++ b/libs/session-transcript/bundle.ts
@@ -47,7 +47,8 @@ export function buildTranscriptBundle(input: TranscriptBundleInput): TranscriptB
 
   input.files.forEach((file, index) => {
     if (!existsSync(file)) throw new Error(`Transcript file does not exist: ${file}`);
-    const filteredMarkdown = installer.transcriptToMarkdown(readFileSync(file, "utf8"));
+    const rawTranscript = installer.loadTranscript ? installer.loadTranscript(file) : readFileSync(file, "utf8");
+    const filteredMarkdown = installer.transcriptToMarkdown(rawTranscript);
     const metadata = parseFilteredTranscriptMetadata(filteredMarkdown);
     const sessionId = metadata.session_id;
     const sessionRef = sessionId === undefined ? undefined : installer.sessionSourceRef(sessionId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "greplica",
       "version": "0.1.12",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "better-sqlite3": "^12.11.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc --noEmit",
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
+    "smoke:opencode": "npm run build && node scripts/smoke-opencode-install.mjs",
     "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-proposal-validate.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",

--- a/scripts/check-install-options.js
+++ b/scripts/check-install-options.js
@@ -3,9 +3,10 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const root = new URL("..", import.meta.url);
-const cli = new URL("dist/apps/cli/main.js", root);
+const cliPath = fileURLToPath(new URL("dist/apps/cli/main.js", root));
 const { greplicaHookGuidance } = await import(new URL("dist/libs/hooks/guidance.js", root));
 const { shouldRunAutoMemoryUpdates } = await import(new URL("dist/libs/hooks/worker.js", root));
 
@@ -27,7 +28,7 @@ assert.equal(shouldRunAutoMemoryUpdates(readConfig(guidanceOnly.greplicaHome)), 
 
 const hookOutput = execFileSync(
   process.execPath,
-  [cli.pathname, "hook", "ingest", "--platform", "codex"],
+  [cliPath, "hook", "ingest", "--platform", "codex"],
   {
     cwd: guidanceOnly.repo,
     encoding: "utf8",
@@ -50,10 +51,12 @@ assert.ok(noHooks.output.includes(greplicaHookGuidance));
 assert.equal(existsSync(join(noHooks.codexHome, "hooks.json")), false);
 assert.equal(readConfig(noHooks.greplicaHome).session.autoMemoryUpdates, false);
 
-const unsupportedHooks = installInTempRepo("unsupported-hooks", ["--hooks", "enabled", "--auto-memory", "enabled"], "opencode");
-assert.match(unsupportedHooks.output, /Hooks: not installed for this platform\./);
-assert.match(unsupportedHooks.output, /Automatic memory updates: disabled\./);
-assert.equal(readConfig(unsupportedHooks.greplicaHome).session.autoMemoryUpdates, false);
+const opencodeHooks = installInTempRepo("opencode-hooks", ["--hooks", "enabled", "--auto-memory", "enabled"], "opencode");
+assert.match(opencodeHooks.output, /Installed Greplica for OpenCode\./);
+assert.match(opencodeHooks.output, /Hooks: installed for UserPromptSubmit, Stop\./);
+assert.match(opencodeHooks.output, /Automatic memory updates: enabled\./);
+assert.ok(existsSync(join(opencodeHooks.xdgConfigHome, "opencode", "hooks.json")));
+assert.equal(readConfig(opencodeHooks.greplicaHome).session.autoMemoryUpdates, true);
 
 const copilotHooks = installInTempRepo("copilot-hooks", ["--hooks", "enabled", "--auto-memory", "enabled"], "copilot");
 assert.match(copilotHooks.output, /Installed Greplica for GitHub Copilot CLI\./);
@@ -65,7 +68,7 @@ assert.equal(readConfig(copilotHooks.greplicaHome).session.autoMemoryUpdates, tr
 const invalid = spawnSync(
   process.execPath,
   [
-    cli.pathname,
+    cliPath,
     "install",
     "--platform",
     "codex",
@@ -87,7 +90,7 @@ assert.match(invalid.stderr, /--auto-memory enabled requires --hooks enabled/);
 
 const invalidValue = spawnSync(
   process.execPath,
-  [cli.pathname, "install", "--platform", "codex", "--embedding", "local", "--hooks", "sometimes"],
+  [cliPath, "install", "--platform", "codex", "--embedding", "local", "--hooks", "sometimes"],
   {
     cwd: noHooks.repo,
     encoding: "utf8",
@@ -104,6 +107,7 @@ function installInTempRepo(name, flags, platform = "codex") {
   const greplicaHome = join(tmp, name, "greplica-home");
   const codexHome = join(tmp, name, "codex-home");
   const copilotHome = join(tmp, name, "copilot-home");
+  const xdgConfigHome = join(tmp, name, "xdg-config-home");
   mkdirSync(repo, { recursive: true });
   execFileSync("git", ["init", "--quiet"], { cwd: repo, encoding: "utf8" });
 
@@ -112,24 +116,24 @@ function installInTempRepo(name, flags, platform = "codex") {
     GREPLICA_HOME: greplicaHome,
     CODEX_HOME: codexHome,
     COPILOT_HOME: copilotHome,
-    XDG_CONFIG_HOME: join(tmp, name, "xdg-config-home"),
+    XDG_CONFIG_HOME: xdgConfigHome,
     GREPLICA_INSTALL_SKIP_PREWARM: "1",
   };
   const output = execFileSync(
     process.execPath,
-    [cli.pathname, "install", "--platform", platform, "--embedding", "local", ...flags],
+    [cliPath, "install", "--platform", platform, "--embedding", "local", ...flags],
     {
       cwd: repo,
       encoding: "utf8",
       env,
     },
   );
-  execFileSync(process.execPath, [cli.pathname, "doctor"], {
+  execFileSync(process.execPath, [cliPath, "doctor"], {
     cwd: repo,
     encoding: "utf8",
     env,
   });
-  return { repo, greplicaHome, codexHome, copilotHome, output, env };
+  return { repo, greplicaHome, codexHome, copilotHome, xdgConfigHome, output, env };
 }
 
 function readConfig(greplicaHome) {

--- a/scripts/check-transcript-bundle.js
+++ b/scripts/check-transcript-bundle.js
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 
 const root = new URL("..", import.meta.url);
-const cli = new URL("dist/apps/cli/main.js", root);
+const cliPath = fileURLToPath(new URL("dist/apps/cli/main.js", root));
 const tmp = mkdtempSync(join(tmpdir(), "greplica-transcript-bundle-test-"));
 
 const codexOne = join(tmp, "codex-one.jsonl");
@@ -128,7 +129,7 @@ writeFileSync(
 const codexOutput = execFileSync(
   process.execPath,
   [
-    cli.pathname,
+    cliPath,
     "transcript",
     "bundle",
     "--platform",
@@ -157,7 +158,7 @@ assert.doesNotMatch(codexBundle, /drop this/);
 const claudeOutput = execFileSync(
   process.execPath,
   [
-    cli.pathname,
+    cliPath,
     "transcript",
     "bundle",
     "--platform",
@@ -177,7 +178,7 @@ assert.match(claudeBundle, /Remember this durable Claude insight/);
 const copilotOutput = execFileSync(
   process.execPath,
   [
-    cli.pathname,
+    cliPath,
     "transcript",
     "bundle",
     "--platform",
@@ -202,20 +203,70 @@ assert.throws(
   () =>
     execFileSync(
       process.execPath,
-      [cli.pathname, "transcript", "bundle", "--platform", "codex", "--file", join(tmp, "missing.jsonl"), "--out", join(tmp, "missing.md")],
+      [cliPath, "transcript", "bundle", "--platform", "codex", "--file", join(tmp, "missing.jsonl"), "--out", join(tmp, "missing.md")],
       { encoding: "utf8", stdio: "pipe" },
     ),
   /Transcript file does not exist/,
 );
 
-assert.throws(
-  () =>
-    execFileSync(
-      process.execPath,
-      [cli.pathname, "transcript", "bundle", "--platform", "opencode", "--file", codexOne, "--out", opencodeOut],
-      { encoding: "utf8", stdio: "pipe" },
-    ),
-  /OpenCode transcript projection is not supported yet/,
+const opencodeDataHome = join(tmp, "opencode-data");
+const opencodeSessionId = "opencode-session-one";
+const opencodeSessionFile = join(opencodeDataHome, "opencode", "storage", "session", `${opencodeSessionId}.json`);
+mkdirSync(dirname(opencodeSessionFile), { recursive: true });
+mkdirSync(join(opencodeDataHome, "opencode", "storage", "message", opencodeSessionId), { recursive: true });
+writeFileSync(
+  opencodeSessionFile,
+  JSON.stringify({
+    id: opencodeSessionId,
+    directory: "/repo/example",
+  }),
+  "utf8",
 );
+writeFileSync(
+  join(opencodeDataHome, "opencode", "storage", "message", opencodeSessionId, "msg-01.json"),
+  JSON.stringify({
+    role: "user",
+    content: "Remember this durable OpenCode insight. <system_instruction>remove this</system_instruction>",
+    time: "2026-06-25T00:06:00.000Z",
+  }),
+  "utf8",
+);
+writeFileSync(
+  join(opencodeDataHome, "opencode", "storage", "message", opencodeSessionId, "msg-02.json"),
+  JSON.stringify({
+    role: "assistant",
+    parts: [{ text: "An OpenCode assistant fact." }],
+    time: "2026-06-25T00:07:00.000Z",
+  }),
+  "utf8",
+);
+
+const opencodeOutput = execFileSync(
+  process.execPath,
+  [
+    cliPath,
+    "transcript",
+    "bundle",
+    "--platform",
+    "opencode",
+    "--file",
+    opencodeSessionFile,
+    "--out",
+    opencodeOut,
+  ],
+  {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      XDG_DATA_HOME: opencodeDataHome,
+    },
+  },
+);
+const opencodeBundle = readFileSync(opencodeOut, "utf8");
+assert.match(opencodeOutput, /opencode-session:opencode-session-one/);
+assert.match(opencodeBundle, /session_ref: opencode-session:opencode-session-one/);
+assert.match(opencodeBundle, /Remember this durable OpenCode insight/);
+assert.match(opencodeBundle, /An OpenCode assistant fact/);
+assert.doesNotMatch(opencodeBundle, /remove this/);
 
 console.log("Transcript bundle checks passed.");

--- a/scripts/smoke-opencode-install.mjs
+++ b/scripts/smoke-opencode-install.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// Focused smoke check for `greplica install --platform opencode`.
+//
+// Verifies user-level OpenCode skills + hooks under XDG config, guidance output
+// shape for UserPromptSubmit, non-destructive hook reinstall, Stop hook session
+// tracking, and transcript bundling from file-layout session storage.
+
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = findRepoRoot(scriptDir);
+const cli = resolve(repoRoot, "dist/apps/cli/main.js");
+const command = "greplica hook ingest --platform opencode";
+
+const tempDir = mkdtempSync(resolve(tmpdir(), "greplica-opencode-smoke-"));
+const workspace = resolve(tempDir, "repo");
+const greplicaHome = resolve(tempDir, "greplica-home");
+const xdgConfigHome = resolve(tempDir, "xdg-config");
+const xdgDataHome = resolve(tempDir, "xdg-data");
+const sessionId = "opencode-smoke-session";
+const bundleOut = resolve(tempDir, "opencode-bundle.md");
+
+const env = {
+  ...process.env,
+  XDG_CONFIG_HOME: xdgConfigHome,
+  XDG_DATA_HOME: xdgDataHome,
+  GREPLICA_HOME: greplicaHome,
+  GREPLICA_INSTALL_SKIP_PREWARM: "1",
+};
+delete env.GREPLICA_HOOK_DISABLE;
+
+try {
+  assert.ok(existsSync(cli), `Built CLI not found at ${cli}. Run "npm run build" first.`);
+  runOrThrow(["git", "init", "-q", workspace], repoRoot);
+
+  const installOutput = runOrThrow([
+    process.execPath,
+    cli,
+    "install",
+    "--platform",
+    "opencode",
+    "--embedding",
+    "local",
+  ], workspace);
+  assert.match(installOutput.stdout, /Installed Greplica for OpenCode\./);
+  assert.match(installOutput.stdout, /Hooks: installed for UserPromptSubmit, Stop\./);
+
+  checkSkills();
+  checkHooks();
+  checkGuidanceOutput();
+  checkStopSessionTracking();
+  checkTranscriptBundle();
+  checkNonDestructiveReinstall();
+
+  console.log(`OK: OpenCode skills + hooks installed under ${xdgConfigHome}/opencode`);
+} finally {
+  try {
+    rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  } catch {
+    // Best-effort cleanup; Windows may keep SQLite handles open briefly.
+  }
+}
+
+function checkSkills() {
+  for (const skill of ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"]) {
+    assert.ok(existsSync(resolve(xdgConfigHome, "opencode", "skills", skill, "SKILL.md")), `missing skill ${skill}`);
+  }
+}
+
+function checkHooks() {
+  const hooksPath = resolve(xdgConfigHome, "opencode", "hooks.json");
+  assert.ok(existsSync(hooksPath), "hooks.json was not created");
+  const hooks = JSON.parse(readFileSync(hooksPath, "utf8")).hooks ?? {};
+  for (const event of ["UserPromptSubmit", "Stop"]) {
+    assert.ok(commandPresent(hooks[event], command), `${event} hook missing command "${command}"`);
+  }
+}
+
+function checkGuidanceOutput() {
+  const hookInput = JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    session_id: sessionId,
+    cwd: workspace,
+  });
+  const result = run([process.execPath, cli, "hook", "ingest", "--platform", "opencode"], workspace, hookInput);
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout.trim());
+  const guidance = payload.additionalContext ?? payload.hookSpecificOutput?.additionalContext;
+  assert.equal(typeof guidance, "string");
+  assert.match(guidance, /Greplica hook guidance/);
+}
+
+function checkStopSessionTracking() {
+  seedOpenCodeSession();
+
+  const stopInput = JSON.stringify({
+    hook_event_name: "Stop",
+    session_id: sessionId,
+    cwd: workspace,
+  });
+  const stopResult = run([process.execPath, cli, "hook", "ingest", "--platform", "opencode"], workspace, stopInput);
+  assert.equal(stopResult.status, 0, stopResult.stderr);
+
+  const markResult = run([
+    process.execPath,
+    cli,
+    "session",
+    "mark-memory-current",
+    "--session-ref",
+    `opencode-session:${sessionId}`,
+  ], workspace);
+  assert.equal(markResult.status, 0, markResult.stderr);
+  assert.match(markResult.stdout, /Marked session memory current\./);
+}
+
+function checkTranscriptBundle() {
+  const sessionFile = resolve(xdgDataHome, "opencode", "storage", "session", `${sessionId}.json`);
+  const bundleResult = run([
+    process.execPath,
+    cli,
+    "transcript",
+    "bundle",
+    "--platform",
+    "opencode",
+    "--file",
+    sessionFile,
+    "--out",
+    bundleOut,
+  ], workspace);
+  assert.equal(bundleResult.status, 0, bundleResult.stderr);
+
+  const bundle = readFileSync(bundleOut, "utf8");
+  assert.match(bundle, /session_ref: opencode-session:opencode-smoke-session/);
+  assert.match(bundle, /Remember this OpenCode transcript fact/);
+  assert.match(bundle, /Stored OpenCode transcript context/);
+}
+
+function checkNonDestructiveReinstall() {
+  const hooksPath = resolve(xdgConfigHome, "opencode", "hooks.json");
+  const hooks = JSON.parse(readFileSync(hooksPath, "utf8"));
+  hooks.hooks.UserPromptSubmit.push({ matcher: "", hooks: [{ type: "command", command: "echo user-custom-hook", timeout: 3 }] });
+  hooks.hooks.PreToolUse = [{ matcher: "", hooks: [{ type: "command", command: "echo user-pretool", timeout: 3 }] }];
+  writeFileSync(hooksPath, `${JSON.stringify(hooks, null, 2)}\n`);
+
+  runOrThrow([
+    process.execPath,
+    cli,
+    "install",
+    "--platform",
+    "opencode",
+    "--embedding",
+    "local",
+  ], workspace);
+
+  const after = readFileSync(hooksPath, "utf8");
+  assert.match(after, /user-custom-hook/, "user's UserPromptSubmit hook was dropped on reinstall");
+  assert.match(after, /user-pretool/, "user's unrelated PreToolUse hook was dropped on reinstall");
+  const occurrences = after.split(command).length - 1;
+  assert.equal(occurrences, 2, `expected greplica command exactly twice after reinstall, found ${occurrences}`);
+}
+
+function seedOpenCodeSession() {
+  const messageDir = resolve(xdgDataHome, "opencode", "storage", "message", sessionId);
+  const sessionFile = resolve(xdgDataHome, "opencode", "storage", "session", `${sessionId}.json`);
+  mkdirSync(messageDir, { recursive: true });
+  mkdirSync(dirname(sessionFile), { recursive: true });
+  writeFileSync(
+    sessionFile,
+    JSON.stringify({ id: sessionId, directory: workspace }),
+    "utf8",
+  );
+  writeFileSync(
+    resolve(messageDir, "msg-01.json"),
+    JSON.stringify({
+      role: "user",
+      content: "Remember this OpenCode transcript fact.",
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    resolve(messageDir, "msg-02.json"),
+    JSON.stringify({
+      role: "assistant",
+      content: "Stored OpenCode transcript context.",
+    }),
+    "utf8",
+  );
+}
+
+function commandPresent(groups, value) {
+  if (!Array.isArray(groups)) return false;
+  return groups.some((group) => Array.isArray(group?.hooks) && group.hooks.some((handler) => handler?.command === value));
+}
+
+function run(commandArgs, cwd, input) {
+  return spawnSync(commandArgs[0], commandArgs.slice(1), { cwd, env, input, encoding: "utf8" });
+}
+
+function runOrThrow(commandArgs, cwd) {
+  const result = run(commandArgs, cwd);
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status}): ${commandArgs.join(" ")}\n${result.stderr ?? ""}`);
+  }
+  return result;
+}
+
+function findRepoRoot(startDir) {
+  let current = startDir;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (existsSync(resolve(current, "package.json")) && existsSync(resolve(current, "libs/install/platforms/opencode.ts"))) return current;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Could not find repo root from ${startDir}`);
+}


### PR DESCRIPTION
## Summary

This PR brings the OpenCode platform to feature parity with the other supported Greplica integrations by implementing the previously unsupported platform functionality.

It replaces the existing placeholder implementations with a complete platform integration, enabling transcript backfill, working-memory updates, and session tracking for OpenCode.

## What's Included

### Platform Support
- Implemented full `PlatformInstaller` support for OpenCode.
- Added session source reference generation and parsing.
- Added OpenCode hook installation and bundled skills.
- Enabled non-destructive hook configuration updates.

### Transcript Support
- Added transcript projection for OpenCode sessions.
- Supported both:
  - Current JSON-based session storage
  - Legacy SQLite session storage
- Reused the shared markdown renderer and transcript sanitization pipeline.

### Working Memory
- Added an OpenCode agent runner for background working-memory updates.
- Implemented non-interactive OpenCode execution for automated memory refreshes.

### Testing
- Added `smoke:opencode` installation smoke test.
- Replaced the previous "not supported" assertion with positive transcript bundle validation.
- Added regression coverage for transcript bundling and installation flow.

### Documentation
- Removed the "OpenCode transcript backfill is not supported" note from the installation guide.
- Updated documentation to reflect OpenCode as a fully supported platform.

## Why

OpenCode was listed as a supported `--platform` value, but `sessionSourceRef`, `transcriptToMarkdown`, and `runWorkingMemoryUpdate` all threw "not supported yet" — leaving OpenCode users locked out of transcript backfill and auto-save working memory. This PR closes those three gaps and aligns OpenCode with the other five installers.

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run smoke:opencode`
- [x] Existing smoke tests continue to pass

## Notes

The implementation prefers OpenCode's current file-based session layout and falls back to the legacy SQLite format when necessary, maintaining compatibility with existing installations while keeping the integration transparent to users.