### PR TITLE
feat: add Antigravity platform support (skills-only)

### DIFF
--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -57,7 +57,7 @@ const cliCommands = [
   {
     key: "install",
     path: ["install"],
-    usage: "install --platform codex|claude|copilot|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
+    usage: "install --platform codex|claude|copilot|opencode|openhands|factory-droid|antigravity --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
     handler: runInstallCommand,
     showInTopLevelHelp: true,
   },
@@ -766,7 +766,7 @@ function requireFlagValue(args: string[], index: number, flag: string, usageText
 }
 
 function parseInstallPlatform(value: string): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode" || value === "openhands" || value === "factory-droid") return value;
+  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode" || value === "openhands" || value === "factory-droid" || value === "antigravity") return value;
   throw new Error(`Invalid --platform ${value}.\n${usage("install")}`);
 }
 

--- a/libs/install/install.ts
+++ b/libs/install/install.ts
@@ -74,6 +74,7 @@ export function platformDisplayName(platform: InstallPlatform): string {
   if (platform === "opencode") return "OpenCode";
   if (platform === "openhands") return "OpenHands";
   if (platform === "factory-droid") return "Factory Droid";
+  if (platform === "antigravity") return "Antigravity";
   return "Claude Code";
 }
 

--- a/libs/install/paths.ts
+++ b/libs/install/paths.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid" | "copilot";
+export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid" | "copilot" | "antigravity";
 export type InstallEmbedding = "local" | "openai";
 
 export const skillNames = ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"] as const;

--- a/libs/install/platforms/antigravity.ts
+++ b/libs/install/platforms/antigravity.ts
@@ -1,0 +1,47 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { copyBundledSkills } from "../skills.js";
+import type { PlatformInstallContext, PlatformInstallResult, PlatformInstaller, WorkingMemoryUpdateInput } from "./types.js";
+
+// Antigravity CLI (the `agy` binary) reads global skills from
+// ~/.gemini/antigravity-cli/skills/ -- it shares the ~/.gemini namespace
+// with Gemini CLI, which it's built on top of. ANTIGRAVITY_HOME is not a
+// documented Antigravity setting; Greplica checks it purely so installs can
+// be redirected in tests, matching the override convention already used by
+// the other platform installers (FACTORY_HOME, COPILOT_HOME, etc).
+function antigravityHome(): string {
+  return process.env.ANTIGRAVITY_HOME ?? join(homedir(), ".gemini", "antigravity-cli");
+}
+
+export const antigravityInstaller: PlatformInstaller = {
+  platform: "antigravity",
+  // Antigravity CLI hooks are configured via a workspace-local
+  // .agents/hooks.json and, for tool-approval events like PreToolUse, drive
+  // decisions through a JSON stdin / JSON stdout allow-deny contract --
+  // materially different from the command + exit-code hooks.json shape the
+  // other installers share via mergeHookConfig(). Whether a plain
+  // fire-and-forget SessionStart/Stop hook (what Greplica actually needs)
+  // uses that same contract or something simpler isn't confirmed from
+  // documentation available at the time this was written. Rather than
+  // guess and risk writing a hooks.json that breaks a user's Antigravity
+  // setup, this installs skills only for now, the same approach already
+  // taken for OpenCode. Someone running Antigravity CLI day to day is best
+  // placed to confirm the real hook contract and extend this.
+  install(_context: PlatformInstallContext): PlatformInstallResult {
+    return {
+      skills: copyBundledSkills(join(antigravityHome(), "skills")),
+    };
+  },
+  sessionSourceRef(_sessionId: string): string {
+    throw new Error("Antigravity session source refs are not supported yet.");
+  },
+  sessionIdFromSourceRef(_ref: string): string | undefined {
+    return undefined;
+  },
+  transcriptToMarkdown(_transcript: string): string {
+    throw new Error("Antigravity transcript projection is not supported yet.");
+  },
+  async runWorkingMemoryUpdate(_input: WorkingMemoryUpdateInput): Promise<void> {
+    throw new Error("Antigravity background working-memory updates are not supported yet.");
+  },
+};

--- a/libs/install/platforms/index.ts
+++ b/libs/install/platforms/index.ts
@@ -1,4 +1,5 @@
 import type { InstallPlatform } from "../paths.js";
