### PR TITLE
feat(cline): implement Cline platform integration with installer and transcript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Current showcase rows:
 ## Commands
 
 ```bash
-greplica install --platform codex|claude|copilot|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica install --platform codex|claude|copilot|cline|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
 greplica config
 greplica doctor [--check-embeddings]
 greplica graph read
@@ -138,7 +138,7 @@ greplica proposal apply <proposal.json>
 - `greplica doctor` - verifies installation and diagnoses configuration failures. Not a required preflight before every command.
 - `greplica install` prepares repo state, local storage, and agent integration; normal repo commands require install first.
 
-For **OpenHands**, install is repo-local: skills are written to `.agents/skills/` and the `UserPromptSubmit`/`Stop` hooks to `.openhands/hooks.json` (Claude/Codex/Copilot install to the agent's home config instead). GitHub Copilot CLI installs personal skills under `~/.copilot/skills` (or `$COPILOT_HOME/skills`) and user hooks under `~/.copilot/hooks/greplica.json`. The hooks inject `graph context` guidance and trigger background working-memory updates; OpenHands must trust the repo hooks for the background save to run.
+For **OpenHands**, install is repo-local: skills are written to `.agents/skills/` and the `UserPromptSubmit`/`Stop` hooks to `.openhands/hooks.json` (Claude/Codex/Copilot install to the agent's home config instead). **Cline** is also repo-local: skills go to `.clinerules/greplica-skills/` and guidance is written to `.clinerules/greplica.md` as project rules (Cline has no hook events for Greplica to attach to). GitHub Copilot CLI installs personal skills under `~/.copilot/skills` (or `$COPILOT_HOME/skills`) and user hooks under `~/.copilot/hooks/greplica.json`. The hooks inject `graph context` guidance and trigger background working-memory updates; OpenHands must trust the repo hooks for the background save to run.
 
 ## License
 

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -57,7 +57,7 @@ const cliCommands = [
   {
     key: "install",
     path: ["install"],
-    usage: "install --platform codex|claude|copilot|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
+    usage: "install --platform codex|claude|copilot|cline|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
     handler: runInstallCommand,
     showInTopLevelHelp: true,
   },
@@ -766,7 +766,7 @@ function requireFlagValue(args: string[], index: number, flag: string, usageText
 }
 
 function parseInstallPlatform(value: string): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode" || value === "openhands" || value === "factory-droid") return value;
+  if (value === "codex" || value === "claude" || value === "copilot" || value === "cline" || value === "opencode" || value === "openhands" || value === "factory-droid") return value;
   throw new Error(`Invalid --platform ${value}.\n${usage("install")}`);
 }
 

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -38,7 +38,7 @@ Then run:
 
 ```bash
 npm install -g greplica
