### PR TITLE
fix: sync graph view dependencies in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "better-sqlite3": "^12.11.1",
+        "chart.js": "4.4.7",
+        "chartjs-plugin-datalabels": "2.2.0",
         "tree-sitter-wasms": "^0.1.13",
         "web-tree-sitter": "^0.24.7"
       },
@@ -530,6 +532,12 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -704,6 +712,27 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
+      "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chownr": {


### PR DESCRIPTION
## Summary

  Synchronizes package-lock.json with the graph-view dependencies already declared in package.json.

  Previously, the lockfile omitted chart.js and chartjs-plugin-datalabels, preventing reproducible clean installs and causing graph-
  view tests to fail with Cannot find module 'chart.js'.

  ## Changes

  - Lock chart.js@4.4.7.
  - Lock chartjs-plugin-datalabels@2.2.0.
  - Lock the required @kurkle/color@0.3.4 transitive dependency.
  - No unrelated dependency versions were changed.

  ## Testing

  npm ci
  npm test
  npm run typecheck

  All pass.