+import { antigravityInstaller } from "./antigravity.js";
 import { claudeInstaller } from "./claude.js";
 import { copilotInstaller } from "./copilot.js";
 import { codexInstaller } from "./codex.js";
@@ -14,6 +15,7 @@ const platformInstallers: Partial<Record<InstallPlatform, PlatformInstaller>> = 
   opencode: opencodeInstaller,
   openhands: openhandsInstaller,
   "factory-droid": droidInstaller,
+  antigravity: antigravityInstaller,
 };
 
 export type { HookInstallResult };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "greplica",
       "version": "0.1.12",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "better-sqlite3": "^12.11.1",

--- a/scripts/check-install-options.js
+++ b/scripts/check-install-options.js
@@ -3,9 +3,10 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const root = new URL("..", import.meta.url);
-const cli = new URL("dist/apps/cli/main.js", root);
+const cliPath = fileURLToPath(new URL("dist/apps/cli/main.js", root));
 const { greplicaHookGuidance } = await import(new URL("dist/libs/hooks/guidance.js", root));
 const { shouldRunAutoMemoryUpdates } = await import(new URL("dist/libs/hooks/worker.js", root));
 
@@ -27,7 +28,7 @@ assert.equal(shouldRunAutoMemoryUpdates(readConfig(guidanceOnly.greplicaHome)), 
 
 const hookOutput = execFileSync(
   process.execPath,
-  [cli.pathname, "hook", "ingest", "--platform", "codex"],
+  [cliPath, "hook", "ingest", "--platform", "codex"],
   {
     cwd: guidanceOnly.repo,
     encoding: "utf8",
@@ -65,7 +66,7 @@ assert.equal(readConfig(copilotHooks.greplicaHome).session.autoMemoryUpdates, tr
 const invalid = spawnSync(
   process.execPath,
   [
-    cli.pathname,
+    cliPath,
     "install",
     "--platform",
     "codex",
@@ -87,7 +88,7 @@ assert.match(invalid.stderr, /--auto-memory enabled requires --hooks enabled/);
 
 const invalidValue = spawnSync(
   process.execPath,
-  [cli.pathname, "install", "--platform", "codex", "--embedding", "local", "--hooks", "sometimes"],
+  [cliPath, "install", "--platform", "codex", "--embedding", "local", "--hooks", "sometimes"],
   {
     cwd: noHooks.repo,
     encoding: "utf8",
@@ -117,14 +118,14 @@ function installInTempRepo(name, flags, platform = "codex") {
   };
   const output = execFileSync(
     process.execPath,
-    [cli.pathname, "install", "--platform", platform, "--embedding", "local", ...flags],
+    [cliPath, "install", "--platform", platform, "--embedding", "local", ...flags],
     {
       cwd: repo,
       encoding: "utf8",
       env,
     },
   );
-  execFileSync(process.execPath, [cli.pathname, "doctor"], {
+  execFileSync(process.execPath, [cliPath, "doctor"], {
     cwd: repo,
     encoding: "utf8",
     env,

--- a/scripts/check-transcript-bundle.js
+++ b/scripts/check-transcript-bundle.js
@@ -3,9 +3,10 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 
 const root = new URL("..", import.meta.url);
-const cli = new URL("dist/apps/cli/main.js", root);
+const cliPath = fileURLToPath(new URL("dist/apps/cli/main.js", root));
 const tmp = mkdtempSync(join(tmpdir(), "greplica-transcript-bundle-test-"));
 
 const codexOne = join(tmp, "codex-one.jsonl");
@@ -128,7 +129,7 @@ writeFileSync(
 const codexOutput = execFileSync(
   process.execPath,
   [
-    cli.pathname,
+    cliPath,
     "transcript",
     "bundle",
     "--platform",
@@ -157,7 +158,7 @@ assert.doesNotMatch(codexBundle, /drop this/);
 const claudeOutput = execFileSync(
   process.execPath,
   [
-    cli.pathname,
+    cliPath,
     "transcript",
     "bundle",
     "--platform",
@@ -177,7 +178,7 @@ assert.match(claudeBundle, /Remember this durable Claude insight/);
 const copilotOutput = execFileSync(
   process.execPath,
   [
-    cli.pathname,
+    cliPath,
     "transcript",
     "bundle",
     "--platform",
@@ -202,7 +203,7 @@ assert.throws(
   () =>
     execFileSync(
       process.execPath,
-      [cli.pathname, "transcript", "bundle", "--platform", "codex", "--file", join(tmp, "missing.jsonl"), "--out", join(tmp, "missing.md")],
+      [cliPath, "transcript", "bundle", "--platform", "codex", "--file", join(tmp, "missing.jsonl"), "--out", join(tmp, "missing.md")],
       { encoding: "utf8", stdio: "pipe" },
     ),
   /Transcript file does not exist/,
@@ -212,7 +213,7 @@ assert.throws(
   () =>
     execFileSync(
       process.execPath,
-      [cli.pathname, "transcript", "bundle", "--platform", "opencode", "--file", codexOne, "--out", opencodeOut],
+      [cliPath, "transcript", "bundle", "--platform", "opencode", "--file", codexOne, "--out", opencodeOut],
       { encoding: "utf8", stdio: "pipe" },
     ),
   /OpenCode transcript projection is not supported yet/,


### PR DESCRIPTION
#104 
## Summary

Adds `--platform antigravity` to `greplica install`, following the roadmap note about missing Antigravity support.

## Scope: skills-only, deliberately

Antigravity turns out to be several products under one name (standalone app, IDE, CLI), each with a different config convention. The CLI's hook system (workspace-local `.agents/hooks.json`, JSON stdin / JSON stdout allow-deny decisions for tool-approval events like `PreToolUse`) is a materially different contract from the command + exit-code `hooks.json` shape every other installer shares via `mergeHookConfig()`. Whether a plain fire-and-forget `SessionStart`/`Stop` hook uses that same contract or something simpler isn't something I could confirm from documentation alone.

Rather than guess and risk writing a `hooks.json` that breaks someone's real Antigravity setup, this follows the exact precedent already in the codebase for OpenCode: skills install correctly, hooks/session-tracking explicitly throw "not supported yet." `--auto-memory` degrades gracefully to disabled automatically (existing behavior when `hooks` comes back `undefined`).

Someone running Antigravity CLI day to day is much better placed to confirm the real hook contract and extend this than I am guessing from docs.

## Changes

- `libs/install/platforms/antigravity.ts` (new) — installs the 3 bundled skills to `~/.gemini/antigravity-cli/skills/` (documented Antigravity CLI global skill scope). `ANTIGRAVITY_HOME` override added purely for testability, matching the existing `FACTORY_HOME`/`COPILOT_HOME` pattern.
- `paths.ts`, `platforms/index.ts`, `install.ts` — wired up like every other platform.
- `main.ts` — added to the install usage string and `parseInstallPlatform` only; deliberately left out of `parseHookPlatform`/`parseTranscriptBundlePlatform`, same scope as OpenCode.
- `README.md` — documented the skills-only scope and why.

## Also included: Windows path fix for two test scripts

`check-install-options.js` and `check-transcript-bundle.js` both built the CLI path via `new URL(...).pathname`. On Windows, `URL.pathname` for a file path returns `/C:/greplica/dist/apps/cli/main.js` (leading slash before the drive letter), which isn't a valid Windows filesystem path — passing it to `execFileSync` doubled the drive letter into `C:\C:\...` and crashed both scripts before they could run a single check. Fixed by using `fileURLToPath()` from `node:url` instead, which correctly resolves a file URL to a real OS path on any platform. Unrelated to Antigravity itself, but discovered while trying to actually run these tests on Windows to verify this PR, and blocks Windows contributors from running either script at all.

## Testing

- `npx tsc --noEmit` / `npm run build` — clean.
- `node scripts/check-install-options.js` and `node scripts/check-transcript-bundle.js` — both pass locally on Windows.
- Manually verified: `install --platform antigravity` prints "Installed Greplica for Antigravity.", correctly reports `Hooks: not installed for this platform.` and `Automatic memory updates: disabled.`, and writes all 3 skills (verified non-empty: 7KB/11KB/28KB `SKILL.md` files, correct folder names) to `$ANTIGRAVITY_HOME/skills/`.
- Verified `install --platform notarealplatform` still rejects invalid platforms with a clear error.