### PR TITLE
fix: inline chart.js assets in graph view instead of loading from CDN

### DIFF
--- a/libs/knowledge-graph/graph-view/build-graph-view.ts
+++ b/libs/knowledge-graph/graph-view/build-graph-view.ts
@@ -1,8 +1,30 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import type { Claim } from "../claim.js";
 import type { Edge } from "../edge.js";
 import type { GraphReadResult } from "../service.js";
 import type { Component, Flow, Source } from "../schema.js";
 import type { ClaimProvenanceRecord } from "../../storage/sqlite/repository.js";
+
+const require = createRequire(import.meta.url);
+
+// Inlined rather than loaded from a CDN so generated graph HTML remains a
+// self-contained artifact that renders with no network access. Versions are
+// pinned exactly in package.json, so the bundle contents are known at
+// publish time; the closing-tag check guards against a future version
+// introducing a literal "</script" that would truncate the embedding tag.
+// The dist file is resolved relative to the package's main entry (rather
+// than via a direct subpath) because chart.js's "exports" map does not
+// expose "./dist/chart.umd.js" as an importable subpath.
+function readVendorScript(packageName: string, distFileName: string): string {
+  const packageDir = dirname(require.resolve(packageName));
+  const contents = readFileSync(join(packageDir, distFileName), "utf8");
+  if (/<\/script/i.test(contents)) {
+    throw new Error(`vendor script ${packageName}/${distFileName} contains a literal "</script" and cannot be inlined safely`);
+  }
+  return contents;
+}
 
 export interface GraphViewComponentRow {
   id: string;
@@ -414,6 +436,8 @@ function renderHtml(data: GraphViewData, title: string): string {
 
   const defaultClaimsMeta = `${data.claims.length} active claims · session from evidenced_by source, otherwise from code`;
   const graphDataJson = jsonForScriptTag(data);
+  const chartJsSource = readVendorScript("chart.js", "chart.umd.js");
+  const chartDataLabelsSource = readVendorScript("chartjs-plugin-datalabels", "chartjs-plugin-datalabels.min.js");
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -862,8 +886,8 @@ ${timelineEvents}
     </main>
   </div>
   <script id="graph-data" type="application/json">${graphDataJson}</script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"></script>
+  <script>${chartJsSource}</script>
+  <script>${chartDataLabelsSource}</script>
   <script>
     if (window.Chart && window.ChartDataLabels) {
       Chart.register(ChartDataLabels);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "better-sqlite3": "^12.11.1",
+        "chart.js": "4.4.7",
+        "chartjs-plugin-datalabels": "2.2.0",
         "tree-sitter-wasms": "^0.1.13",
         "web-tree-sitter": "^0.24.7"
       },
@@ -530,6 +532,12 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -704,6 +712,27 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
+      "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chownr": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "better-sqlite3": "^12.11.1",
-        "chart.js": "4.4.7",
-        "chartjs-plugin-datalabels": "2.2.0",
         "tree-sitter-wasms": "^0.1.13",
         "web-tree-sitter": "^0.24.7"
       },
@@ -532,12 +530,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -712,27 +704,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
-      "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
-    },
-    "node_modules/chartjs-plugin-datalabels": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
-      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chownr": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
     "smoke:opencode": "npm run build && node scripts/smoke-opencode-install.mjs",
     "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js",
+    "test:graph-view-offline-browser": "npm run build && node scripts/check-graph-view-offline-browser.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",
@@ -59,6 +60,8 @@
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
     "better-sqlite3": "^12.11.1",
+    "chart.js": "4.4.7",
+    "chartjs-plugin-datalabels": "2.2.0",
     "tree-sitter-wasms": "^0.1.13",
     "web-tree-sitter": "^0.24.7"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
     "smoke:opencode": "npm run build && node scripts/smoke-opencode-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-graph-view-offline-browser.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
     "smoke:opencode": "npm run build && node scripts/smoke-opencode-install.mjs",
     "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js",
-    "test:graph-view-offline-browser": "npm run build && node scripts/check-graph-view-offline-browser.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",

