### PR TITLE
fix: import HookInput type from types.ts in opencode installer

### DIFF
--- a/libs/install/platforms/opencode.ts
+++ b/libs/install/platforms/opencode.ts
@@ -5,7 +5,8 @@ import Database from "better-sqlite3";
 import { hookCommand, hookEvents, mergeHookConfig, readJsonObject, writeJson } from "../hook-config.js";
 import { copyBundledSkills } from "../skills.js";
 import { runOpenCodeAgent } from "../../agent-runner/opencode.js";
-import { hookSessionId, type HookInput } from "../../hooks/hook-input.js";
+import { hookSessionId } from "../../hooks/hook-input.js";
+import type { HookInput } from "../../hooks/types.js";
 import {
   isRecord,
   parseJsonLine,


### PR DESCRIPTION
## Summary

Fixes a build break introduced by #95. `opencode.ts` imports `HookInput` as a type from `../../hooks/hook-input.js`, but #95 ("extract hook module interfaces into dedicated types.ts") moved that interface out of `hook-input.ts` into `types.ts`. `hook-input.ts` imports `HookInput` for its own use but does not re-export it, so the type is no longer available from that module.

As a result, `npm run build` (and `npm install`, which runs `build` via the `prepare` script) fail on a clean checkout:

`libs/install/platforms/opencode.ts:8:30` - error `TS2459: Module '"../../hooks/hook-input.js"'` declares `HookInput` locally, but it is not exported.

## Fix

Import the value (`hookSessionId`) from `hook-input.js` and the type (`HookInput`) from its actual source, `hooks/types.js`:

```ts
import { hookSessionId } from "../../hooks/hook-input.js";
import type { HookInput } from "../../hooks/types.js";
```

## Testing

- npm run build - passes
- npm run typecheck - passes
- npm test - passes
- node dist/apps/cli/main.js --help - runs