### PR TITLE
fix stale install platform guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Current showcase rows:
 ## Commands
 
 ```bash
-greplica install --platform codex|claude|copilot|opencode|openhands|factory-droid --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica install --platform codex|claude|copilot|opencode|openhands|factory-droid|antigravity --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
 greplica config
 greplica doctor [--check-embeddings]
 greplica graph read

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -20,6 +20,7 @@ import { buildGraphFolderExport } from "../../libs/knowledge-graph/folder-export
 import { buildTranscriptBundle } from "../../libs/session-transcript/bundle.js";
 import { installGreplica, platformDisplayName } from "../../libs/install/install.js";
 import { allPlatformInstallers, platformInstaller } from "../../libs/install/platforms/index.js";
+import { installPlatforms, installPlatformUsage } from "../../libs/install/paths.js";
 import type { InstallEmbedding, InstallPlatform } from "../../libs/install/paths.js";
 import { hookCwd, hookEventName, hookSessionId, hookTranscriptPath, readHookInput } from "../../libs/hooks/hook-input.js";
 import { greplicaHookGuidance } from "../../libs/hooks/guidance.js";
@@ -57,7 +58,7 @@ const cliCommands = [
   {
     key: "install",
     path: ["install"],
-    usage: "install --platform codex|claude|copilot|opencode|openhands|factory-droid|antigravity --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]",
+    usage: `install --platform ${installPlatformUsage} --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]`,
     handler: runInstallCommand,
     showInTopLevelHelp: true,
   },
@@ -766,7 +767,7 @@ function requireFlagValue(args: string[], index: number, flag: string, usageText
 }
 
 function parseInstallPlatform(value: string): InstallPlatform {
-  if (value === "codex" || value === "claude" || value === "copilot" || value === "opencode" || value === "openhands" || value === "factory-droid" || value === "antigravity") return value;
+  if ((installPlatforms as readonly string[]).includes(value)) return value as InstallPlatform;
   throw new Error(`Invalid --platform ${value}.\n${usage("install")}`);
 }
 

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -38,7 +38,7 @@ Then run:
 
 ```bash
 npm install -g greplica
