### PR TITLE
Mark drifted claims in the anchor audit

### DIFF
--- a/libs/install/platforms/opencode.ts
+++ b/libs/install/platforms/opencode.ts
@@ -5,7 +5,8 @@ import Database from "better-sqlite3";
 import { hookCommand, hookEvents, mergeHookConfig, readJsonObject, writeJson } from "../hook-config.js";
 import { copyBundledSkills } from "../skills.js";
 import { runOpenCodeAgent } from "../../agent-runner/opencode.js";
-import { hookSessionId, type HookInput } from "../../hooks/hook-input.js";
+import { hookSessionId } from "../../hooks/hook-input.js";
+import type { HookInput } from "../../hooks/types.js";
 import {
   isRecord,
   parseJsonLine,

--- a/libs/knowledge-graph/code-anchors/audit.ts
+++ b/libs/knowledge-graph/code-anchors/audit.ts
@@ -1,11 +1,20 @@
-import type { Claim } from "../claim.js";
+import type { Claim, ClaimCodeAnchor } from "../claim.js";
+import { anchorFingerprintKey, fingerprintAnchor } from "./fingerprint.js";
 import { CodeAnchorResolver } from "./resolver.js";
-import type { ClaimAnchorAuditIssue, ClaimAnchorAuditResult } from "./types.js";
+import type { ClaimAnchorAuditResult } from "./types.js";
 
+/**
+ * Audit each claim's code anchors against the repo. Reports broken anchors
+ * (missing file/symbol, etc.) and, when `baselineFingerprints` are supplied,
+ * anchors that still resolve but whose code has drifted from the fingerprint
+ * stored when the claim was written. Claims with no stored baseline are left
+ * unreported rather than assumed drifted.
+ */
 export async function auditClaimCodeAnchors(
   repoRoot: string | undefined,
   claims: Claim[],
   resolver = new CodeAnchorResolver(),
+  baselineFingerprints?: Map<string, Record<string, string>>,
 ): Promise<ClaimAnchorAuditResult> {
   const result: ClaimAnchorAuditResult = {
     missing_anchors: [],
@@ -13,6 +22,7 @@ export async function auditClaimCodeAnchors(
     missing_symbols: [],
     ambiguous_symbols: [],
     unsupported_languages: [],
+    drifted: [],
   };
 
   for (const claim of claims) {
@@ -22,6 +32,7 @@ export async function auditClaimCodeAnchors(
       continue;
     }
 
+    const baseline = baselineFingerprints?.get(claim.id);
     const resolvedAnchors = await resolver.resolveMany(repoRoot, claim.code_anchors);
     for (const anchor of resolvedAnchors) {
       switch (anchor.status) {
@@ -39,10 +50,28 @@ export async function auditClaimCodeAnchors(
           break;
         case "resolved":
         case "file_only":
+          if (await hasDrifted(repoRoot, anchor, resolver, baseline)) {
+            result.drifted.push({ claim_id: claim.id, anchor, status: "drifted" });
+          }
           break;
       }
     }
   }
 
   return result;
+}
+
+// An anchor has drifted when it has a stored baseline fingerprint and the code
+// it currently points to no longer hashes to that baseline.
+async function hasDrifted(
+  repoRoot: string | undefined,
+  anchor: ClaimCodeAnchor,
+  resolver: CodeAnchorResolver,
+  baseline: Record<string, string> | undefined,
+): Promise<boolean> {
+  if (baseline === undefined) return false;
+  const stored = baseline[anchorFingerprintKey(anchor)];
+  if (stored === undefined) return false;
+  const current = await fingerprintAnchor(repoRoot, anchor, resolver);
+  return current !== undefined && current !== stored;
 }

--- a/libs/knowledge-graph/code-anchors/fingerprint.ts
+++ b/libs/knowledge-graph/code-anchors/fingerprint.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+import type { ClaimCodeAnchor } from "../claim.js";
+import { CodeAnchorResolver } from "./resolver.js";
+
+/**
+ * Fingerprints the code a claim anchor points to, so a stored fact can later be
+ * compared against the current code to detect drift. The comment-free signature
+ * of the anchored span is produced by the tree-sitter resolver, so reformatting
+ * and comment edits do not change the fingerprint while real changes (including
+ * a literal value such as a threshold going 3 -> 8) do.
+ */
+
+/** Stable identifier for an anchor, used as the key when storing fingerprints. */
+export function anchorFingerprintKey(anchor: ClaimCodeAnchor): string {
+  return anchor.symbol === undefined ? anchor.file : `${anchor.file}#${anchor.symbol}`;
+}
+
+/**
+ * Return the fingerprint of a single anchor, or `undefined` when the anchor
+ * cannot be resolved to stable content (missing file, missing/ambiguous symbol,
+ * or an unsupported language). Callers treat `undefined` as "not comparable"
+ * rather than as drift.
+ */
+export async function fingerprintAnchor(
+  repoRoot: string | undefined,
+  anchor: ClaimCodeAnchor,
+  resolver: CodeAnchorResolver,
+): Promise<string | undefined> {
+  const signature = await resolver.codeSignatureForAnchor(repoRoot, anchor);
+  return signature === undefined ? undefined : hashText(signature);
+}
+
+/**
+ * Fingerprint every anchor of a claim, keyed by {@link anchorFingerprintKey}.
+ * Anchors that cannot be resolved are omitted so they are never mistaken for
+ * drift; broken anchors are surfaced separately by the anchor audit.
+ */
+export async function fingerprintClaimAnchors(
+  repoRoot: string | undefined,
+  anchors: ClaimCodeAnchor[] | undefined,
+  resolver: CodeAnchorResolver = new CodeAnchorResolver(),
+): Promise<Record<string, string>> {
+  const fingerprints: Record<string, string> = {};
+  for (const anchor of anchors ?? []) {
+    const hash = await fingerprintAnchor(repoRoot, anchor, resolver);
+    if (hash !== undefined) fingerprints[anchorFingerprintKey(anchor)] = hash;
+  }
+  return fingerprints;
+}
+
+function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}

--- a/libs/knowledge-graph/code-anchors/resolver.ts
+++ b/libs/knowledge-graph/code-anchors/resolver.ts
@@ -162,6 +162,62 @@ export class CodeAnchorResolver {
     return resolved;
   }
 
+  /**
+   * Build a normalization-stable signature of the code an anchor points to,
+   * used for drift detection. Comments are excluded via the parse tree rather
+   * than by text heuristics: the signature is the ordered text of the anchored
+   * span's non-comment tokens (the whole file for a file-only anchor). Returns
+   * undefined when the anchor does not resolve to stable content.
+   */
+  async codeSignatureForAnchor(repoRoot: string | undefined, anchor: ClaimCodeAnchor): Promise<string | undefined> {
+    if (repoRoot === undefined) return undefined;
+    const filePath = join(repoRoot, anchor.file);
+    if (!isRepoRelative(repoRoot, filePath) || !existsSync(filePath)) return undefined;
+
+    const resolved = await this.resolve(repoRoot, anchor);
+    let startLine: number;
+    let endLine: number;
+    if (resolved.status === "file_only") {
+      startLine = 1;
+      endLine = Number.MAX_SAFE_INTEGER;
+    } else if (resolved.status === "resolved" && resolved.start_line !== undefined) {
+      startLine = resolved.start_line;
+      endLine = resolved.end_line ?? resolved.start_line;
+    } else {
+      return undefined;
+    }
+
+    const source = readFileSync(filePath, "utf8");
+    const wasmFile = wasmByExtension.get(extname(filePath).toLowerCase());
+    if (wasmFile === undefined) {
+      // No grammar available (e.g. Markdown, SQL): fall back to the span text
+      // with only whitespace normalized.
+      return normalizeLines(sliceLines(source, startLine, endLine));
+    }
+
+    // Any parse failure degrades to "not comparable" (undefined) rather than
+    // aborting the whole apply/audit run, mirroring symbolsForFile. The parser
+    // is always freed.
+    let parser: Parser | undefined;
+    try {
+      const language = await this.loadLanguage(wasmFile);
+      parser = new Parser();
+      parser.setLanguage(language);
+      const tree = parser.parse(source);
+      try {
+        const tokens: string[] = [];
+        collectCodeTokens(tree.rootNode, startLine, endLine, tokens);
+        return tokens.join("\n");
+      } finally {
+        tree.delete();
+      }
+    } catch {
+      return undefined;
+    } finally {
+      parser?.delete();
+    }
+  }
+
   private async symbolsForFile(filePath: string): Promise<SymbolCandidate[] | undefined> {
     const cached = this.fileSymbolCache.get(filePath);
     if (cached !== undefined || this.fileSymbolCache.has(filePath)) return cached;
@@ -325,6 +381,35 @@ function normalizeWhitespace(value: string): string {
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Walk the tree and collect the text of leaf tokens within [startLine, endLine],
+// skipping comment nodes entirely. Whitespace never appears (tokens carry none),
+// so formatting and comment edits do not change the result, while identifiers
+// and literal values still do.
+function collectCodeTokens(node: Parser.SyntaxNode, startLine: number, endLine: number, out: string[]): void {
+  if (isCommentNode(node)) return;
+  if (node.childCount === 0) {
+    const line = node.startPosition.row + 1;
+    const text = node.text.trim();
+    if (text.length > 0 && line >= startLine && line <= endLine) out.push(text);
+    return;
+  }
+  for (const child of node.children) collectCodeTokens(child, startLine, endLine, out);
+}
+
+function isCommentNode(node: Parser.SyntaxNode): boolean {
+  return node.type === "comment" || node.type.includes("comment");
+}
+
+function sliceLines(source: string, startLine: number, endLine: number): string[] {
+  const lines = source.split(/\r?\n/);
+  const end = endLine === Number.MAX_SAFE_INTEGER ? lines.length : endLine;
+  return lines.slice(startLine - 1, end);
+}
+
+function normalizeLines(lines: string[]): string {
+  return lines.map((line) => line.trim()).filter((line) => line.length > 0).join("\n");
 }
 
 function collectSymbols(root: Parser.SyntaxNode): SymbolCandidate[] {

--- a/libs/knowledge-graph/code-anchors/types.ts
+++ b/libs/knowledge-graph/code-anchors/types.ts
@@ -18,7 +18,7 @@ export interface ResolvedCodeAnchor extends ClaimCodeAnchor {
 export interface ClaimAnchorAuditIssue {
   claim_id: ClaimId;
   anchor?: ClaimCodeAnchor;
-  status: "missing_anchors" | "missing_file" | "missing_symbol" | "ambiguous_symbol" | "unsupported_language";
+  status: "missing_anchors" | "missing_file" | "missing_symbol" | "ambiguous_symbol" | "unsupported_language" | "drifted";
 }
 
 export interface ClaimAnchorAuditResult {
@@ -27,4 +27,7 @@ export interface ClaimAnchorAuditResult {
   missing_symbols: ClaimAnchorAuditIssue[];
   ambiguous_symbols: ClaimAnchorAuditIssue[];
   unsupported_languages: ClaimAnchorAuditIssue[];
+  // Anchors that still resolve but whose code changed since the fact was
+  // written (its fingerprint no longer matches the stored baseline).
+  drifted: ClaimAnchorAuditIssue[];
 }

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -8,6 +8,8 @@ import { graphContextConfig, type GraphContextConfig } from "./graph-context/con
 import type { EmbeddingStatus, GraphContextResult } from "./graph-context/types.js";
 import { buildGraphViewHtml } from "./graph-view/build-graph-view.js";
 import { auditClaimCodeAnchors } from "./code-anchors/audit.js";
+import { CodeAnchorResolver } from "./code-anchors/resolver.js";
+import { fingerprintClaimAnchors } from "./code-anchors/fingerprint.js";
 import type { ClaimAnchorAuditResult } from "./code-anchors/types.js";
 import { defaultDatabasePath, openDatabase } from "../storage/sqlite/db.js";
 import type { SqliteRepository } from "../storage/sqlite/repository.js";
@@ -122,7 +124,12 @@ export class KnowledgeGraphService {
 
   async auditCodeAnchors(input: RepoRef): Promise<ClaimAnchorAuditResult> {
     const initialized = this.requireRepo(input);
-    return auditClaimCodeAnchors(input.repo_root, this.repository.readGraphView(initialized.repo_id).claims);
+    const claims = this.repository.readGraphView(initialized.repo_id).claims;
+    const baselineFingerprints = this.repository.readClaimAnchorFingerprints(
+      initialized.repo_id,
+      claims.map((claim) => claim.id),
+    );
+    return auditClaimCodeAnchors(input.repo_root, claims, new CodeAnchorResolver(), baselineFingerprints);
   }
 
   async validateProposal(input: RepoRef, proposal: unknown): Promise<ProposalValidationResult> {
@@ -158,7 +165,8 @@ export class KnowledgeGraphService {
       summary: normalizedProposal.summary,
     });
 
-    this.repository.createProposalRecords(working.id, memoryCommit.id, normalizedProposal);
+    const anchorFingerprints = await computeAnchorFingerprints(input.repo_root, normalizedProposal.creates.claims ?? []);
+    this.repository.createProposalRecords(working.id, memoryCommit.id, normalizedProposal, anchorFingerprints);
     const embeddingStatus = await this.contextBuilder.ensureForGraph(
       initialized.repo_id,
       this.repository.readGraphView(initialized.repo_id),
@@ -203,6 +211,23 @@ function anchorAuditErrors(result: ClaimAnchorAuditResult): string[] {
 function formatAnchor(anchor: { file: string; symbol?: string } | undefined): string {
   if (anchor === undefined) return "<missing>";
   return anchor.symbol === undefined ? anchor.file : `${anchor.file}#${anchor.symbol}`;
+}
+
+// Fingerprint each claim's code anchors against the repo as it is now, so the
+// stored baseline reflects the code the fact was written against. A single
+// resolver is shared so per-file parses are cached across claims.
+async function computeAnchorFingerprints(
+  repoRoot: string | undefined,
+  claims: Claim[],
+): Promise<Map<string, Record<string, string>>> {
+  const resolver = new CodeAnchorResolver();
+  const byClaim = new Map<string, Record<string, string>>();
+  for (const claim of claims) {
+    if (claim.code_anchors === undefined || claim.code_anchors.length === 0) continue;
+    const fingerprints = await fingerprintClaimAnchors(repoRoot, claim.code_anchors, resolver);
+    if (Object.keys(fingerprints).length > 0) byClaim.set(claim.id, fingerprints);
+  }
+  return byClaim;
 }
 
 export function createLocalKnowledgeGraphService(

--- a/libs/storage/sqlite/migrate.ts
+++ b/libs/storage/sqlite/migrate.ts
@@ -6,6 +6,7 @@ export function migrate(db: Database.Database): void {
   migrateReposTable(db);
   migrateClaimsTable(db);
   migrateGraphObjectTables(db);
+  migrateClaimAnchorFingerprints(db);
 }
 
 function migrateReposTable(db: Database.Database): void {
@@ -183,5 +184,19 @@ function migrateGraphObjectTables(db: Database.Database): void {
   } finally {
     db.pragma(`legacy_alter_table = ${legacyAlterTable ? "ON" : "OFF"}`);
     db.pragma(`foreign_keys = ${foreignKeys ? "ON" : "OFF"}`);
+  }
+}
+
+// Stores, per claim, the baseline fingerprint of each code anchor so drift can
+// be detected later. Nullable: claims written before this column exist keep a
+// null baseline and are reported as "unknown" rather than drifted.
+function migrateClaimAnchorFingerprints(db: Database.Database): void {
+  const columns = db.prepare("PRAGMA table_info(claims)").all() as Array<{ name: string }>;
+  if (columns.some((column) => column.name === "anchor_fingerprints")) return;
+  try {
+    db.exec("ALTER TABLE claims ADD COLUMN anchor_fingerprints TEXT");
+  } catch (error: unknown) {
+    if (error instanceof Error && /duplicate column name/i.test(error.message)) return;
+    throw error;
   }
 }

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -231,6 +231,21 @@ export class SqliteRepository {
       .all(repoId) as ClaimProvenanceRecord[];
   }
 
+  // Baseline anchor fingerprints stored when each claim was written, keyed by
+  // claim id then by anchor key. Used by the anchor audit to detect drift.
+  readClaimAnchorFingerprints(repoId: string, ids: string[]): Map<string, Record<string, string>> {
+    const fingerprints = new Map<string, Record<string, string>>();
+    if (ids.length === 0) return fingerprints;
+    const rows = this.db
+      .prepare(`SELECT id, anchor_fingerprints FROM claims WHERE repo_id = ? AND id IN (${placeholders(ids)})`)
+      .all(repoId, ...ids) as Array<{ id: string; anchor_fingerprints: string | null }>;
+    for (const row of rows) {
+      if (row.anchor_fingerprints === null) continue;
+      fingerprints.set(row.id, JSON.parse(row.anchor_fingerprints) as Record<string, string>);
+    }
+    return fingerprints;
+  }
+
   readGraphView(repoId: string): {
     components: Component[];
     flows: Flow[];
@@ -286,7 +301,12 @@ export class SqliteRepository {
     return memoryCommit;
   }
 
-  createProposalRecords(scopeId: string, memoryCommitId: string, proposal: MemoryCommitProposal): void {
+  createProposalRecords(
+    scopeId: string,
+    memoryCommitId: string,
+    proposal: MemoryCommitProposal,
+    anchorFingerprints?: Map<string, Record<string, string>>,
+  ): void {
     const write = this.db.transaction(() => {
       const repoId = this.repoIdForScope(scopeId);
 
@@ -305,15 +325,18 @@ export class SqliteRepository {
       }
 
       for (const claim of proposal.creates.claims ?? []) {
+        const fingerprints = anchorFingerprints?.get(claim.id);
         this.db
           .prepare(
-            `INSERT INTO claims (repo_id, id, kind, text, truth, intent, code_anchors)
-             VALUES (@repo_id, @id, @kind, @text, @truth, @intent, @code_anchors)`,
+            `INSERT INTO claims (repo_id, id, kind, text, truth, intent, code_anchors, anchor_fingerprints)
+             VALUES (@repo_id, @id, @kind, @text, @truth, @intent, @code_anchors, @anchor_fingerprints)`,
           )
           .run({
             repo_id: repoId,
             ...claim,
             code_anchors: claim.code_anchors === undefined ? null : JSON.stringify(claim.code_anchors),
+            anchor_fingerprints:
+              fingerprints === undefined || Object.keys(fingerprints).length === 0 ? null : JSON.stringify(fingerprints),
           });
         this.createMembership(scopeId, "claim", claim.id, memoryCommitId);
       }

--- a/libs/storage/sqlite/schema.ts
+++ b/libs/storage/sqlite/schema.ts
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS claims (
   truth TEXT NOT NULL,
   intent TEXT NOT NULL,
   code_anchors TEXT,
+  anchor_fingerprints TEXT,
   PRIMARY KEY(repo_id, id)
 );
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
     "smoke:opencode": "npm run build && node scripts/smoke-opencode-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",

--- a/scripts/check-anchor-drift.js
+++ b/scripts/check-anchor-drift.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url);
+const { CodeAnchorResolver } = await import(new URL("dist/libs/knowledge-graph/code-anchors/resolver.js", root));
+const { fingerprintClaimAnchors } = await import(new URL("dist/libs/knowledge-graph/code-anchors/fingerprint.js", root));
+const { auditClaimCodeAnchors } = await import(new URL("dist/libs/knowledge-graph/code-anchors/audit.js", root));
+
+const repo = mkdtempSync(join(tmpdir(), "greplica-anchor-drift-test-"));
+const file = join(repo, "mod.py");
+const anchor = { file: "mod.py", symbol: "foo" };
+const claim = { id: "claim.foo", kind: "fact", text: "foo returns 3", truth: "code_verified", intent: "intended", code_anchors: [anchor] };
+
+// Baseline fingerprint captured when the fact was "written".
+writeFileSync(file, "def foo():\n    # returns the threshold\n    return 3\n");
+const baseline = new Map([["claim.foo", await fingerprintClaimAnchors(repo, [anchor], new CodeAnchorResolver())]]);
+
+async function driftedIds(variant) {
+  writeFileSync(file, variant);
+  const result = await auditClaimCodeAnchors(repo, [claim], new CodeAnchorResolver(), baseline);
+  return result.drifted.map((issue) => issue.claim_id);
+}
+
+// Unchanged code does not drift.
+assert.deepEqual(await driftedIds("def foo():\n    # returns the threshold\n    return 3\n"), []);
+
+// A real value change (3 -> 8) drifts.
+assert.deepEqual(await driftedIds("def foo():\n    # returns the threshold\n    return 8\n"), ["claim.foo"]);
+
+// Comment-only edits do not drift.
+assert.deepEqual(await driftedIds("def foo():\n    # returns the configured threshold value\n    return 3\n"), []);
+
+// Whitespace-only edits do not drift.
+assert.deepEqual(await driftedIds("def foo():\n\n    # returns the threshold\n    return 3\n\n"), []);
+
+// A claim with no stored baseline is treated as unknown, never drifted.
+const noBaseline = await auditClaimCodeAnchors(repo, [claim], new CodeAnchorResolver());
+assert.deepEqual(noBaseline.drifted, []);
+
+console.log("check-anchor-drift: ok");


### PR DESCRIPTION
## Detect anchor drift (mechanism only)

When a fact is written, fingerprint the code its anchor points to; later, the
anchor audit compares against that baseline to know when the code behind a fact
has changed. This PR is the **mechanism only** — the drift signal is computed and
stored but not yet surfaced to the agent (that + the update-working-memory skill
will follow in a second PR, once we have an eval).

## What it does
- On `proposal apply`: fingerprint each anchor and store it in a new nullable
  `claims.anchor_fingerprints` column (scoped by `repo_id`).
- In the anchor audit: re-fingerprint and compare to the baseline; drifted anchors
  are reported in the `ClaimAnchorAuditResult` (`drifted[]`) — not printed anywhere yet.

## Fingerprint
Built from the tree-sitter parse tree: the signature is the ordered non-comment
tokens of the anchored span (whole file for a file-only anchor). Comments are
excluded by grammar, not regex, so reformatting/comment edits don't drift while a
real change (e.g. a literal `3 -> 8`) does.

## Scope / not included
- No change to `graph context` / retrieval.
- No CLI output and no skill change yet (deferred to the follow-up PR + eval).
- Old facts with no baseline are treated as unknown, never flagged.

## Also in this PR
- `scripts/check-anchor-drift.js` (wired into `npm test`).
- One unrelated 1-line build fix: `opencode.ts` imported `HookInput` from
  `hook-input.js`, which #95 moved to `hooks/types.ts`. Happy to split out.

## Known limitations (follow-ups)
- Variable renames and docstring edits still register as drift (hashes tokens, not
  structure). File-only anchors on non-code files are coarse (any edit drifts).
