### PR TITLE
fix: scope graph objects by repo

### DIFF
--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -2,7 +2,7 @@ import { normalizeProposal } from "./proposal.js";
 import { validateProposal, type ProposalValidationResult } from "./validate-proposal.js";
 import type { Claim } from "./claim.js";
 import type { Edge } from "./edge.js";
-import type { Component, Flow, Source } from "./schema.js";
+import type { Component, Flow, GraphObjectType, Source } from "./schema.js";
 import { GraphContextBuilder } from "./graph-context/context-builder.js";
 import { graphContextConfig, type GraphContextConfig } from "./graph-context/config.js";
 import type { EmbeddingStatus, GraphContextResult } from "./graph-context/types.js";
@@ -126,9 +126,10 @@ export class KnowledgeGraphService {
   }
 
   async validateProposal(input: RepoRef, proposal: unknown): Promise<ProposalValidationResult> {
-    this.requireRepo(input);
-    const normalizedProposal = normalizeProposal(proposal, this.repository);
-    const validation = validateProposal(normalizedProposal, this.repository);
+    const initialized = this.requireRepo(input);
+    const subjectLookup = this.subjectLookup(initialized.repo_id);
+    const normalizedProposal = normalizeProposal(proposal, subjectLookup);
+    const validation = validateProposal(normalizedProposal, subjectLookup);
     if (!validation.valid) return validation;
 
     const anchorErrors = anchorAuditErrors(
@@ -143,13 +144,13 @@ export class KnowledgeGraphService {
   }
 
   async applyProposal(input: RepoRef, proposal: unknown): Promise<ApplyProposalResult> {
-    const normalizedProposal = normalizeProposal(proposal, this.repository);
+    const initialized = this.requireRepo(input);
+    const normalizedProposal = normalizeProposal(proposal, this.subjectLookup(initialized.repo_id));
     const validation = await this.validateProposal(input, normalizedProposal);
     if (!validation.valid) {
       throw new Error(`Proposal is invalid:\n${validation.errors.map((error) => `- ${error}`).join("\n")}`);
     }
 
-    const initialized = this.requireRepo(input);
     const working = this.repository.requireWorkingScope(initialized.repo_id);
     const memoryCommit = this.repository.createMemoryCommit({
       scope_id: working.id,
@@ -178,6 +179,15 @@ export class KnowledgeGraphService {
     };
   }
 
+  private subjectLookup(repoId: string): {
+    subjectExists: (type: GraphObjectType, id: string) => boolean;
+    subjectType: (id: string) => GraphObjectType | undefined;
+  } {
+    return {
+      subjectExists: (type, id) => this.repository.subjectExists(repoId, type, id),
+      subjectType: (id) => this.repository.subjectType(repoId, id),
+    };
+  }
 }
 
 function anchorAuditErrors(result: ClaimAnchorAuditResult): string[] {

--- a/libs/storage/sqlite/migrate.ts
+++ b/libs/storage/sqlite/migrate.ts
@@ -5,6 +5,7 @@ export function migrate(db: Database.Database): void {
   db.exec(schemaSql);
   migrateReposTable(db);
   migrateClaimsTable(db);
+  migrateGraphObjectTables(db);
 }
 
 function migrateReposTable(db: Database.Database): void {
@@ -67,5 +68,120 @@ function migrateClaimsTable(db: Database.Database): void {
   } catch (error: unknown) {
     if (error instanceof Error && /duplicate column name/i.test(error.message)) return;
     throw error;
+  }
+}
+
+function migrateGraphObjectTables(db: Database.Database): void {
+  const columns = db.prepare("PRAGMA table_info(components)").all() as Array<{ name: string }>;
+  if (columns.some((column) => column.name === "repo_id")) return;
+
+  const foreignKeys = db.pragma("foreign_keys", { simple: true }) as number;
+  const legacyAlterTable = db.pragma("legacy_alter_table", { simple: true }) as number;
+  db.pragma("foreign_keys = OFF");
+  db.pragma("legacy_alter_table = ON");
+  try {
+    db.exec(`
+      BEGIN;
+
+      ALTER TABLE components RENAME TO components_old;
+      ALTER TABLE flows RENAME TO flows_old;
+      ALTER TABLE claims RENAME TO claims_old;
+      ALTER TABLE sources RENAME TO sources_old;
+      ALTER TABLE edges RENAME TO edges_old;
+
+      CREATE TABLE components (
+        repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        code_anchor TEXT,
+        PRIMARY KEY(repo_id, id)
+      );
+
+      CREATE TABLE flows (
+        repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        PRIMARY KEY(repo_id, id)
+      );
+
+      CREATE TABLE claims (
+        repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        text TEXT NOT NULL,
+        truth TEXT NOT NULL,
+        intent TEXT NOT NULL,
+        code_anchors TEXT,
+        PRIMARY KEY(repo_id, id)
+      );
+
+      CREATE TABLE sources (
+        repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        ref TEXT NOT NULL,
+        title TEXT,
+        PRIMARY KEY(repo_id, id)
+      );
+
+      CREATE TABLE edges (
+        repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        id TEXT NOT NULL,
+        from_id TEXT NOT NULL,
+        from_type TEXT NOT NULL,
+        to_id TEXT NOT NULL,
+        to_type TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        metadata TEXT,
+        PRIMARY KEY(repo_id, id)
+      );
+
+      INSERT OR IGNORE INTO components (repo_id, id, name, code_anchor)
+      SELECT DISTINCT gs.repo_id, c.id, c.name, c.code_anchor
+      FROM components_old c
+      JOIN graph_memberships gm ON gm.subject_type = 'component' AND gm.subject_id = c.id
+      JOIN graph_scopes gs ON gs.id = gm.scope_id;
+
+      INSERT OR IGNORE INTO flows (repo_id, id, name)
+      SELECT DISTINCT gs.repo_id, f.id, f.name
+      FROM flows_old f
+      JOIN graph_memberships gm ON gm.subject_type = 'flow' AND gm.subject_id = f.id
+      JOIN graph_scopes gs ON gs.id = gm.scope_id;
+
+      INSERT OR IGNORE INTO claims (repo_id, id, kind, text, truth, intent, code_anchors)
+      SELECT DISTINCT gs.repo_id, c.id, c.kind, c.text, c.truth, c.intent, c.code_anchors
+      FROM claims_old c
+      JOIN graph_memberships gm ON gm.subject_type = 'claim' AND gm.subject_id = c.id
+      JOIN graph_scopes gs ON gs.id = gm.scope_id;
+
+      INSERT OR IGNORE INTO edges (repo_id, id, from_id, from_type, to_id, to_type, kind, metadata)
+      SELECT DISTINCT gs.repo_id, e.id, e.from_id, e.from_type, e.to_id, e.to_type, e.kind, e.metadata
+      FROM edges_old e
+      JOIN graph_memberships gm ON gm.subject_type = 'edge' AND gm.subject_id = e.id
+      JOIN graph_scopes gs ON gs.id = gm.scope_id;
+
+      INSERT OR IGNORE INTO sources (repo_id, id, kind, ref, title)
+      SELECT DISTINCT gs.repo_id, s.id, s.kind, s.ref, s.title
+      FROM sources_old s
+      JOIN edges_old e ON
+        (e.from_type = 'source' AND e.from_id = s.id) OR
+        (e.to_type = 'source' AND e.to_id = s.id)
+      JOIN graph_memberships gm ON gm.subject_type = 'edge' AND gm.subject_id = e.id
+      JOIN graph_scopes gs ON gs.id = gm.scope_id;
+
+      DROP TABLE components_old;
+      DROP TABLE flows_old;
+      DROP TABLE claims_old;
+      DROP TABLE sources_old;
+      DROP TABLE edges_old;
+
+      COMMIT;
+    `);
+  } catch (error) {
+    db.exec("ROLLBACK;");
+    throw error;
+  } finally {
+    db.pragma(`legacy_alter_table = ${legacyAlterTable ? "ON" : "OFF"}`);
+    db.pragma(`foreign_keys = ${foreignKeys ? "ON" : "OFF"}`);
   }
 }

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -44,7 +44,9 @@ type MembershipRow = {
 
 type ComponentRow = Omit<Component, "code_anchor"> & { code_anchor: string | null };
 type ClaimRow = Omit<Claim, "code_anchors"> & { code_anchors: string | null };
-type EdgeRow = Omit<Edge, "metadata"> & { metadata: string | null };
+type FlowRow = Flow & { repo_id: string };
+type SourceRow = Omit<Source, "title"> & { repo_id: string; title: string | null };
+type EdgeRow = Omit<Edge, "metadata"> & { repo_id: string; metadata: string | null };
 type RepoMatch = { repo: RepoRecord; matchedBy: "remote" | "root" };
 
 export type EmbeddingObjectType = "claim" | "component" | "flow";
@@ -205,14 +207,14 @@ export class SqliteRepository {
   readSupersededClaims(repoId: string): Claim[] {
     const scopeIds = this.currentScopeIds(repoId);
     const memberships = this.membershipsForScopes(scopeIds);
-    const rawEdges = this.loadEdges(selectIds(memberships, "edge"));
+    const rawEdges = this.loadEdges(repoId, selectIds(memberships, "edge"));
     const supersededIds = new Set(
       rawEdges
         .filter((edge) => edge.kind === "supersedes" && edge.to_type === "claim")
         .map((edge) => edge.to_id),
     );
     const claimIds = selectIds(memberships, "claim").filter((id) => supersededIds.has(id));
-    return this.loadClaims(claimIds);
+    return this.loadClaims(repoId, claimIds);
   }
 
   readClaimProvenance(repoId: string): ClaimProvenanceRecord[] {
@@ -238,7 +240,7 @@ export class SqliteRepository {
   } {
     const scopeIds = this.currentScopeIds(repoId);
     const memberships = this.membershipsForScopes(scopeIds);
-    const rawEdges = this.loadEdges(selectIds(memberships, "edge"));
+    const rawEdges = this.loadEdges(repoId, selectIds(memberships, "edge"));
     const active = activeSubjectKeys(memberships, rawEdges);
 
     const edges = rawEdges.filter(
@@ -249,10 +251,10 @@ export class SqliteRepository {
     );
 
     return {
-      components: this.loadComponents(selectActiveIds(memberships, active, "component")),
-      flows: this.loadFlows(selectActiveIds(memberships, active, "flow")),
-      claims: this.loadClaims(selectActiveIds(memberships, active, "claim")),
-      sources: this.loadSources([...new Set(edges.filter((edge) => edge.to_type === "source").map((edge) => edge.to_id))]),
+      components: this.loadComponents(repoId, selectActiveIds(memberships, active, "component")),
+      flows: this.loadFlows(repoId, selectActiveIds(memberships, active, "flow")),
+      claims: this.loadClaims(repoId, selectActiveIds(memberships, active, "claim")),
+      sources: this.loadSources(repoId, [...new Set(edges.filter((edge) => edge.to_type === "source").map((edge) => edge.to_id))]),
       edges,
     };
   }
@@ -286,25 +288,30 @@ export class SqliteRepository {
 
   createProposalRecords(scopeId: string, memoryCommitId: string, proposal: MemoryCommitProposal): void {
     const write = this.db.transaction(() => {
+      const repoId = this.repoIdForScope(scopeId);
+
       for (const component of proposal.creates.components ?? []) {
         this.db
-          .prepare("INSERT INTO components (id, name, code_anchor) VALUES (@id, @name, @code_anchor)")
-          .run({ ...component, code_anchor: component.code_anchor ?? null });
+          .prepare("INSERT INTO components (repo_id, id, name, code_anchor) VALUES (@repo_id, @id, @name, @code_anchor)")
+          .run({ repo_id: repoId, ...component, code_anchor: component.code_anchor ?? null });
         this.createMembership(scopeId, "component", component.id, memoryCommitId);
       }
 
       for (const flow of proposal.creates.flows ?? []) {
-        this.db.prepare("INSERT INTO flows (id, name) VALUES (@id, @name)").run(flow);
+        this.db
+          .prepare("INSERT INTO flows (repo_id, id, name) VALUES (@repo_id, @id, @name)")
+          .run({ repo_id: repoId, ...flow });
         this.createMembership(scopeId, "flow", flow.id, memoryCommitId);
       }
 
       for (const claim of proposal.creates.claims ?? []) {
         this.db
           .prepare(
-            `INSERT INTO claims (id, kind, text, truth, intent, code_anchors)
-             VALUES (@id, @kind, @text, @truth, @intent, @code_anchors)`,
+            `INSERT INTO claims (repo_id, id, kind, text, truth, intent, code_anchors)
+             VALUES (@repo_id, @id, @kind, @text, @truth, @intent, @code_anchors)`,
           )
           .run({
+            repo_id: repoId,
             ...claim,
             code_anchors: claim.code_anchors === undefined ? null : JSON.stringify(claim.code_anchors),
           });
@@ -313,17 +320,17 @@ export class SqliteRepository {
 
       for (const source of proposal.creates.sources ?? []) {
         this.db
-          .prepare("INSERT INTO sources (id, kind, ref, title) VALUES (@id, @kind, @ref, @title)")
-          .run({ ...source, title: source.title ?? null });
+          .prepare("INSERT INTO sources (repo_id, id, kind, ref, title) VALUES (@repo_id, @id, @kind, @ref, @title)")
+          .run({ repo_id: repoId, ...source, title: source.title ?? null });
       }
 
       for (const edge of proposal.creates.edges ?? []) {
         this.db
           .prepare(
-            `INSERT INTO edges (id, from_id, from_type, to_id, to_type, kind, metadata)
-             VALUES (@id, @from_id, @from_type, @to_id, @to_type, @kind, @metadata)`,
+            `INSERT INTO edges (repo_id, id, from_id, from_type, to_id, to_type, kind, metadata)
+             VALUES (@repo_id, @id, @from_id, @from_type, @to_id, @to_type, @kind, @metadata)`,
           )
-          .run({ ...edge, metadata: edge.metadata === undefined ? null : JSON.stringify(edge.metadata) });
+          .run({ repo_id: repoId, ...edge, metadata: edge.metadata === undefined ? null : JSON.stringify(edge.metadata) });
         this.createMembership(scopeId, "edge", edge.id, memoryCommitId);
       }
     });
@@ -331,15 +338,15 @@ export class SqliteRepository {
     write();
   }
 
-  subjectExists(type: GraphObjectType, id: string): boolean {
+  subjectExists(repoId: string, type: GraphObjectType, id: string): boolean {
     const table = tableForType(type);
-    const row = this.db.prepare(`SELECT id FROM ${table} WHERE id = ?`).get(id);
+    const row = this.db.prepare(`SELECT id FROM ${table} WHERE repo_id = ? AND id = ?`).get(repoId, id);
     return row !== undefined;
   }
 
-  subjectType(id: string): GraphObjectType | undefined {
+  subjectType(repoId: string, id: string): GraphObjectType | undefined {
     for (const type of ["component", "flow", "claim", "edge", "source"] as const) {
-      if (this.subjectExists(type, id)) return type;
+      if (this.subjectExists(repoId, type, id)) return type;
     }
     return undefined;
   }
@@ -390,6 +397,14 @@ export class SqliteRepository {
       .run(scopeId, subjectType, subjectId, memoryCommitId);
   }
 
+  private repoIdForScope(scopeId: string): string {
+    const row = this.db.prepare("SELECT repo_id FROM graph_scopes WHERE id = ?").get(scopeId) as
+      | { repo_id: string }
+      | undefined;
+    if (!row) throw new Error(`Graph scope ${scopeId} is missing.`);
+    return row.repo_id;
+  }
+
   private currentScopeIds(repoId: string): string[] {
     const rows = this.db
       .prepare("SELECT id FROM graph_scopes WHERE repo_id = ? AND kind IN ('main', 'working') ORDER BY kind")
@@ -404,20 +419,23 @@ export class SqliteRepository {
       .all(...scopeIds) as MembershipRow[];
   }
 
-  private loadComponents(ids: string[]): Component[] {
-    return this.loadByIds<ComponentRow>("components", ids).map((row) => ({
+  private loadComponents(repoId: string, ids: string[]): Component[] {
+    return this.loadByIds<ComponentRow>(repoId, "components", ids).map((row) => ({
       id: row.id,
       name: row.name,
       code_anchor: row.code_anchor ?? undefined,
     }));
   }
 
-  private loadFlows(ids: string[]): Flow[] {
-    return this.loadByIds<Flow>("flows", ids);
+  private loadFlows(repoId: string, ids: string[]): Flow[] {
+    return this.loadByIds<FlowRow>(repoId, "flows", ids).map((row) => ({
+      id: row.id,
+      name: row.name,
+    }));
   }
 
-  private loadClaims(ids: string[]): Claim[] {
-    return this.loadByIds<ClaimRow>("claims", ids).map((row) => ({
+  private loadClaims(repoId: string, ids: string[]): Claim[] {
+    return this.loadByIds<ClaimRow>(repoId, "claims", ids).map((row) => ({
       id: row.id,
       kind: row.kind,
       text: row.text,
@@ -427,24 +445,29 @@ export class SqliteRepository {
     }));
   }
 
-  private loadSources(ids: string[]): Source[] {
-    return this.loadByIds<Source>("sources", ids);
-  }
-
-  private loadEdges(ids: string[]): Edge[] {
-    if (ids.length === 0) return [];
-    const rows = this.db
-      .prepare(`SELECT * FROM edges WHERE id IN (${placeholders(ids)})`)
-      .all(...ids) as EdgeRow[];
-    return rows.map((row) => ({
-      ...row,
-      metadata: row.metadata === null ? undefined : (JSON.parse(row.metadata) as Record<string, unknown>),
+  private loadSources(repoId: string, ids: string[]): Source[] {
+    return this.loadByIds<SourceRow>(repoId, "sources", ids).map((row) => ({
+      id: row.id,
+      kind: row.kind,
+      ref: row.ref,
+      title: row.title ?? undefined,
     }));
   }
 
-  private loadByIds<T>(table: string, ids: string[]): T[] {
+  private loadEdges(repoId: string, ids: string[]): Edge[] {
     if (ids.length === 0) return [];
-    return this.db.prepare(`SELECT * FROM ${table} WHERE id IN (${placeholders(ids)})`).all(...ids) as T[];
+    const rows = this.db
+      .prepare(`SELECT * FROM edges WHERE repo_id = ? AND id IN (${placeholders(ids)})`)
+      .all(repoId, ...ids) as EdgeRow[];
+    return rows.map(({ repo_id: _repoId, metadata, ...row }) => ({
+      ...row,
+      metadata: metadata === null ? undefined : (JSON.parse(metadata) as Record<string, unknown>),
+    }));
+  }
+
+  private loadByIds<T>(repoId: string, table: string, ids: string[]): T[] {
+    if (ids.length === 0) return [];
+    return this.db.prepare(`SELECT * FROM ${table} WHERE repo_id = ? AND id IN (${placeholders(ids)})`).all(repoId, ...ids) as T[];
   }
 }
 

--- a/libs/storage/sqlite/schema.ts
+++ b/libs/storage/sqlite/schema.ts
@@ -29,40 +29,50 @@ CREATE TABLE IF NOT EXISTS memory_commits (
 );
 
 CREATE TABLE IF NOT EXISTS components (
-  id TEXT PRIMARY KEY,
+  repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
   name TEXT NOT NULL,
-  code_anchor TEXT
+  code_anchor TEXT,
+  PRIMARY KEY(repo_id, id)
 );
 
 CREATE TABLE IF NOT EXISTS flows (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL
+  repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  PRIMARY KEY(repo_id, id)
 );
 
 CREATE TABLE IF NOT EXISTS claims (
-  id TEXT PRIMARY KEY,
+  repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
   kind TEXT NOT NULL,
   text TEXT NOT NULL,
   truth TEXT NOT NULL,
   intent TEXT NOT NULL,
-  code_anchors TEXT
+  code_anchors TEXT,
+  PRIMARY KEY(repo_id, id)
 );
 
 CREATE TABLE IF NOT EXISTS sources (
-  id TEXT PRIMARY KEY,
+  repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
   kind TEXT NOT NULL,
   ref TEXT NOT NULL,
-  title TEXT
+  title TEXT,
+  PRIMARY KEY(repo_id, id)
 );
 
 CREATE TABLE IF NOT EXISTS edges (
-  id TEXT PRIMARY KEY,
+  repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
   from_id TEXT NOT NULL,
   from_type TEXT NOT NULL,
   to_id TEXT NOT NULL,
   to_type TEXT NOT NULL,
   kind TEXT NOT NULL,
-  metadata TEXT
+  metadata TEXT,
+  PRIMARY KEY(repo_id, id)
 );
 
 CREATE TABLE IF NOT EXISTS graph_memberships (

--- a/scripts/check-proposal-validate.js
+++ b/scripts/check-proposal-validate.js
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const root = new URL("..", import.meta.url);
 const { normalizeProposal } = await import(new URL("dist/libs/knowledge-graph/proposal.js", root));
 const { validateProposal } = await import(new URL("dist/libs/knowledge-graph/validate-proposal.js", root));
+const { KnowledgeGraphService } = await import(new URL("dist/libs/knowledge-graph/service.js", root));
+const { openDatabase } = await import(new URL("dist/libs/storage/sqlite/db.js", root));
+const { SqliteRepository } = await import(new URL("dist/libs/storage/sqlite/repository.js", root));
 
 const components = [
   { id: "component.a", name: "A" },
@@ -57,5 +63,98 @@ const compactEdge = {
 
 const compactResult = validateProposal(normalizeProposal(compactEdge));
 assert.equal(compactResult.valid, true, `compact edge must stay valid, got: ${JSON.stringify(compactResult.errors)}`);
+
+const tmp = mkdtempSync(join(tmpdir(), "greplica-proposal-validate-test-"));
+const db = openDatabase(join(tmp, "graph.db"));
+
+try {
+  const repository = new SqliteRepository(db);
+  const service = new KnowledgeGraphService(repository);
+  const repoA = {
+    repo_root: join(tmp, "repo-a"),
+    repo_name: "repo-a",
+    default_branch: "main",
+  };
+  const repoB = {
+    repo_root: join(tmp, "repo-b"),
+    repo_name: "repo-b",
+    default_branch: "main",
+  };
+  const repoC = {
+    repo_root: join(tmp, "repo-c"),
+    repo_name: "repo-c",
+    default_branch: "main",
+  };
+  const repoAProposal = {
+    title: "Seed CLI component",
+    creates: {
+      components: [{ id: "component.cli", name: "Repo A CLI" }],
+    },
+  };
+  const repoBProposal = {
+    title: "Seed CLI component",
+    creates: {
+      components: [{ id: "component.cli", name: "Repo B CLI" }],
+    },
+  };
+
+  const initializedA = service.initRepo(repoA);
+  const initializedB = service.initRepo(repoB);
+  service.initRepo(repoC);
+  const memoryCommit = repository.createMemoryCommit({
+    scope_id: initializedA.working_scope_id,
+    title: "Seed repo A",
+  });
+  repository.createProposalRecords(initializedA.working_scope_id, memoryCommit.id, normalizeProposal(repoAProposal));
+
+  const repoBResult = await service.validateProposal(repoB, repoBProposal);
+  assert.equal(
+    repoBResult.valid,
+    true,
+    `repo B must be able to create its own component.cli, got: ${JSON.stringify(repoBResult.errors)}`,
+  );
+
+  const repoCCrossReference = await service.validateProposal(repoC, {
+    title: "Repo C cross-repo compact reference",
+    creates: {
+      claims: [
+        {
+          id: "claim.about_cli",
+          kind: "fact",
+          text: "Repo C references a CLI component.",
+          truth: "unknown",
+          intent: "unknown",
+          about: "component.cli",
+        },
+      ],
+    },
+  });
+  assert.equal(repoCCrossReference.valid, false, "repo C must not resolve compact references through repo A");
+  assert.ok(
+    repoCCrossReference.errors.some((error) => error.includes("component:component.cli")),
+    `expected repo C to report missing component.cli, got: ${JSON.stringify(repoCCrossReference.errors)}`,
+  );
+
+  const repoBMemoryCommit = repository.createMemoryCommit({
+    scope_id: initializedB.working_scope_id,
+    title: "Seed repo B",
+  });
+  repository.createProposalRecords(initializedB.working_scope_id, repoBMemoryCommit.id, normalizeProposal(repoBProposal));
+
+  const repoBDuplicateResult = await service.validateProposal(repoB, repoBProposal);
+  assert.equal(repoBDuplicateResult.valid, false, "repo B must still reject duplicate IDs inside the same repo");
+  assert.ok(
+    repoBDuplicateResult.errors.includes("component:component.cli already exists."),
+    `expected repo B duplicate error, got: ${JSON.stringify(repoBDuplicateResult.errors)}`,
+  );
+
+  const repoAGraph = service.readGraph(repoA);
+  const repoBGraph = service.readGraph(repoB);
+  assert.deepEqual(repoAGraph.components.map((component) => component.name), ["Repo A CLI"]);
+  assert.deepEqual(repoBGraph.components.map((component) => component.name), ["Repo B CLI"]);
+  assert.equal(initializedB.repo_id === initializedA.repo_id, false, "test repos must be distinct");
+} finally {
+  db.close();
+}
 
 console.log("check-proposal-validate: ok");

--- a/scripts/memory-build/apply-proposals.ts
+++ b/scripts/memory-build/apply-proposals.ts
@@ -141,6 +141,10 @@ async function applyManifest(input: {
   skipped_reason?: string;
 }>> {
   const manifest = readJson<ProposalManifest>(join(input.taskDir, "proposals", "manifest.json"));
+  const initialized = input.service.requireRepo(input.repoRef);
+  const subjectLookup = {
+    subjectType: (id: string) => input.repository.subjectType(initialized.repo_id, id),
+  };
   const applied = [];
   for (const file of manifest.apply_order) {
     const proposalPath = join(input.taskDir, "proposals", file);
@@ -156,7 +160,7 @@ async function applyManifest(input: {
       });
       continue;
     }
-    const normalized = normalizeProposal(sanitized.proposal, input.repository);
+    const normalized = normalizeProposal(sanitized.proposal, subjectLookup);
     const result = await input.service.applyProposal(input.repoRef, normalized);
     applied.push({
       source: input.label,


### PR DESCRIPTION
## Problem

Graph object IDs are currently global across all repositories. Components, flows, claims, sources, and edges are keyed only by `id`, while repo membership is tracked separately through graph scopes. That means memory created for one repo can block another repo from creating the same logical object ID, and graph reads can accidentally load another repo's object row when memberships share an ID.

The issue is reproducible by creating `component.cli` in repo A and then validating the same normal proposal for repo B, which incorrectly reports `component:component.cli already exists.`

## Changes

- Scope graph object storage by repository with `(repo_id, id)` primary keys for components, flows, claims, sources, and edges.
- Add a migration for existing databases that preserves legacy object rows under the repos that actually reference them through graph memberships.
- Make proposal normalization and validation use repo-aware `subjectExists` and `subjectType` lookups.
- Write proposal objects with the owning repo ID and load graph objects using both repo ID and object ID.
- Update the memory-build proposal apply path so compact relationship normalization also resolves subjects inside the current repo only.
- Extend proposal validation checks to cover cross-repo ID reuse, graph read isolation, same-repo duplicate rejection, and compact reference isolation.

## Verification

```bash
npm run build
npm run typecheck
npm test
git diff --check
```

Additional local smoke coverage was run against temporary SQLite databases:

```text
fresh cross-repo matrix: ok
legacy cross-repo migration matrix: ok
```

The smoke matrix verified that:

- Repo B can validate and store the same component, flow, claim, source, and edge IDs after Repo A already stored them.
- Repo A and Repo B graph reads return only their own rows.
- Same-repo duplicates are still rejected.
- Compact references and explicit source edges do not resolve objects from another repo.
- Legacy global object rows migrate into repo-scoped rows based on graph memberships and referenced edges.

Resolves #103