-greplica install --platform <codex|claude|copilot|opencode|openhands|factory-droid> --embedding local <mapped-hook-and-memory-flags>
+greplica install --platform <codex|claude|copilot|opencode|openhands|factory-droid|antigravity> --embedding local <mapped-hook-and-memory-flags>
 ```
 
 Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps.

--- a/libs/install/paths.ts
+++ b/libs/install/paths.ts
@@ -5,6 +5,10 @@ import { fileURLToPath } from "node:url";
 export type InstallPlatform = "codex" | "claude" | "opencode" | "openhands" | "factory-droid" | "copilot" | "antigravity";
 export type InstallEmbedding = "local" | "openai";
 
+export const installPlatforms = ["codex", "claude", "copilot", "opencode", "openhands", "factory-droid", "antigravity"] as const satisfies readonly InstallPlatform[];
+export const installPlatformUsage = installPlatforms.join("|");
+export const installCommandSuggestion = `greplica install --platform <${installPlatformUsage}> --embedding local`;
+
 export const skillNames = ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"] as const;
 export type SkillName = (typeof skillNames)[number];
 

--- a/libs/install/platforms/opencode.ts
+++ b/libs/install/platforms/opencode.ts
@@ -5,7 +5,8 @@ import Database from "better-sqlite3";
 import { hookCommand, hookEvents, mergeHookConfig, readJsonObject, writeJson } from "../hook-config.js";
 import { copyBundledSkills } from "../skills.js";
 import { runOpenCodeAgent } from "../../agent-runner/opencode.js";
-import { hookSessionId, type HookInput } from "../../hooks/hook-input.js";
+import { hookSessionId } from "../../hooks/hook-input.js";
+import type { HookInput } from "../../hooks/types.js";
 import {
   isRecord,
   parseJsonLine,

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -6,6 +6,7 @@ import type { MemoryCommitProposal } from "../../knowledge-graph/proposal.js";
 import type { Component, Flow, GraphObjectType, Source } from "../../knowledge-graph/schema.js";
 import type { Claim } from "../../knowledge-graph/claim.js";
 import type { GraphScope, GraphScopeKind } from "../../knowledge-graph/scope.js";
+import { installCommandSuggestion } from "../../install/paths.js";
 
 export interface RepoRecord {
   id: string;
@@ -118,7 +119,7 @@ export class SqliteRepository {
   requireRepo(input: UpsertRepoInput): RepoRecord {
     const repo = this.getRepo(input);
     if (!repo) {
-      throw new Error("Greplica is not installed for this repo. Run greplica install --platform <codex|claude|copilot|opencode> --embedding local from the repo you want to use.");
+      throw new Error(`Greplica is not installed for this repo. Run ${installCommandSuggestion} from the repo you want to use.`);
     }
     return repo;
   }
@@ -192,7 +193,7 @@ export class SqliteRepository {
     const scope = this.db
       .prepare("SELECT * FROM graph_scopes WHERE repo_id = ? AND kind = 'working' AND name = 'working'")
       .get(repoId) as GraphScope | undefined;
-    if (!scope) throw new Error("Working scope is missing. Run 'greplica install --platform <codex|claude|copilot|opencode> --embedding local' from this repo.");
+    if (!scope) throw new Error(`Working scope is missing. Run '${installCommandSuggestion}' from this repo.`);
     return scope;
   }
 
@@ -200,7 +201,7 @@ export class SqliteRepository {
     const scope = this.db
       .prepare("SELECT * FROM graph_scopes WHERE repo_id = ? AND kind = 'main' ORDER BY created_at LIMIT 1")
       .get(repoId) as GraphScope | undefined;
-    if (!scope) throw new Error("Main scope is missing. Run 'greplica install --platform <codex|claude|copilot|opencode> --embedding local' from this repo.");
+    if (!scope) throw new Error(`Main scope is missing. Run '${installCommandSuggestion}' from this repo.`);
     return scope;
   }
 

--- a/scripts/check-install-options.js
+++ b/scripts/check-install-options.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const root = new URL("..", import.meta.url);
 const cliPath = fileURLToPath(new URL("dist/apps/cli/main.js", root));
+const { installCommandSuggestion, installPlatformUsage } = await import(new URL("dist/libs/install/paths.js", root));
 const { greplicaHookGuidance } = await import(new URL("dist/libs/hooks/guidance.js", root));
 const { shouldRunAutoMemoryUpdates } = await import(new URL("dist/libs/hooks/worker.js", root));
 
@@ -99,6 +100,26 @@ const invalidValue = spawnSync(
 );
 assert.notEqual(invalidValue.status, 0);
 assert.match(invalidValue.stderr, /expected enabled or disabled/);
+
+const notInstalledRepo = join(tmp, "not-installed", "repo");
+const notInstalledHome = join(tmp, "not-installed", "greplica-home");
+mkdirSync(notInstalledRepo, { recursive: true });
+execFileSync("git", ["init", "--quiet"], { cwd: notInstalledRepo, encoding: "utf8" });
+const notInstalled = spawnSync(process.execPath, [cliPath, "graph", "read"], {
+  cwd: notInstalledRepo,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    GREPLICA_HOME: notInstalledHome,
+  },
+});
+assert.notEqual(notInstalled.status, 0);
+assert.match(notInstalled.stderr, /Greplica is not installed for this repo/);
+assert.ok(notInstalled.stderr.includes(installCommandSuggestion), "not installed error should use shared install guidance");
+assert.ok(notInstalled.stderr.includes(installPlatformUsage), "not installed error should include every install platform");
+assert.match(notInstalled.stderr, /openhands/);
+assert.match(notInstalled.stderr, /factory-droid/);
+assert.match(notInstalled.stderr, /antigravity/);
 
 console.log("Install option checks passed.");
 


### PR DESCRIPTION
## Summary

  - Centralized the supported install platform list and install recovery command
  - Reused the shared platform guidance in CLI install usage and repository setup errors
  - Updated README and agent install prompt install examples to include Antigravity
  - Added regression coverage for the not-installed graph command error

  ## Why

  Some setup errors still suggested only the older platform list:

  `codex|claude|copilot|opencode`

  That conflicted with the CLI’s accepted install platforms and could confuse OpenHands, Factory Droid, or Antigravity users when recovery
  guidance appeared.

  ## Validation

  - `npm run build && node scripts/check-install-options.js`
  - `npm test`