### PR TITLE
fix: import HookInput from hooks/types after #95 refactor

### DIFF
--- a/libs/install/platforms/opencode.ts
+++ b/libs/install/platforms/opencode.ts
@@ -5,7 +5,8 @@ import Database from "better-sqlite3";
 import { hookCommand, hookEvents, mergeHookConfig, readJsonObject, writeJson } from "../hook-config.js";
 import { copyBundledSkills } from "../skills.js";
 import { runOpenCodeAgent } from "../../agent-runner/opencode.js";
-import { hookSessionId, type HookInput } from "../../hooks/hook-input.js";
+import { hookSessionId } from "../../hooks/hook-input.js";
+import type { HookInput } from "../../hooks/types.js";
 import {
   isRecord,
   parseJsonLine,


### PR DESCRIPTION
 ## Problem

  `main` currently fails `npm run typecheck` and `npm run build`:

      libs/install/platforms/opencode.ts(8,30): error TS2459: Module
      '"../../hooks/hook-input.js"' declares 'HookInput' locally, but it is not exported.

  #95 moved the hook module interfaces (including `HookInput`) into
  `libs/hooks/types.ts`, but `opencode.ts` still imports the type from
  `hook-input.js`, which now only re-uses it internally.

  ## Fix

  Import `HookInput` from `../../hooks/types.js` instead. One-line change,
  no behavior change.

  ## Verification

  - `npm run typecheck` — clean
  - `npm run build` — clean
  - `npm test` — all checks pass

  ## Note

  This slipped through because typecheck isn't run on PRs. Worth adding a CI
  step (related: #84, the Vitest testing-surface proposal).