-greplica install --platform <codex|claude|copilot|opencode|openhands|factory-droid> --embedding local <mapped-hook-and-memory-flags>
+greplica install --platform <codex|claude|copilot|cline|opencode|openhands|factory-droid> --embedding local <mapped-hook-and-memory-flags>
 ```
 
 Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps.
@@ -54,6 +54,7 @@ If I chose "Yes, recent sessions", analyze prior sessions:
 - Candidate locations: Codex `~/.codex/sessions/**/*.jsonl`; Claude Code `~/.claude/projects/**/*.jsonl`; GitHub Copilot CLI paths from `Stop` hook `transcript_path` values or `$COPILOT_HOME/session-state`.
 - Do not require transcript metadata `cwd` to equal the current checkout path. Users may use worktrees, renamed folders, or multiple checkouts of the same repo.
 - Treat a transcript as same-repo when its metadata `cwd` is the current path, or when that `cwd` still exists and Git reports the same `remote.origin.url` or same normalized repo identity as the current repo. If the old path no longer exists, use transcript cwd text, repo name, branch, and recent session content as weaker matching evidence.
+- For Cline, transcript backfill is not supported; Greplica guidance is installed via `.clinerules/greplica.md` and skills under `.clinerules/greplica-skills/`. Skip transcript search for Cline.
 - For OpenCode, tell me transcript backfill is not supported yet and skip this step.
 - Select 1-3 transcripts. Use one if there is a large high-signal session, two by default when multiple sessions are useful, and three only when sessions are smaller or cover distinct work.
 - Show me the selected transcripts before bundling them: title if available, date/time, path, size/turn count if available, and why each matched this repo.

--- a/libs/install/install.ts
+++ b/libs/install/install.ts
@@ -70,6 +70,7 @@ export async function installGreplica(options: InstallOptions): Promise<InstallR
 
 export function platformDisplayName(platform: InstallPlatform): string {
   if (platform === "codex") return "Codex";
+  if (platform === "cline") return "Cline";
   if (platform === "copilot") return "GitHub Copilot CLI";
   if (platform === "opencode") return "OpenCode";
   if (platform === "openhands") return "OpenHands";

--- a/libs/install/paths.ts
+++ b/libs/install/paths.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid" | "copilot";
+export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid" | "copilot" | "cline";
 export type InstallEmbedding = "local" | "openai";
 
 export const skillNames = ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"] as const;

--- a/libs/install/platforms/cline.ts
+++ b/libs/install/platforms/cline.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { greplicaContextMarker, greplicaHookGuidance } from "../../hooks/guidance.js";
+import { copyBundledSkills } from "../skills.js";
+import type { PlatformInstallContext, PlatformInstallResult, PlatformInstaller, WorkingMemoryUpdateInput } from "./types.js";
+
+const guidanceFileName = "greplica.md";
+
+export const clineInstaller: PlatformInstaller = {
+  platform: "cline",
+  install(context: PlatformInstallContext): PlatformInstallResult {
+    // Cline loads project rules from .clinerules/ in the repo, not a user home dir.
+    const { repoRoot } = context;
+    const clinerulesDir = join(repoRoot, ".clinerules");
+    mkdirSync(clinerulesDir, { recursive: true });
+
+    const skills = copyBundledSkills(join(clinerulesDir, "greplica-skills"));
+    writeClineGuidance(join(clinerulesDir, guidanceFileName));
+
+    return { skills };
+  },
+  sessionSourceRef(_sessionId: string): string {
+    throw new Error(
+      "Cline is a VS Code extension without Greplica session source refs; sessions live in extension state, not exportable files.",
+    );
+  },
+  sessionIdFromSourceRef(_ref: string): string | undefined {
+    return undefined;
+  },
+  transcriptToMarkdown(_transcript: string): string {
+    throw new Error(
+      "Cline is a VS Code extension without JSONL session transcripts; use greplica graph context and the skills in .clinerules/greplica-skills/ instead.",
+    );
+  },
+  async runWorkingMemoryUpdate(_input: WorkingMemoryUpdateInput): Promise<void> {
+    throw new Error(
+      "Cline is a VS Code extension without Stop/UserPromptSubmit hooks; run greplica-update-working-memory manually near the end of useful sessions.",
+    );
+  },
+};
+
+function writeClineGuidance(path: string): void {
+  if (existsSync(path)) {
+    const existing = readFileSync(path, "utf8");
+    if (existing.includes(greplicaContextMarker)) return;
+    const separator = existing.endsWith("\n") ? "" : "\n";
+    writeFileSync(path, `${existing}${separator}\n${greplicaHookGuidance}\n`, "utf8");
+    return;
+  }
+  writeFileSync(path, `${greplicaHookGuidance}\n`, "utf8");
+}

--- a/libs/install/platforms/index.ts
+++ b/libs/install/platforms/index.ts
@@ -1,5 +1,6 @@
 import type { InstallPlatform } from "../paths.js";
 import { claudeInstaller } from "./claude.js";
+import { clineInstaller } from "./cline.js";
 import { copilotInstaller } from "./copilot.js";
 import { codexInstaller } from "./codex.js";
 import { droidInstaller } from "./droid.js";
@@ -9,6 +10,7 @@ import type { HookInstallResult, PlatformInstallContext, PlatformInstaller, Plat
 
 const platformInstallers: Partial<Record<InstallPlatform, PlatformInstaller>> = {
   claude: claudeInstaller,
+  cline: clineInstaller,
   codex: codexInstaller,
   copilot: copilotInstaller,
   opencode: opencodeInstaller,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
+    "smoke:cline": "npm run build && node scripts/smoke-cline-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
     "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-proposal-validate.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",

--- a/scripts/check-install-options.js
+++ b/scripts/check-install-options.js
@@ -3,9 +3,10 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const root = new URL("..", import.meta.url);
-const cli = new URL("dist/apps/cli/main.js", root);
+const cli = fileURLToPath(new URL("dist/apps/cli/main.js", root));
 const { greplicaHookGuidance } = await import(new URL("dist/libs/hooks/guidance.js", root));
 const { shouldRunAutoMemoryUpdates } = await import(new URL("dist/libs/hooks/worker.js", root));
 
@@ -27,7 +28,7 @@ assert.equal(shouldRunAutoMemoryUpdates(readConfig(guidanceOnly.greplicaHome)), 
 
 const hookOutput = execFileSync(
   process.execPath,
-  [cli.pathname, "hook", "ingest", "--platform", "codex"],
+  [cli, "hook", "ingest", "--platform", "codex"],
   {
     cwd: guidanceOnly.repo,
     encoding: "utf8",
@@ -62,10 +63,19 @@ assert.match(copilotHooks.output, /Automatic memory updates: enabled\./);
 assert.ok(existsSync(join(copilotHooks.copilotHome, "hooks", "greplica.json")));
 assert.equal(readConfig(copilotHooks.greplicaHome).session.autoMemoryUpdates, true);
 
+const clineInstall = installInTempRepo("cline", ["--hooks", "enabled", "--auto-memory", "enabled"], "cline");
+assert.match(clineInstall.output, /Installed Greplica for Cline\./);
+assert.match(clineInstall.output, /Hooks: not installed for this platform\./);
+assert.match(clineInstall.output, /Automatic memory updates: disabled\./);
+assert.ok(existsSync(join(clineInstall.repo, ".clinerules", "greplica.md")));
+assert.match(readFileSync(join(clineInstall.repo, ".clinerules", "greplica.md"), "utf8"), /Greplica hook guidance/);
+assert.ok(existsSync(join(clineInstall.repo, ".clinerules", "greplica-skills", "greplica-bootstrap", "SKILL.md")));
+assert.equal(readConfig(clineInstall.greplicaHome).session.autoMemoryUpdates, false);
+
 const invalid = spawnSync(
   process.execPath,
   [
-    cli.pathname,
+    cli,
     "install",
     "--platform",
     "codex",
@@ -87,7 +97,7 @@ assert.match(invalid.stderr, /--auto-memory enabled requires --hooks enabled/);
 
 const invalidValue = spawnSync(
   process.execPath,
-  [cli.pathname, "install", "--platform", "codex", "--embedding", "local", "--hooks", "sometimes"],
+  [cli, "install", "--platform", "codex", "--embedding", "local", "--hooks", "sometimes"],
   {
     cwd: noHooks.repo,
     encoding: "utf8",
@@ -117,14 +127,14 @@ function installInTempRepo(name, flags, platform = "codex") {
   };
   const output = execFileSync(
     process.execPath,
-    [cli.pathname, "install", "--platform", platform, "--embedding", "local", ...flags],
+    [cli, "install", "--platform", platform, "--embedding", "local", ...flags],
     {
       cwd: repo,
       encoding: "utf8",
       env,
     },
   );
-  execFileSync(process.execPath, [cli.pathname, "doctor"], {
+  execFileSync(process.execPath, [cli, "doctor"], {
     cwd: repo,
     encoding: "utf8",
     env,

--- a/scripts/smoke-cline-install.mjs
+++ b/scripts/smoke-cline-install.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Focused smoke check for `greplica install --platform cline`.
+// Verifies Cline-compatible guidance (skills + .clinerules/greplica.md) is
+// generated in the expected repo-local locations and that re-install is
+// non-destructive.
+//
+// Hermetic: GREPLICA_HOME points at a temp dir so it never touches ~/.greplica.
+// Usage: node scripts/smoke-cline-install.mjs [--keep-temp] [--result-json <path>]
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = findRepoRoot(scriptDir);
+const cli = resolve(repoRoot, "dist/apps/cli/main.js");
+const guidanceMarker = "Greplica hook guidance";
+
+const args = parseArgs(process.argv.slice(2));
+const ownsTempDir = args.keepTemp !== true;
+const tempDir = mkdtempSync(resolve(tmpdir(), "greplica-cline-smoke-"));
+const workspace = resolve(tempDir, "repo");
+const greplicaHome = resolve(tempDir, "home");
+
+const env = { ...process.env, GREPLICA_HOME: greplicaHome };
+delete env.GREPLICA_HOOK_DISABLE;
+
+let checks = [];
+try {
+  if (!existsSync(cli)) throw new Error(`Built CLI not found at ${cli}. Run "npm run build" first.`);
+
+  runOrThrow(["git", "init", "-q", workspace], repoRoot);
+  runOrThrow(["node", cli, "install", "--platform", "cline", "--embedding", "local"], workspace);
+
+  checks.push(checkSkills());
+  checks.push(checkGuidanceFile());
+  checks.push(checkNonDestructiveReinstall());
+} catch (error) {
+  checks = [{ id: "smoke_script", passed: false, details: [error instanceof Error ? error.stack ?? error.message : String(error)] }];
+} finally {
+  const passed = checks.filter((check) => check.passed).length;
+  const result = { success: passed === checks.length, passed_checks: passed, total_checks: checks.length, workspace, checks };
+  const serialized = `${JSON.stringify(result, null, 2)}\n`;
+  if (args.resultJson !== undefined) writeFileSync(args.resultJson, serialized);
+  process.stdout.write(serialized);
+  if (ownsTempDir) rmSync(tempDir, { recursive: true, force: true });
+  process.exitCode = result.success ? 0 : 1;
+}
+
+function checkSkills() {
+  const details = [];
+  for (const skill of ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"]) {
+    const skillPath = resolve(workspace, ".clinerules/greplica-skills", skill, "SKILL.md");
+    if (!existsSync(skillPath)) details.push(`missing skill ${skillPath}`);
+  }
+  return { id: "skills_installed", passed: details.length === 0, details };
+}
+
+function checkGuidanceFile() {
+  const details = [];
+  const guidancePath = resolve(workspace, ".clinerules/greplica.md");
+  if (!existsSync(guidancePath)) {
+    details.push(".clinerules/greplica.md was not created");
+    return { id: "guidance_file", passed: false, details };
+  }
+  const content = readFileSync(guidancePath, "utf8");
+  if (!content.includes(guidanceMarker)) details.push(`greplica.md missing "${guidanceMarker}"`);
+  if (!content.includes("greplica graph context")) details.push("greplica.md missing graph context guidance");
+  return { id: "guidance_file", passed: details.length === 0, details };
+}
+
+function checkNonDestructiveReinstall() {
+  const details = [];
+  const clinerulesDir = resolve(workspace, ".clinerules");
+  const guidancePath = resolve(clinerulesDir, "greplica.md");
+  const customRulePath = resolve(clinerulesDir, "custom-rule.md");
+
+  writeFileSync(customRulePath, "# User custom Cline rule\nKeep this file.\n");
+  const before = readFileSync(guidancePath, "utf8");
+  writeFileSync(guidancePath, `${before}\n# Extra user notes above guidance\n`);
+
+  runOrThrow(["node", cli, "install", "--platform", "cline", "--embedding", "local"], workspace);
+
+  if (!existsSync(customRulePath)) details.push("user's custom-rule.md was removed on re-install");
+  if (!readFileSync(customRulePath, "utf8").includes("Keep this file")) {
+    details.push("user's custom-rule.md content was changed on re-install");
+  }
+
+  const after = readFileSync(guidancePath, "utf8");
+  if (!after.includes("Extra user notes above guidance")) {
+    details.push("user content in greplica.md was clobbered on re-install");
+  }
+  const occurrences = after.split(guidanceMarker).length - 1;
+  if (occurrences !== 1) details.push(`expected guidance marker exactly once after re-install, found ${occurrences}`);
+
+  return { id: "non_destructive_reinstall", passed: details.length === 0, details };
+}
+
+function run(commandArgs, cwd, input) {
+  return spawnSync(commandArgs[0], commandArgs.slice(1), { cwd, env, input, encoding: "utf8" });
+}
+
+function runOrThrow(commandArgs, cwd) {
+  const result = run(commandArgs, cwd);
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status}): ${commandArgs.join(" ")}\n${result.stderr ?? ""}`);
+  }
+}
+
+function findRepoRoot(startDir) {
+  let current = startDir;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (existsSync(resolve(current, "package.json")) && existsSync(resolve(current, "libs/install/platforms/cline.ts"))) return current;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Could not find repo root from ${startDir}`);
+}
+
+function parseArgs(values) {
+  const parsed = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (value === "--result-json") parsed.resultJson = values[(index += 1)];
+    else if (value === "--keep-temp") parsed.keepTemp = true;
+    else throw new Error(`Unknown argument: ${value}`);
+  }
+  return parsed;
+}


