### PR TITLE
fix: roll back proposals when embedding generation fails

### DIFF
--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -159,19 +159,28 @@ export class KnowledgeGraphService {
     }
 
     const working = this.repository.requireWorkingScope(initialized.repo_id);
-    const memoryCommit = this.repository.createMemoryCommit({
-      scope_id: working.id,
-      title: normalizedProposal.title,
-      summary: normalizedProposal.summary,
-    });
-
     const anchorFingerprints = await computeAnchorFingerprints(input.repo_root, normalizedProposal.creates.claims ?? []);
-    this.repository.createProposalRecords(working.id, memoryCommit.id, normalizedProposal, anchorFingerprints);
-    const embeddingStatus = await this.contextBuilder.ensureForGraph(
-      initialized.repo_id,
-      this.repository.readGraphView(initialized.repo_id),
-      this.contextConfig,
+    const memoryCommit = this.repository.createMemoryCommitWithProposal(
+      {
+        scope_id: working.id,
+        title: normalizedProposal.title,
+        summary: normalizedProposal.summary,
+      },
+      normalizedProposal,
+      anchorFingerprints,
     );
+
+    let embeddingStatus: EmbeddingStatus;
+    try {
+      embeddingStatus = await this.contextBuilder.ensureForGraph(
+        initialized.repo_id,
+        this.repository.readGraphView(initialized.repo_id),
+        this.contextConfig,
+      );
+    } catch (error: unknown) {
+      this.repository.rollbackProposalRecords(working.id, memoryCommit.id, normalizedProposal);
+      throw error;
+    }
 
     return {
       memory_commit_id: memoryCommit.id,

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -302,6 +302,19 @@ export class SqliteRepository {
     return memoryCommit;
   }
 
+  createMemoryCommitWithProposal(
+    input: CreateMemoryCommitInput,
+    proposal: MemoryCommitProposal,
+    anchorFingerprints?: Map<string, Record<string, string>>,
+  ): MemoryCommit {
+    const write = this.db.transaction(() => {
+      const memoryCommit = this.createMemoryCommit(input);
+      this.createProposalRecords(input.scope_id, memoryCommit.id, proposal, anchorFingerprints);
+      return memoryCommit;
+    });
+    return write() as MemoryCommit;
+  }
+
   createProposalRecords(
     scopeId: string,
     memoryCommitId: string,
@@ -362,6 +375,22 @@ export class SqliteRepository {
     write();
   }
 
+  rollbackProposalRecords(scopeId: string, memoryCommitId: string, proposal: MemoryCommitProposal): void {
+    const write = this.db.transaction(() => {
+      const repoId = this.repoIdForScope(scopeId);
+      this.deleteEmbeddings(repoId, "component", proposal.creates.components?.map((component) => component.id) ?? []);
+      this.deleteEmbeddings(repoId, "flow", proposal.creates.flows?.map((flow) => flow.id) ?? []);
+      this.deleteEmbeddings(repoId, "claim", proposal.creates.claims?.map((claim) => claim.id) ?? []);
+      this.deleteByIds(repoId, "edges", proposal.creates.edges?.map((edge) => edge.id) ?? []);
+      this.deleteByIds(repoId, "components", proposal.creates.components?.map((component) => component.id) ?? []);
+      this.deleteByIds(repoId, "flows", proposal.creates.flows?.map((flow) => flow.id) ?? []);
+      this.deleteByIds(repoId, "claims", proposal.creates.claims?.map((claim) => claim.id) ?? []);
+      this.deleteByIds(repoId, "sources", proposal.creates.sources?.map((source) => source.id) ?? []);
+      this.db.prepare("DELETE FROM memory_commits WHERE id = ? AND scope_id = ?").run(memoryCommitId, scopeId);
+    });
+    write();
+  }
+
   subjectExists(repoId: string, type: GraphObjectType, id: string): boolean {
     const table = tableForType(type);
     const row = this.db.prepare(`SELECT id FROM ${table} WHERE repo_id = ? AND id = ?`).get(repoId, id);
@@ -419,6 +448,21 @@ export class SqliteRepository {
          VALUES (?, ?, ?, ?)`,
       )
       .run(scopeId, subjectType, subjectId, memoryCommitId);
+  }
+
+  private deleteEmbeddings(repoId: string, objectType: EmbeddingObjectType, ids: string[]): void {
+    if (ids.length === 0) return;
+    this.db
+      .prepare(
+        `DELETE FROM graph_object_embeddings
+         WHERE repo_id = ? AND object_type = ? AND object_id IN (${placeholders(ids)})`,
+      )
+      .run(repoId, objectType, ...ids);
+  }
+
+  private deleteByIds(repoId: string, table: string, ids: string[]): void {
+    if (ids.length === 0) return;
+    this.db.prepare(`DELETE FROM ${table} WHERE repo_id = ? AND id IN (${placeholders(ids)})`).run(repoId, ...ids);
   }
 
   private repoIdForScope(scopeId: string): string {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "smoke:openhands": "npm run build && node scripts/smoke-openhands-install.mjs",
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
     "smoke:opencode": "npm run build && node scripts/smoke-opencode-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-graph-view-offline-browser.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-graph-view-offline-browser.js && node scripts/check-proposal-validate.js && node scripts/check-proposal-apply-atomicity.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "eval:bootstrap-current": "npm run build && node dist/evals/cases/bootstrap-current-repo-at-8038fe8/run.js",

--- a/scripts/check-proposal-apply-atomicity.js
+++ b/scripts/check-proposal-apply-atomicity.js
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url);
+const { graphContextConfig } = await import(new URL("dist/libs/knowledge-graph/graph-context/config.js", root));
+const { KnowledgeGraphService } = await import(new URL("dist/libs/knowledge-graph/service.js", root));
+const { openDatabase } = await import(new URL("dist/libs/storage/sqlite/db.js", root));
+const { SqliteRepository } = await import(new URL("dist/libs/storage/sqlite/repository.js", root));
+
+const tmp = mkdtempSync(join(tmpdir(), "greplica-proposal-apply-atomicity-test-"));
+const db = openDatabase(join(tmp, "graph.db"));
+
+const repoRef = {
+  repo_root: join(tmp, "repo"),
+  repo_name: "proposal-apply-atomicity",
+  default_branch: "main",
+};
+const proposal = {
+  title: "Proposal apply atomicity",
+  creates: {
+    components: [{ id: "component.atomicity", name: "Atomicity Component" }],
+    flows: [{ id: "flow.atomicity", name: "Atomicity Flow", touches: "component.atomicity" }],
+    claims: [
+      {
+        id: "claim.atomicity",
+        kind: "fact",
+        text: "Proposal apply is atomic when embedding generation fails.",
+        truth: "source_verified",
+        intent: "intended",
+        about: "component.atomicity",
+      },
+    ],
+    sources: [
+      {
+        id: "source.atomicity",
+        kind: "session",
+        ref: "test:proposal-apply-atomicity",
+      },
+    ],
+    edges: [
+      {
+        kind: "evidenced_by",
+        from: "claim.atomicity",
+        to: "source.atomicity",
+        metadata: { reason: "Deterministic proposal apply test." },
+      },
+    ],
+  },
+};
+
+try {
+  const repository = new SqliteRepository(db);
+  const failingContextBuilder = {
+    async ensureForGraph(repoId, graph, config) {
+      repository.insertGraphObjectEmbeddings([
+        {
+          repo_id: repoId,
+          object_type: "component",
+          object_id: graph.components[0].id,
+          provider: config.embedding.provider,
+          model: config.embedding.model,
+          dimensions: config.embedding.dimensions,
+          embedding: Buffer.alloc(config.embedding.dimensions * Float32Array.BYTES_PER_ELEMENT),
+        },
+      ]);
+      throw new Error("synthetic embedding failure");
+    },
+  };
+  const failingService = new KnowledgeGraphService(repository, graphContextConfig, failingContextBuilder);
+  failingService.initRepo(repoRef);
+
+  await assert.rejects(
+    failingService.applyProposal(repoRef, proposal),
+    /synthetic embedding failure/,
+  );
+
+  const failedGraph = failingService.readGraph(repoRef);
+  assert.deepEqual(failedGraph.components, []);
+  assert.deepEqual(failedGraph.flows, []);
+  assert.deepEqual(failedGraph.claims, []);
+  assert.deepEqual(failedGraph.sources, []);
+  assert.deepEqual(failedGraph.edges, []);
+
+  for (const table of [
+    "components",
+    "flows",
+    "claims",
+    "sources",
+    "edges",
+    "graph_memberships",
+    "memory_commits",
+    "graph_object_embeddings",
+  ]) {
+    const row = db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get();
+    assert.equal(row.count, 0, `${table} must not retain rows from a failed proposal apply`);
+  }
+
+  const successfulContextBuilder = {
+    async ensureForGraph(_repoId, graph) {
+      const checkedObjects = graph.components.length + graph.flows.length + graph.claims.length;
+      return { checked_objects: checkedObjects, created: 0, reused: checkedObjects };
+    },
+  };
+  const successfulService = new KnowledgeGraphService(repository, graphContextConfig, successfulContextBuilder);
+  await successfulService.applyProposal(repoRef, proposal);
+
+  const successfulGraph = successfulService.readGraph(repoRef);
+  assert.deepEqual(successfulGraph.components.map((component) => component.id), ["component.atomicity"]);
+  assert.deepEqual(successfulGraph.flows.map((flow) => flow.id), ["flow.atomicity"]);
+  assert.deepEqual(successfulGraph.claims.map((claim) => claim.id), ["claim.atomicity"]);
+  assert.deepEqual(successfulGraph.sources.map((source) => source.id), ["source.atomicity"]);
+} finally {
+  db.close();
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log("check-proposal-apply-atomicity: ok");


### PR DESCRIPTION
## Summary

  This PR fixes proposal-apply atomicity when graph-object embedding generation fails.

  Previously, greplica proposal apply persisted the memory commit and proposal records before generating embeddings. If embedding
  generation then failed—for example because the local model could not load or an external embedding request failed—the command
  reported an error even though the proposal had already been written to SQLite.

  The failed proposal could not be safely retried because its graph-object IDs already existed.

  ## Problem

  The proposal-apply path performed these operations in order:

  1. Validate and normalize the proposal.
  2. Create the memory commit.
  3. Persist components, flows, claims, sources, edges, and memberships.
  4. Generate and store graph-object embeddings.
  5. Return a successful result.

  Step 4 can fail independently of SQLite persistence. Because steps 2 and 3 had already committed, an embedding failure left partial
  proposal state behind while reporting the overall operation as failed.

  This could leave:

  - A memory commit from an operation reported as unsuccessful.
  - Components, flows, claims, sources, and edges from the failed apply.
  - Graph memberships associated with the failed commit.
  - Partially generated graph-object embeddings.
  - A proposal that could not be retried because validation detected duplicate IDs.

  ## Root cause

  KnowledgeGraphService.applyProposal() called createMemoryCommit() and createProposalRecords() separately before awaiting
  GraphContextBuilder.ensureForGraph().

  There was no rollback path for proposal data if embedding generation rejected.

  Additionally, memory-commit creation and proposal-record creation were separate persistence operations, so a record-write failure
  could leave an orphan memory commit.

  ## Changes

  ### Make commit and proposal-record creation atomic

  Added SqliteRepository.createMemoryCommitWithProposal().

  This method creates the memory commit and its proposal records within one SQLite transaction. If writing any component, flow, claim,
  source, edge, or membership fails, the entire transaction is rolled back, including the memory commit.

  ### Roll back proposal data after embedding failures

  Added SqliteRepository.rollbackProposalRecords().

  If embedding generation fails after the proposal has been persisted, the service now removes the data created by that apply attempt
  in a compensating SQLite transaction:

  - Graph-object embeddings for the proposal’s components, flows, and claims.
  - Edges.
  - Components.
  - Flows.
  - Claims.
  - Sources.
  - The memory commit and its cascading graph memberships.

  The original embedding error is then rethrown so callers still receive the actual failure.

  ### Avoid orphan commits during anchor fingerprinting

  Code-anchor fingerprints are now computed before creating the memory commit. A fingerprinting failure therefore cannot leave an
  empty or orphaned commit behind.

  ### Add deterministic regression coverage

  Added scripts/check-proposal-apply-atomicity.js and included it in the default npm test chain.

  The regression test injects a context builder that:

  1. Stores an embedding for a newly created graph object.
  2. Throws a synthetic embedding failure.

  It then verifies that:

  - applyProposal() rejects with the embedding error.
  - The visible graph remains empty.
  - No components, flows, claims, sources, or edges remain.
  - No graph memberships or memory commits remain.
  - No graph-object embeddings remain.
  - The exact same proposal can subsequently be applied successfully.

  ## Behavior before this PR

  proposal records persisted
          ↓
  embedding generation fails
          ↓
  command reports failure
          ↓
  proposal data remains in SQLite
          ↓
  retry fails because IDs already exist

  ## Behavior after this PR

  proposal records persisted atomically
          ↓
  embedding generation fails
          ↓
  proposal data and generated embeddings are rolled back
          ↓
  original embedding error is reported
          ↓
  same proposal can be retried safely

  ## Testing

  The following checks pass:

  npm test
  npm run typecheck

  The full test suite includes:

  - Transcript bundle checks.
  - Repository-context checks.
  - Installation-option checks.
  - Graph-view checks.
  - Offline browser graph-view rendering.
  - Proposal validation.
  - Proposal-apply atomicity and retry behavior.
  - BM25 tokenization.
  - Code-anchor drift detection.

  ## Scope

  This PR is limited to proposal-apply failure handling and its regression coverage.

  It does not change:

  - Proposal normalization or validation rules.
  - Successful proposal-apply output.
  - Embedding provider configuration.
  - Retrieval or ranking behavior.
  - The graph schema.
  - Existing proposal formats.