### PR TITLE
Fix/stdin epipe

### DIFF
--- a/libs/agent-runner/codex.ts
+++ b/libs/agent-runner/codex.ts
@@ -58,6 +58,9 @@ function runCodexProcess(
 
     child.once("error", reject);
     child.stdout.pipe(transcript);
+    // If the child exits before draining the prompt, stdin emits EPIPE;
+    // the failure is reported via the exit code on "close".
+    child.stdin.once("error", () => {});
     child.stdin.end(input.prompt);
     child.once("close", (exitCode, signal) => {
       resolve({ exitCode, signal });

--- a/libs/install/platforms/claude.ts
+++ b/libs/install/platforms/claude.ts
@@ -132,6 +132,9 @@ function runClaudePrint(input: WorkingMemoryUpdateInput): Promise<void> {
       reject(error);
     });
     child.stdout.pipe(transcript);
+    // If the child exits before draining the prompt, stdin emits EPIPE;
+    // the failure is reported via the exit code on "close".
+    child.stdin.once("error", () => {});
     child.stdin.end(input.prompt);
     child.once("close", (exitCode, signal) => {
       transcript.end();

--- a/libs/install/platforms/copilot.ts
+++ b/libs/install/platforms/copilot.ts
@@ -210,6 +210,9 @@ function runCopilot(input: WorkingMemoryUpdateInput): Promise<void> {
     child.stdout.on("data", (chunk: Buffer) => {
       stdoutChunks.push(chunk);
     });
+    // If the child exits before draining the prompt, stdin emits EPIPE;
+    // the failure is reported via the exit code on "close".
+    child.stdin.once("error", () => {});
     child.stdin.end(input.prompt);
     child.once("close", (exitCode, signal) => {
       const stdout = Buffer.concat(stdoutChunks).toString("utf8");

--- a/libs/install/platforms/droid.ts
+++ b/libs/install/platforms/droid.ts
@@ -77,6 +77,9 @@ function runDroidExec(input: WorkingMemoryUpdateInput): Promise<void> {
       reject(error);
     });
     child.stdout.pipe(transcript);
+    // If the child exits before draining the prompt, stdin emits EPIPE;
+    // the failure is reported via the exit code on "close".
+    child.stdin.once("error", () => {});
     child.stdin.end(input.prompt);
     child.once("close", (exitCode, signal) => {
       transcript.end();

--- a/libs/install/platforms/opencode.ts
+++ b/libs/install/platforms/opencode.ts
@@ -5,7 +5,8 @@ import Database from "better-sqlite3";
 import { hookCommand, hookEvents, mergeHookConfig, readJsonObject, writeJson } from "../hook-config.js";
 import { copyBundledSkills } from "../skills.js";
 import { runOpenCodeAgent } from "../../agent-runner/opencode.js";
-import { hookSessionId, type HookInput } from "../../hooks/hook-input.js";
+import { hookSessionId } from "../../hooks/hook-input.js";
+import type { HookInput } from "../../hooks/types.js";
 import {
   isRecord,
   parseJsonLine,


### PR DESCRIPTION
Stacked on #112  - pls merge that first; the first commit here is that PR.
-------
## Problem

All four agent runners that feed the prompt via stdin (`libs/agent-runner/codex.ts`, `libs/install/platforms/claude.ts`, `libs/install/platforms/droid.ts`, `libs/install/platforms/copilot.ts`) call `child.stdin.end(input.prompt)` with an `error` listener on the child process, but none on the stdin stream.

The working-memory prompt embeds the full projected session transcript, which routinely exceeds the 64 KiB pipe buffer. If the child CLI exits before draining stdin (binary missing from the hook worker's `PATH`, auth error, unrecognized flag after a CLI update, etc.), the write fails with `EPIPE` on `child.stdin`. With no listener, that's an **uncaught exception that kills the detached hook worker mid-batch**, skipping cleanup for any other claimed session updates.

The existing `child.once("error", ...)` handler doesn't help because it only covers spawn failures, not stream errors.

## Fix

Attach a no-op `error` listener to `child.stdin` before writing in all four runners. Swallowing the stream error is correct here: if the child exits early, `close` still fires, and the failure is reported through the existing exit-code path (recorded in the run result/final-message file).

## Verification

Tested the real compiled `runCodexAgent` with a fake `codex` binary on `PATH` that exits immediately without reading stdin, using a 1 MiB prompt.

- **Before** (guard removed): `UNCAUGHT: EPIPE`; the process crashes.
- **After**: resolves normally with `exit_code: 1`; no crash.

`npm run typecheck`, `npm run build`, and `npm test` all pass.

## Note

This depends on the `HookInput` import fix, since `main` doesn't typecheck without it.

A follow-up worth tracking separately: failed update attempts are never recorded (`libs/hooks/session-state.ts`), so a permanently failing child is retried on every hook event. This PR prevents the crash but does not address the retry loop.