### PR DESCRIPTION
## Summary

This PR adds first-class support for the Cline platform by implementing a dedicated platform installer and integrating it into Greplica's installation workflow.

The implementation follows the existing platform abstractions used for Claude Code, Codex, Copilot, OpenHands, Factory Droid, and OpenCode while respecting Cline's project-specific architecture.

## What's Included

### Platform Integration

- Added a new `PlatformInstaller` implementation for Cline.
- Registered Cline as a supported installation platform.
- Extended the CLI to recognize `--platform cline`.
- Installed Greplica skills and configuration into the appropriate Cline directories.

### Cline-Specific Behavior

Cline differs from other supported platforms because it does not provide JSONL session transcripts or `Stop`/`UserPromptSubmit` hook events. As a result:

- `sessionSourceRef` throws a descriptive error explaining that transcript-based workflows are unavailable.
- `transcriptToMarkdown` throws a descriptive error since Cline does not generate supported transcripts.
- `runWorkingMemoryUpdate` throws a clear error explaining that users should run `greplica-update-working-memory` manually near the end of useful sessions.
- Guidance is provided through `.clinerules/greplica.md`.

This mirrors how OpenHands scopes installation to the repository (`.agents/`) instead of a user home directory, following Cline's repository-local configuration model.

### Installation