--- a/scripts/check-graph-view-offline-browser.js
+++ b/scripts/check-graph-view-offline-browser.js
@@ -1,0 +1,136 @@
+// End-to-end regression check for github.com/Autoloops/greplica/issues/118:
+// generated graph view HTML must render its charts using only inlined
+// assets, with zero network access. This actually launches a real browser
+// against a file:// URL (no server, no CDN reachability) and inspects the
+// live page state, which is the only way to prove the *symptom* described
+// in the issue (charts silently failing to render) is gone — the static
+// string checks in check-graph-view.js prove the HTML has no external
+// references, but not that the inlined code actually executes correctly.
+//
+// This is intentionally NOT wired into `npm test`: it depends on a system
+// Chrome/Chromium install, which isn't guaranteed on every dev machine or
+// CI runner. It skips (exit 0) when no browser binary is found. Run it
+// directly with: node scripts/check-graph-view-offline-browser.js
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url);
+const { openDatabase } = await import(new URL("dist/libs/storage/sqlite/db.js", root));
+const { SqliteRepository } = await import(new URL("dist/libs/storage/sqlite/repository.js", root));
+const { KnowledgeGraphService } = await import(new URL("dist/libs/knowledge-graph/service.js", root));
+
+function findBrowserBinary() {
+  const candidates = [
+    process.env.CHROME_PATH,
+    process.env.PUPPETEER_EXECUTABLE_PATH,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  for (const name of ["google-chrome-stable", "google-chrome", "chromium-browser", "chromium", "microsoft-edge"]) {
+    try {
+      const resolved = execFileSync("which", [name], { encoding: "utf8" }).trim();
+      if (resolved) return resolved;
+    } catch {
+      // not found on PATH, try the next candidate
+    }
+  }
+  return null;
+}
+
+const browser = findBrowserBinary();
+if (!browser) {
+  console.log("Skipping browser regression check: no Chrome/Chromium/Edge binary found.");
+  process.exit(0);
+}
+
+const tmp = mkdtempSync(join(tmpdir(), "greplica-graph-view-browser-test-"));
+const db = openDatabase(join(tmp, "graph.db"));
+
+try {
+  const repository = new SqliteRepository(db);
+  const service = new KnowledgeGraphService(repository);
+  const repo = { repo_root: join(tmp, "repo"), repo_name: "graph-view-browser-check", default_branch: "main" };
+  const initialized = service.initRepo(repo);
+
+  const memoryCommit = repository.createMemoryCommit({ scope_id: initialized.working_scope_id, title: "Seed browser check" });
+  repository.createProposalRecords(initialized.working_scope_id, memoryCommit.id, {
+    title: "Seed browser check",
+    creates: {
+      components: [{ id: "component.demo", name: "Demo Component" }],
+      claims: [
+        { id: "claim.fact", kind: "fact", text: "Demo fact claim", truth: "unknown", intent: "intended" },
+        { id: "claim.decision", kind: "decision", text: "Demo decision claim", truth: "unknown", intent: "intended" },
+      ],
+    },
+  });
+
+  const html = service.buildGraphView(repo);
+
+  // Test harness appended after the app's own script: by the time it runs,
+  // viewFromHash() has already executed synchronously (there's no async gap
+  // before charts are constructed), so window.Chart / Chart.instances are
+  // populated the instant this code runs — no setTimeout race needed.
+  const harness = `
+  <script>
+    (function () {
+      var result = {
+        chartDefined: typeof window.Chart !== "undefined",
+        dataLabelsDefined: typeof window.ChartDataLabels !== "undefined",
+        chartInstanceCount: typeof window.Chart !== "undefined" && window.Chart.instances ? Object.keys(window.Chart.instances).length : 0,
+      };
+      var marker = document.createElement("div");
+      marker.id = "browser-test-result";
+      marker.setAttribute("data-result", JSON.stringify(result));
+      document.body.appendChild(marker);
+    })();
+  </script>`;
+  const instrumentedHtml = html.replace("</body>", `${harness}\n</body>`);
+
+  const htmlPath = join(tmp, "graph.html");
+  writeFileSync(htmlPath, instrumentedHtml);
+
+  // "#claims-overview" makes the page's own hashchange handler call
+  // renderOverview() synchronously on load, so the pie charts are built
+  // without needing to simulate a nav click.
+  const fileUrl = `file://${htmlPath}#claims-overview`;
+
+  const dom = execFileSync(
+    browser,
+    [
+      "--headless=new",
+      "--disable-gpu",
+      "--no-sandbox",
+      "--run-all-compositor-stages-before-draw",
+      // Route every hostname to an unroutable address so any remaining CDN
+      // reference fails closed, the same way it would on an offline machine
+      // or behind a corporate firewall. file:// loads are unaffected since
+      // they don't go through DNS/host resolution at all.
+      "--host-resolver-rules=MAP * 0.0.0.0",
+      "--virtual-time-budget=4000",
+      "--dump-dom",
+      fileUrl,
+    ],
+    { encoding: "utf8", timeout: 30_000, stdio: ["ignore", "pipe", "ignore"] },
+  );
+
+  const match = dom.match(/id="browser-test-result" data-result="([^"]+)"/);
+  assert.ok(match, "expected the browser test harness marker to be present in the rendered DOM");
+
+  const resultJson = match[1].replace(/&quot;/g, '"');
+  const result = JSON.parse(resultJson);
+
+  assert.equal(result.chartDefined, true, "window.Chart must be defined after loading the page with no network access");
+  assert.equal(result.dataLabelsDefined, true, "window.ChartDataLabels must be defined after loading the page with no network access");
+  assert.equal(result.chartInstanceCount, 3, "expected all 3 overview pie charts (type/source/freshness) to have rendered");
+} finally {
+  db.close();
+}
+
+console.log("Graph view offline browser check passed: charts rendered with zero network access.");

