### PR TITLE
fix: reject cyclic graph relationships

### DIFF
--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -190,10 +190,12 @@ export class KnowledgeGraphService {
   private subjectLookup(repoId: string): {
     subjectExists: (type: GraphObjectType, id: string) => boolean;
     subjectType: (id: string) => GraphObjectType | undefined;
+    existingEdges: () => Edge[];
   } {
     return {
       subjectExists: (type, id) => this.repository.subjectExists(repoId, type, id),
       subjectType: (id) => this.repository.subjectType(repoId, id),
+      existingEdges: () => this.repository.readEdges(repoId),
     };
   }
 }

--- a/libs/knowledge-graph/validate-proposal.ts
+++ b/libs/knowledge-graph/validate-proposal.ts
@@ -1,5 +1,5 @@
 import { isAllowedEdge } from "./edge.js";
-import type { EdgeKind } from "./edge.js";
+import type { Edge, EdgeKind } from "./edge.js";
 import type { MemoryCommitProposal, ProposalSubject } from "./proposal.js";
 import type { GraphObjectType } from "./schema.js";
 
@@ -11,8 +11,11 @@ const edgeKinds = new Set(["about", "contains", "touches", "supersedes", "eviden
 const graphObjectTypes = new Set(["component", "flow", "claim", "edge", "source"]);
 const maxCodeAnchorsPerClaim = 3;
 
+type AcyclicRelationshipEdge = Edge & { kind: "contains" | "supersedes" };
+
 export interface ExistingSubjectLookup {
   subjectExists(type: GraphObjectType, id: string): boolean;
+  existingEdges?(): Edge[];
 }
 
 export interface ProposalValidationResult {
@@ -148,7 +151,72 @@ export function validateProposal(
     }
   }
 
+  validateRelationshipCycles(edges, existingSubjects?.existingEdges?.() ?? [], errors);
+
   return { valid: errors.length === 0, errors };
+}
+
+function validateRelationshipCycles(proposalEdges: unknown[], existingEdges: Edge[], errors: string[]): void {
+  const adjacency = new Map<string, Set<string>>();
+  for (const edge of existingEdges) addRelationshipEdge(adjacency, edge);
+
+  for (const value of proposalEdges) {
+    const edge = relationshipEdge(value);
+    if (edge === undefined) continue;
+
+    const from = relationshipNodeKey(edge.kind, edge.from_type, edge.from_id);
+    const to = relationshipNodeKey(edge.kind, edge.to_type, edge.to_id);
+    if (from === to) {
+      errors.push(`Edge ${edge.id} cannot ${relationshipVerb(edge.kind)} itself.`);
+    } else if (hasPath(adjacency, to, from)) {
+      errors.push(`Edge ${edge.id} creates a ${edge.kind} cycle.`);
+    }
+    addRelationshipEdge(adjacency, edge);
+  }
+}
+
+function relationshipEdge(value: unknown): AcyclicRelationshipEdge | undefined {
+  if (!isRecord(value)) return undefined;
+  const kind = value.kind;
+  const fromType = value.from_type;
+  const toType = value.to_type;
+  if (kind !== "contains" && kind !== "supersedes") return undefined;
+  if (fromType !== toType) return undefined;
+  if (kind === "contains" && fromType !== "component" && fromType !== "flow") return undefined;
+  if (kind === "supersedes" && fromType !== "component" && fromType !== "flow" && fromType !== "claim") return undefined;
+  if (!isNonEmptyString(value.id) || !isNonEmptyString(value.from_id) || !isNonEmptyString(value.to_id)) return undefined;
+  return value as unknown as AcyclicRelationshipEdge;
+}
+
+function addRelationshipEdge(adjacency: Map<string, Set<string>>, edge: Edge): void {
+  const relationship = relationshipEdge(edge);
+  if (relationship === undefined) return;
+  const from = relationshipNodeKey(relationship.kind, relationship.from_type, relationship.from_id);
+  const to = relationshipNodeKey(relationship.kind, relationship.to_type, relationship.to_id);
+  const targets = adjacency.get(from) ?? new Set<string>();
+  targets.add(to);
+  adjacency.set(from, targets);
+}
+
+function hasPath(adjacency: Map<string, Set<string>>, start: string, target: string): boolean {
+  const pending = [start];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined || visited.has(current)) continue;
+    if (current === target) return true;
+    visited.add(current);
+    pending.push(...(adjacency.get(current) ?? []));
+  }
+  return false;
+}
+
+function relationshipNodeKey(kind: "contains" | "supersedes", type: GraphObjectType, id: string): string {
+  return `${kind}:${type}:${id}`;
+}
+
+function relationshipVerb(kind: "contains" | "supersedes"): string {
+  return kind === "contains" ? "contain" : "supersede";
 }
 
 function validateEvidenceMetadata(edge: Record<string, unknown>, errors: string[]): void {

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -232,6 +232,11 @@ export class SqliteRepository {
       .all(repoId) as ClaimProvenanceRecord[];
   }
 
+  readEdges(repoId: string): Edge[] {
+    const rows = this.db.prepare("SELECT * FROM edges WHERE repo_id = ?").all(repoId) as EdgeRow[];
+    return deserializeEdges(rows);
+  }
+
   // Baseline anchor fingerprints stored when each claim was written, keyed by
   // claim id then by anchor key. Used by the anchor audit to detect drift.
   readClaimAnchorFingerprints(repoId: string, ids: string[]): Map<string, Record<string, string>> {
@@ -483,10 +488,7 @@ export class SqliteRepository {
     const rows = this.db
       .prepare(`SELECT * FROM edges WHERE repo_id = ? AND id IN (${placeholders(ids)})`)
       .all(repoId, ...ids) as EdgeRow[];
-    return rows.map(({ repo_id: _repoId, metadata, ...row }) => ({
-      ...row,
-      metadata: metadata === null ? undefined : (JSON.parse(metadata) as Record<string, unknown>),
-    }));
+    return deserializeEdges(rows);
   }
 
   private loadByIds<T>(repoId: string, table: string, ids: string[]): T[] {
@@ -508,6 +510,13 @@ function activeSubjectKeys(memberships: MembershipRow[], edges: Edge[]): Set<str
   }
 
   return active;
+}
+
+function deserializeEdges(rows: EdgeRow[]): Edge[] {
+  return rows.map(({ repo_id: _repoId, metadata, ...row }) => ({
+    ...row,
+    metadata: metadata === null ? undefined : (JSON.parse(metadata) as Record<string, unknown>),
+  }));
 }
 
 function selectIds(memberships: MembershipRow[], type: MembershipRow["subject_type"]): string[] {

--- a/scripts/check-proposal-validate.js
+++ b/scripts/check-proposal-validate.js
@@ -64,6 +64,44 @@ const compactEdge = {
 const compactResult = validateProposal(normalizeProposal(compactEdge));
 assert.equal(compactResult.valid, true, `compact edge must stay valid, got: ${JSON.stringify(compactResult.errors)}`);
 
+const selfSupersedes = normalizeProposal({
+  title: "Self supersedes",
+  creates: {
+    claims: [
+      {
+        id: "claim.self_supersedes",
+        kind: "fact",
+        text: "A claim cannot supersede itself.",
+        truth: "unknown",
+        intent: "unknown",
+        supersedes: "claim.self_supersedes",
+      },
+    ],
+  },
+});
+const selfSupersedesResult = validateProposal(selfSupersedes);
+assert.equal(selfSupersedesResult.valid, false, "self-superseding claims must be invalid");
+assert.ok(
+  selfSupersedesResult.errors.some((error) => error.includes("cannot supersede itself")),
+  `expected a self-supersedes error, got: ${JSON.stringify(selfSupersedesResult.errors)}`,
+);
+
+const containsCycle = normalizeProposal({
+  title: "Contains cycle",
+  creates: {
+    components: [
+      { id: "component.cycle_a", name: "Cycle A", contains: "component.cycle_b" },
+      { id: "component.cycle_b", name: "Cycle B", contains: "component.cycle_a" },
+    ],
+  },
+});
+const containsCycleResult = validateProposal(containsCycle);
+assert.equal(containsCycleResult.valid, false, "proposal-local contains cycles must be invalid");
+assert.ok(
+  containsCycleResult.errors.some((error) => error.includes("creates a contains cycle")),
+  `expected a contains-cycle error, got: ${JSON.stringify(containsCycleResult.errors)}`,
+);
+
 const tmp = mkdtempSync(join(tmpdir(), "greplica-proposal-validate-test-"));
 const db = openDatabase(join(tmp, "graph.db"));
 
@@ -85,6 +123,11 @@ try {
     repo_name: "repo-c",
     default_branch: "main",
   };
+  const repoD = {
+    repo_root: join(tmp, "repo-d"),
+    repo_name: "repo-d",
+    default_branch: "main",
+  };
   const repoAProposal = {
     title: "Seed CLI component",
     creates: {
@@ -101,6 +144,7 @@ try {
   const initializedA = service.initRepo(repoA);
   const initializedB = service.initRepo(repoB);
   service.initRepo(repoC);
+  const initializedD = service.initRepo(repoD);
   const memoryCommit = repository.createMemoryCommit({
     scope_id: initializedA.working_scope_id,
     title: "Seed repo A",
@@ -146,6 +190,65 @@ try {
   assert.ok(
     repoBDuplicateResult.errors.includes("component:component.cli already exists."),
     `expected repo B duplicate error, got: ${JSON.stringify(repoBDuplicateResult.errors)}`,
+  );
+
+  const repoDSeed = normalizeProposal({
+    title: "Seed graph relationships",
+    creates: {
+      components: [
+        { id: "component.parent", name: "Parent" },
+        { id: "component.child", name: "Child" },
+      ],
+      claims: [
+        {
+          id: "claim.current",
+          kind: "fact",
+          text: "Current claim.",
+          truth: "unknown",
+          intent: "unknown",
+        },
+        {
+          id: "claim.previous",
+          kind: "fact",
+          text: "Previous claim.",
+          truth: "unknown",
+          intent: "unknown",
+        },
+      ],
+      edges: [
+        { kind: "contains", from: "component.parent", to: "component.child" },
+        { kind: "supersedes", from: "claim.current", to: "claim.previous" },
+      ],
+    },
+  });
+  const repoDCommit = repository.createMemoryCommit({
+    scope_id: initializedD.working_scope_id,
+    title: repoDSeed.title,
+  });
+  repository.createProposalRecords(initializedD.working_scope_id, repoDCommit.id, repoDSeed);
+
+  const storedContainsCycle = await service.validateProposal(repoD, {
+    title: "Reverse stored contains edge",
+    creates: {
+      edges: [{ kind: "contains", from: "component.child", to: "component.parent" }],
+    },
+  });
+  assert.equal(storedContainsCycle.valid, false, "proposals must not close a cycle against a stored contains edge");
+  assert.ok(
+    storedContainsCycle.errors.some((error) => error.includes("creates a contains cycle")),
+    `expected a stored contains-cycle error, got: ${JSON.stringify(storedContainsCycle.errors)}`,
+  );
+
+  const storedSupersedesCycle = await service.validateProposal(repoD, {
+    title: "Reverse stored supersedes edge",
+    creates: {
+      edges: [{ kind: "supersedes", from: "claim.previous", to: "claim.current" }],
+    },
+  });
+  assert.equal(storedSupersedesCycle.valid, false, "proposals must not close a cycle against a stored supersedes edge");
+  assert.ok(
+    storedSupersedesCycle.errors.some((error) => error.includes("creates a supersedes cycle")),
+    `expected a stored supersedes-cycle error, got: ${JSON.stringify(storedSupersedesCycle.errors)}`,
   );
 
   const repoAGraph = service.readGraph(repoA);


### PR DESCRIPTION
## Summary

  Rejects cyclic contains and supersedes relationships during proposal validation.

  Previously, self-references and cycles could pass validation, causing graph objects to become hidden or recursive graph exports to
  fail.

  ## Changes

  - Reject self-referential contains and supersedes edges.
  - Detect cycles created entirely within one proposal.
  - Detect cycles closed against existing repo-scoped edges.
  - Include stored inactive edges so reverse supersession cycles are still caught.
  - Add regression coverage for self-supersession, containment cycles, and stored-edge cycles.

  ## Testing

  npm test
  npm run typecheck

  Both pass.