- Added installer support for Cline configuration.
- Installed Greplica into `.clinerules/greplica-skills/`.
- Generated a `.clinerules/greplica.md` guidance file.
- Preserved existing `.clinerules` content during installation and reinstallation.
- Ensured installation behavior is consistent with other supported platforms.

### Testing

- Added a dedicated smoke test for Cline installation.
- Verified installer behavior.
- Confirmed no regressions across existing platform integrations.

## Why

Cline is a widely used coding agent, but Greplica previously did not provide native platform support.

This implementation follows Cline's project-rules convention by installing Greplica into `.clinerules/greplica-skills/` and generating a `.clinerules/greplica.md` guidance file. Because the installation is repository-local, teams can share their Greplica setup through version control just like any other `.clinerules/*.md` file, while preserving existing project configuration.

This PR enables users to install and use Greplica with Cline through the same installation workflow available for the other supported coding agents, while accommodating Cline's platform-specific capabilities and constraints.

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run smoke:cline`
- [x] Existing platform smoke tests continue to pass

## Notes

The implementation follows the existing installer architecture, minimizing platform-specific logic while reusing Greplica's shared installation infrastructure wherever possible. Cline-specific behavior is isolated to areas where the platform's capabilities differ, allowing the overall installation experience to remain consistent across supported coding agents.