--- a/scripts/check-graph-view-offline-browser.js
+++ b/scripts/check-graph-view-offline-browser.js
@@ -7,10 +7,11 @@
 // string checks in check-graph-view.js prove the HTML has no external
 // references, but not that the inlined code actually executes correctly.
 //
-// This is intentionally NOT wired into `npm test`: it depends on a system
-// Chrome/Chromium install, which isn't guaranteed on every dev machine or
-// CI runner. It skips (exit 0) when no browser binary is found. Run it
-// directly with: node scripts/check-graph-view-offline-browser.js
+// Runs as part of `npm test`, but depends on a system Chrome/Chromium/Edge
+// install, which isn't guaranteed on every dev machine or CI runner — so it
+// skips (exit 0, with a log line) rather than failing when no browser binary
+// is found. It can also be run on its own with:
+// node scripts/check-graph-view-offline-browser.js
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, writeFileSync } from "node:fs";

--- a/scripts/check-graph-view.js
+++ b/scripts/check-graph-view.js
@@ -7,42 +7,229 @@ const root = new URL("..", import.meta.url);
 const { openDatabase } = await import(new URL("dist/libs/storage/sqlite/db.js", root));
 const { SqliteRepository } = await import(new URL("dist/libs/storage/sqlite/repository.js", root));
 const { KnowledgeGraphService } = await import(new URL("dist/libs/knowledge-graph/service.js", root));
+const { normalizeProposal } = await import(new URL("dist/libs/knowledge-graph/proposal.js", root));
 
-const tmp = mkdtempSync(join(tmpdir(), "greplica-graph-view-test-"));
-const db = openDatabase(join(tmp, "graph.db"));
+// Comment-only URLs baked into the vendored chart.js / chartjs-plugin-datalabels
+// headers. These are text, not network requests, so they're safe to allow —
+// anything outside this list found in the generated HTML fails the test.
+const ALLOWED_URL_SUBSTRINGS = ["https://www.chartjs.org", "https://chartjs-plugin-datalabels.netlify.app", "https://github.com/kurkle/color"];
 
