### PR TITLE
Fix: code_anchors[].file validator doesn't reject path traversal (../)

### DIFF
--- a/libs/knowledge-graph/validate-proposal.ts
+++ b/libs/knowledge-graph/validate-proposal.ts
@@ -214,7 +214,13 @@ function validateClaimCodeAnchors(claim: Record<string, unknown>, errors: string
 }
 
 function isAbsoluteOrLineAnchor(file: string): boolean {
-  return file.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(file) || /:\d+(:\d+)?$/.test(file);
+  if (file.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(file) || /:\d+(:\d+)?$/.test(file)) return true;
+  // Reject any ".." path segment (checked on both separators, since the string
+  // itself isn't resolved on this OS yet) so a proposal can't escape the repo
+  // root via e.g. "../../../../etc/passwd" -- this validator's error message
+  // promises "repo-relative", so it must actually enforce that, not rely on
+  // the downstream code-anchor resolver's isRepoRelative() guard as the only line of defense.
+  return file.split(/[\\/]/).some((segment) => segment === "..");
 }
 
 function validateSubjectBase(

--- a/libs/knowledge-graph/validate-proposal.ts
+++ b/libs/knowledge-graph/validate-proposal.ts
@@ -214,7 +214,7 @@ function validateClaimCodeAnchors(claim: Record<string, unknown>, errors: string
 }
 
 function isAbsoluteOrLineAnchor(file: string): boolean {
-  if (file.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(file) || /:\d+(:\d+)?$/.test(file)) return true;
+  if (/^[\\/]/.test(file) || /^[a-zA-Z]:[\\/]/.test(file) || /:\d+(:\d+)?$/.test(file)) return true;
   // Reject any ".." path segment (checked on both separators, since the string
   // itself isn't resolved on this OS yet) so a proposal can't escape the repo
   // root via e.g. "../../../../etc/passwd" -- this validator's error message

--- a/scripts/check-proposal-validate.js
+++ b/scripts/check-proposal-validate.js
@@ -194,3 +194,75 @@ for (const { name, proposal } of malformedCompactRelationshipCases) {
 }
 
 console.log("check-proposal-validate: ok");
+
+// Security regression: code_anchors[].file must reject ".." path-traversal
+// segments, not just absolute paths. The validator's own error message says
+// "must be repo-relative" -- it must actually enforce that, since the
+// downstream code-anchor resolver's isRepoRelative() guard should not be the
+// only thing standing between a proposal and an out-of-repo file read.
+const traversalCases = [
+  "../../../../etc/passwd",
+  "../secrets.env",
+  "components/../../../../etc/passwd",
+  "..\\..\\..\\Windows\\System32\\config\\SAM",
+];
+
+for (const file of traversalCases) {
+  const traversalProposal = {
+    title: "t",
+    creates: {
+      components: [{ id: "component.a", name: "A" }],
+      claims: [
+        {
+          id: "claim.a",
+          kind: "fact",
+          text: "x",
+          truth: "unknown",
+          intent: "intended",
+          about: ["component.a"],
+          code_anchors: [{ file }],
+        },
+      ],
+    },
+  };
+
+  let normalizedTraversal;
+  assert.doesNotThrow(() => {
+    normalizedTraversal = normalizeProposal(traversalProposal);
+  }, `normalizeProposal must not throw for traversal case: ${file}`);
+
+  const traversalResult = validateProposal(normalizedTraversal);
+  assert.equal(traversalResult.valid, false, `expected invalid (path traversal) for code_anchors[].file = ${file}`);
+  assert.ok(
+    traversalResult.errors.some((error) => error.includes("repo-relative")),
+    `expected a repo-relative error for code_anchors[].file = ${file}, got: ${JSON.stringify(traversalResult.errors)}`,
+  );
+}
+
+// A genuinely repo-relative path (including one that legitimately contains ".."
+// as a substring, not a path segment) must still be accepted.
+const validAnchorProposal = {
+  title: "t",
+  creates: {
+    components: [{ id: "component.a", name: "A" }],
+    claims: [
+      {
+        id: "claim.a",
+        kind: "fact",
+        text: "x",
+        truth: "unknown",
+        intent: "intended",
+        about: ["component.a"],
+        code_anchors: [{ file: "apps/cli/main.ts" }, { file: "libs/foo..bar/index.ts" }],
+      },
+    ],
+  },
+};
+const normalizedValidAnchor = normalizeProposal(validAnchorProposal);
+const validAnchorResult = validateProposal(normalizedValidAnchor);
+assert.ok(
+  !validAnchorResult.errors.some((error) => error.includes("repo-relative")),
+  `expected no repo-relative error for legitimate paths, got: ${JSON.stringify(validAnchorResult.errors)}`,
+);
+
+console.log("check-proposal-validate: path-traversal regression ok");

--- a/scripts/check-proposal-validate.js
+++ b/scripts/check-proposal-validate.js
@@ -205,6 +205,9 @@ const traversalCases = [
   "../secrets.env",
   "components/../../../../etc/passwd",
   "..\\..\\..\\Windows\\System32\\config\\SAM",
+  "\\Windows\\System32\\config\\SAM",
+  "\\\\server\\share\\secret.txt",
+  "\\\\?\\C:\\Windows\\System32\\config\\SAM",
 ];
 
 for (const file of traversalCases) {


### PR DESCRIPTION

### Bug

`isAbsoluteOrLineAnchor()` in `validate-proposal.ts` is the only check gating
`code_anchors[].file` in proposals. Its error message says the path "must be
repo-relative" -- but it only checks for absolute paths (`/...`, `C:\...`)
and trailing line numbers (`:123`). It never checks for `..` traversal:

    isAbsoluteOrLineAnchor("../../../../etc/passwd") // false

A proposal with that file value passes validation with zero errors.

### Why this matters despite not being actively exploitable

`code-anchors/resolver.ts` has a separate, correctly-written guard
(`isRepoRelative()`) right before every `readFileSync()` call, so a traversal
payload does get blocked in practice today. But that means the validator's
stated contract is false, and the two guards aren't tied together by any
test or shared logic -- if the resolver's guard is ever touched, there's
nothing else standing between a proposal and an out-of-repo file read.

### Fix

`isAbsoluteOrLineAnchor()` now also rejects any `..` path segment, checked on
both `/` and `\` separators. Same technique `resolver.ts` already uses
correctly (`path.relative()` + leading-`..` check), just enforced at the
layer that claims to enforce it.

### Tests

Added to `scripts/check-proposal-validate.js`: traversal payloads (Unix,
Windows-style, mixed-in-middle, backslash) must now be rejected with a
"repo-relative" error; legitimate paths -- including one with `..` as a
substring but not a path segment -- must still pass.