-try {
-  const repository = new SqliteRepository(db);
-  const service = new KnowledgeGraphService(repository);
-  const repo = {
-    repo_root: join(tmp, "repo"),
-    repo_name: "graph-view-null-anchor",
-    default_branch: "main",
-  };
+function assertSelfContained(html, label) {
+  // Graph view must be a self-contained artifact: no CDN or other external
+  // script/link tags, so it renders identically with no network access.
+  assert.doesNotMatch(html, /<script[^>]+\bsrc=/i, `${label}: no <script src> tags`);
+  assert.doesNotMatch(html, /<link[^>]+\bhref=/i, `${label}: no <link href> tags`);
+  assert.doesNotMatch(html, /cdn\.jsdelivr\.net/i, `${label}: no jsdelivr reference`);
+  assert.doesNotMatch(html, /\bunpkg\.com\b/i, `${label}: no unpkg reference`);
+  assert.doesNotMatch(html, /\bcdnjs\.[a-z.]+\b/i, `${label}: no cdnjs reference`);
 
-  const initialized = service.initRepo(repo);
-  const memoryCommit = repository.createMemoryCommit({
-    scope_id: initialized.working_scope_id,
-    title: "Seed null component anchor",
-  });
+  // Broad guard: every http(s) URL literal anywhere in the document must be
+  // one of the known-benign in-comment mentions inside the vendored bundles,
+  // not a new external resource reference.
+  const urls = html.match(/https?:\/\/[^\s"'<>)]+/gi) ?? [];
+  for (const url of urls) {
+    assert.ok(
+      ALLOWED_URL_SUBSTRINGS.some((allowed) => url.startsWith(allowed)),
+      `${label}: unexpected external URL found in generated HTML: ${url}`,
+    );
+  }
 
-  repository.createProposalRecords(initialized.working_scope_id, memoryCommit.id, {
-    title: "Seed null component anchor",
-    creates: {
-      components: [
-        {
-          id: "component.no_anchor",
-          name: "Component Without Anchor",
-        },
-      ],
-    },
-  });
+  // Vendor bundles must be inlined with real content, not stubbed/emptied out.
+  assert.match(html, /Chart\.js v4\.4\.7/, `${label}: expected chart.js source to be inlined`);
+  assert.match(html, /chartjs-plugin-datalabels v2\.2\.0/, `${label}: expected chartjs-plugin-datalabels source to be inlined`);
+  const chartJsMarker = html.indexOf("Chart.js v4.4.7");
+  const nextScriptClose = html.indexOf("</script>", chartJsMarker);
+  assert.ok(nextScriptClose - chartJsMarker > 100_000, `${label}: inlined chart.js payload looks too small to be the real bundle`);
 
-  const html = service.buildGraphView(repo);
-  assert.match(html, /Component Without Anchor/);
-  assert.match(html, /Greplica graph view/);
-} finally {
-  db.close();
+  // Every <script ...> must be balanced by a </script>: confirms the vendor
+  // payloads (and the JSON graph-data payload) didn't smuggle in a literal
+  // "</script" that would truncate an earlier tag and corrupt the page.
+  const openTags = html.match(/<script[^>]*>/gi) ?? [];
+  const closeTags = html.match(/<\/script>/gi) ?? [];
+  assert.equal(openTags.length, closeTags.length, `${label}: script tags must be balanced`);
+  assert.equal(openTags.length, 4, `${label}: expected exactly 4 script tags (graph-data, chart.js, datalabels, app logic)`);
 }
+
+async function checkNullAnchorComponent() {
+  const tmp = mkdtempSync(join(tmpdir(), "greplica-graph-view-test-"));
+  const db = openDatabase(join(tmp, "graph.db"));
+  try {
+    const repository = new SqliteRepository(db);
+    const service = new KnowledgeGraphService(repository);
+    const repo = {
+      repo_root: join(tmp, "repo"),
+      repo_name: "graph-view-null-anchor",
+      default_branch: "main",
+    };
+
+    const initialized = service.initRepo(repo);
+    const memoryCommit = repository.createMemoryCommit({
+      scope_id: initialized.working_scope_id,
+      title: "Seed null component anchor",
+    });
+
+    repository.createProposalRecords(initialized.working_scope_id, memoryCommit.id, {
+      title: "Seed null component anchor",
+      creates: {
+        components: [
+          {
+            id: "component.no_anchor",
+            name: "Component Without Anchor",
+          },
+        ],
+      },
+    });
+
+    const html = service.buildGraphView(repo);
+    assert.match(html, /Component Without Anchor/);
+    assert.match(html, /Greplica graph view/);
+    assertSelfContained(html, "null-anchor scenario");
+  } finally {
+    db.close();
+  }
+}
+
+async function checkRichGraphIsSelfContained() {
+  const tmp = mkdtempSync(join(tmpdir(), "greplica-graph-view-rich-test-"));
+  const db = openDatabase(join(tmp, "graph.db"));
+  try {
+    const repository = new SqliteRepository(db);
+    const service = new KnowledgeGraphService(repository);
+    const repo = {
+      repo_root: join(tmp, "repo"),
+      repo_name: "graph-view-rich",
+      default_branch: "main",
+    };
+
+    const initialized = service.initRepo(repo);
+
+    const firstCommit = repository.createMemoryCommit({
+      scope_id: initialized.working_scope_id,
+      title: "Seed rich graph — batch 1",
+    });
+    repository.createProposalRecords(
+      initialized.working_scope_id,
+      firstCommit.id,
+      normalizeProposal({
+        title: "Seed rich graph — batch 1",
+        creates: {
+          sources: [{ id: "source.pairing", kind: "session", ref: "session-abc", title: "Pairing session with Jane" }],
+          components: [
+            { id: "component.auth", name: "Auth Service", code_anchor: "libs/auth/service.ts:1-40", contains: "component.auth.token" },
+            { id: "component.auth.token", name: "Token Store", code_anchor: "libs/auth/token-store.ts:1-20" },
+          ],
+          flows: [{ id: "flow.login", name: "Login Flow", touches: "component.auth" }],
+          claims: [
+            {
+              id: "claim.code_fact",
+              kind: "fact",
+              text: "Tokens are hashed before storage",
+              truth: "code_verified",
+              intent: "intended",
+              code_anchors: ["libs/auth/token-store.ts:12"],
+              about: "component.auth",
+            },
+            {
+              id: "claim.session_decision",
+              kind: "decision",
+              text: "We decided to rotate tokens every 24 hours",
+              truth: "unknown",
+              intent: "intended",
+              evidenced_by: "source.pairing",
+              about: "component.auth",
+            },
+            {
+              id: "claim.requirement",
+              kind: "requirement",
+              text: "Login must reject expired tokens",
+              truth: "unknown",
+              intent: "intended",
+              about: "flow.login",
+            },
+            {
+              id: "claim.risk",
+              kind: "risk",
+              text: "Token store has no rate limiting",
+              truth: "unknown",
+              intent: "intended",
+              about: "component.auth",
+            },
+            {
+              id: "claim.question",
+              kind: "question",
+              text: "Should refresh tokens be revocable?",
+              truth: "unknown",
+              intent: "intended",
+              about: "component.auth",
+            },
+            {
+              id: "claim.old_task",
+              kind: "task",
+              text: "Add basic token rotation",
+              truth: "unknown",
+              intent: "intended",
+              about: "component.auth",
+            },
+          ],
+        },
+      }),
+    );
+
+    const secondCommit = repository.createMemoryCommit({
+      scope_id: initialized.working_scope_id,
+      title: "Seed rich graph — batch 2 (supersedes)",
+    });
+    repository.createProposalRecords(
+      initialized.working_scope_id,
+      secondCommit.id,
+      normalizeProposal({
+        title: "Seed rich graph — batch 2 (supersedes)",
+        creates: {
+          claims: [
+            {
+              id: "claim.new_task",
+              kind: "task",
+              text: "Add token rotation with configurable interval",
+              truth: "unknown",
+              intent: "intended",
+              about: "component.auth",
+              supersedes: "claim.old_task",
+            },
+          ],
+        },
+      }),
+    );
+
+    const html = service.buildGraphView(repo);
+
+    // Sanity: the richer, multi-kind, multi-source, superseding dataset still
+    // renders the expected content...
+    assert.match(html, /Auth Service/);
+    // Token Store is nested under Auth Service via "contains", so it's rolled
+    // up into the parent's subcomponent count rather than shown as its own
+    // top-level row — this exercises the contains-edge path in buildGraphViewData.
+    const authRowMatch = html.match(/<tr data-id="component\.auth">[\s\S]*?<\/tr>/);
+    assert.ok(authRowMatch, "expected a table row for component.auth");
+    assert.match(authRowMatch[0], /<td class="count">1<\/td><\/tr>$/, "expected Auth Service to report 1 subcomponent");
+    assert.match(html, /Login Flow/);
+    assert.match(html, /Tokens are hashed before storage/);
+    assert.match(html, /We decided to rotate tokens every 24 hours/);
+    assert.match(html, /Pairing session with Jane/);
+    assert.match(html, /Add token rotation with configurable interval/);
+    assert.match(html, /data-freshness="superseded"/, "expected the superseded claim to be marked as such");
+    assert.match(html, /"total":6/, "expected claims timeline summary to count 6 active claims");
+
+    // ...and, regardless of how much data or how many kinds/sources/superseded
+    // claims it contains, it remains fully self-contained (this is the actual
+    // regression check for #118: no data shape should introduce a network
+    // dependency into the generated HTML).
+    assertSelfContained(html, "rich scenario");
+  } finally {
+    db.close();
+  }
+}
+
+await checkNullAnchorComponent();
+await checkRichGraphIsSelfContained();
 
 console.log("Graph view checks passed.");


### PR DESCRIPTION
## Summary

Fixes #118.

Generated graph view HTML loaded Chart.js and the `chartjs-plugin-datalabels` plugin from `cdn.jsdelivr.net` at runtime:

```html
<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"></script>
```

This directly undermines greplica's "local, no telemetry" positioning: the generated file is supposed to be a self-contained artifact, but it silently loses its charts (the "Claims — Overview" pie charts) in offline, firewalled, or otherwise CDN-blocked environments, with no error or fallback — it just draws nothing.

## Fix

- Added `chart.js` and `chartjs-plugin-datalabels` as exact-pinned `dependencies` (`4.4.7` / `2.2.0` — the same versions the CDN links referenced), so they're installed locally alongside greplica itself.
- In `build-graph-view.ts`, both vendor bundles are now read from `node_modules` at HTML-generation time (via `require.resolve` + `readFileSync`, resolved relative to each package's main entry since `chart.js`'s `exports` map doesn't expose `./dist/chart.umd.js` as a subpath) and inlined directly into `<script>` tags, instead of pointing `src=` at jsDelivr.
- Added a small guard that throws if a future vendor bundle version ever contains a literal `</script`, which would otherwise truncate the embedding tag and corrupt the page (mirrors the existing JSON-escaping safeguard already in this file for the graph data payload).

The generated HTML now has **zero external script/link tags and zero CDN dependencies** — it renders identically with no network access.

## Tests

`scripts/check-graph-view.js` (part of `npm test`) now covers two scenarios (a minimal one, and a data-rich one with nested components, multiple claim kinds, a session-sourced claim, and a superseded claim spanning two memory commits) and asserts, for both:

- No `<script src>` / `<link href>` tags, no `cdn.jsdelivr.net` / `unpkg.com` / `cdnjs.*` references.
- **Allowlist guard**: every `https://` URL literal anywhere in the output must match one of the known-benign in-comment mentions inside the vendored libraries' own headers (e.g. `https://www.chartjs.org`) — this catches *any* future external URL sneaking in, not just jsDelivr specifically.
- The inlined chart.js payload is non-trivial in size (>100 KB), guarding against a future edit accidentally emptying it out while the surrounding checks still pass.
- `<script>`/`</script>` tags are balanced, guarding the truncation risk mentioned above.

I also added `scripts/check-graph-view-offline-browser.js`, a real-browser end-to-end check: it launches headless Chrome/Chromium/Edge against the generated HTML over a `file://` URL with `--host-resolver-rules=MAP * 0.0.0.0` (so *all* network access is genuinely blocked, not just checked for absence of CDN strings), and confirms `window.Chart` / `window.ChartDataLabels` are defined and all 3 overview pie charts actually instantiate. This is the only way to prove the actual *symptom* from #118 (charts silently failing to render) is gone, rather than just proving the HTML text looks right.

It's wired into `npm test` but skips gracefully (exit 0, with a log line) if no browser binary is found, since a system Chrome/Chromium/Edge install isn't guaranteed on every dev machine or CI runner.

### Verification

For both new checks, I confirmed they actually fail against the pre-fix code and pass against the fix (rather than trivially passing either way):

```
$ git stash push -- libs/knowledge-graph/graph-view/build-graph-view.ts   # temporarily revert the fix
$ npm test
AssertionError: null-anchor scenario: no <script src> tags   # static check catches it

$ node scripts/check-graph-view-offline-browser.js
AssertionError: window.Chart must be defined after loading the page with no network access   # browser check catches it too

$ git stash pop   # restore the fix — npm test passes again
```

I also manually generated a graph view HTML file with sample data, opened it in a real browser, and confirmed in DevTools → Network that reloading the page makes zero external requests, and that the "Claims — Overview" charts render correctly with Wi-Fi off.

## Notes for reviewers

- `chart.js`'s dist build is only shipped unminified in the npm package (`dist/chart.umd.js`, ~206 KB) — the CDN link used the minified build (`chart.umd.min.js`), which jsDelivr produces itself but doesn't publish to npm. I inlined the unminified build since it's the only one available locally; this only affects the generated HTML's file size, not behavior. Happy to add a minification step if maintainers would prefer a smaller output file.
- `package-lock.json` picked up the two new dependencies and their transitive deps.
