### PR TITLE
Add claim relevance audit — track retrieval usage, block unsubstantiated unknown claims at write time

### DIFF
--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -5,7 +5,7 @@ import { isatty } from "node:tty";
 import { basename, dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { createLocalKnowledgeGraphService, KnowledgeGraphService } from "../../libs/knowledge-graph/service.js";
-import type { ClaimAnchorAuditResult, RepoRef } from "../../libs/knowledge-graph/service.js";
+import type { ClaimAnchorAuditResult, RelevanceAuditResult, RepoRef } from "../../libs/knowledge-graph/service.js";
 import { envVarSource, loadRepoEnv, type LoadedRepoEnv } from "../../libs/env/load-local-env.js";
 import {
   ensureGreplicaConfig,
@@ -106,6 +106,13 @@ const cliCommands = [
     path: ["graph", "audit", "anchors"],
     usage: "graph audit anchors",
     handler: withCommandContext(runGraphAuditAnchorsCommand),
+    showInTopLevelHelp: true,
+  },
+  {
+    key: "graphAuditRelevance",
+    path: ["graph", "audit", "relevance"],
+    usage: "graph audit relevance [--min-age-days <n>]",
+    handler: withCommandContext(runGraphAuditRelevanceCommand),
     showInTopLevelHelp: true,
   },
   {
@@ -282,6 +289,27 @@ async function runGraphAuditAnchorsCommand(_args: string[], getContext: CommandC
   if (anchorAuditIssueCount(result) > 0) process.exitCode = 1;
 }
 
+function runGraphAuditRelevanceCommand(args: string[], getContext: CommandContextProvider): void {
+  const minAgeDays = parseMinAgeDaysArg(args);
+  const { repo, service } = getContext();
+  const result = service.auditRelevance(repo, minAgeDays === undefined ? undefined : { minAgeDays });
+  printRelevanceAudit(result);
+  // Advisory only, unlike the anchor audit: an unretrieved claim may simply
+  // be rare, correct memory that hasn't come up yet. This never fails the
+  // command; it's a prompt for a human to look, not a build-breaking check.
+}
+
+function parseMinAgeDaysArg(args: string[]): number | undefined {
+  const index = args.indexOf("--min-age-days");
+  if (index === -1) return undefined;
+  const raw = args[index + 1];
+  const value = raw === undefined ? NaN : Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(usage("graphAuditRelevance"));
+  }
+  return value;
+}
+
 function runGraphExportCommand(args: string[], getContext: CommandContextProvider): void {
   const outputDir = requireFile(args[0], usage("graphExport"));
   const { repo, service } = getContext();
@@ -361,6 +389,25 @@ function printAnchorAudit(result: ClaimAnchorAuditResult): void {
   printAuditSection("Missing symbols", result.missing_symbols, (issue) => `${issue.claim_id} -> ${formatAuditAnchor(issue.anchor)}`);
   printAuditSection("Ambiguous symbols", result.ambiguous_symbols, (issue) => `${issue.claim_id} -> ${formatAuditAnchor(issue.anchor)}`);
   printAuditSection("Unsupported languages", result.unsupported_languages, (issue) => `${issue.claim_id} -> ${formatAuditAnchor(issue.anchor)}`);
+}
+
+function printRelevanceAudit(result: RelevanceAuditResult): void {
+  console.log("Relevance audit");
+  console.log("");
+  printAuditSection(
+    "Unsubstantiated, never retrieved (highest-confidence prune candidates)",
+    result.unsubstantiated_never_retrieved,
+    (issue) => `${issue.claim_id} (${formatAuditAgeDays(issue.age_days)}) -> ${issue.text}`,
+  );
+  printAuditSection(
+    "Substantiated, never retrieved (has an anchor or evidence; review before pruning)",
+    result.substantiated_never_retrieved,
+    (issue) => `${issue.claim_id} (${formatAuditAgeDays(issue.age_days)}) -> ${issue.text}`,
+  );
+}
+
+function formatAuditAgeDays(ageDays: number | null): string {
+  return ageDays === null ? "age unknown" : `${Math.floor(ageDays)}d old`;
 }
 
 function anchorAuditIssueCount(result: ClaimAnchorAuditResult): number {

--- a/libs/knowledge-graph/relevance-audit.ts
+++ b/libs/knowledge-graph/relevance-audit.ts
@@ -1,0 +1,94 @@
+import type { Claim } from "./claim.js";
+import type { ClaimId } from "./schema.js";
+import type { Edge } from "./edge.js";
+import type { ClaimRelevanceStats } from "../storage/sqlite/repository.js";
+
+export interface RelevanceAuditOptions {
+  // A claim is only flagged once it has existed for at least this long
+  // without being retrieved, so brand-new memory isn't flagged just because
+  // no agent has queried it yet. Defaults to 30 days.
+  minAgeDays?: number;
+  now?: Date;
+}
+
+export interface RelevanceAuditIssue {
+  claim_id: ClaimId;
+  text: string;
+  created_at: string | null;
+  age_days: number | null;
+  // Whether the claim has any structural backing (a code anchor or an
+  // evidenced_by edge). Claims with neither are the highest-confidence
+  // candidates for pruning: nothing ties them to a verifiable source, and
+  // no future agent has ever needed them.
+  has_anchor: boolean;
+  has_evidence: boolean;
+}
+
+export interface RelevanceAuditResult {
+  // Never retrieved, old enough to judge, and unsubstantiated. Highest
+  // confidence candidates for pruning.
+  unsubstantiated_never_retrieved: RelevanceAuditIssue[];
+  // Never retrieved but backed by an anchor or evidence. Still worth a
+  // human glance, but lower priority: it may simply be narrow/rare memory.
+  substantiated_never_retrieved: RelevanceAuditIssue[];
+}
+
+const defaultMinAgeDays = 30;
+const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+export function auditClaimRelevance(
+  claims: Claim[],
+  edges: Edge[],
+  stats: Map<ClaimId, ClaimRelevanceStats>,
+  options: RelevanceAuditOptions = {},
+): RelevanceAuditResult {
+  const minAgeDays = options.minAgeDays ?? defaultMinAgeDays;
+  const now = options.now ?? new Date();
+
+  const evidencedClaimIds = new Set(
+    edges
+      .filter((edge) => edge.kind === "evidenced_by" && edge.from_type === "claim")
+      .map((edge) => edge.from_id),
+  );
+
+  const unsubstantiated: RelevanceAuditIssue[] = [];
+  const substantiated: RelevanceAuditIssue[] = [];
+
+  for (const claim of claims) {
+    const claimStats = stats.get(claim.id);
+    if (claimStats !== undefined && claimStats.retrieval_count > 0) continue;
+
+    const ageDays = ageInDays(claimStats?.created_at ?? null, now);
+    if (ageDays !== null && ageDays < minAgeDays) continue;
+
+    const hasAnchor = Array.isArray(claim.code_anchors) && claim.code_anchors.length > 0;
+    const hasEvidence = evidencedClaimIds.has(claim.id);
+
+    const issue: RelevanceAuditIssue = {
+      claim_id: claim.id,
+      text: claim.text,
+      created_at: claimStats?.created_at ?? null,
+      age_days: ageDays,
+      has_anchor: hasAnchor,
+      has_evidence: hasEvidence,
+    };
+
+    if (hasAnchor || hasEvidence) {
+      substantiated.push(issue);
+    } else {
+      unsubstantiated.push(issue);
+    }
+  }
+
+  return {
+    unsubstantiated_never_retrieved: unsubstantiated,
+    substantiated_never_retrieved: substantiated,
+  };
+}
+
+function ageInDays(createdAt: string | null, now: Date): number | null {
+  if (createdAt === null) return null;
+  const createdAtMs = Date.parse(createdAt);
+  if (Number.isNaN(createdAtMs)) return null;
+  return (now.getTime() - createdAtMs) / millisecondsPerDay;
+}

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -18,9 +18,11 @@ import { bufferToFloat32Array } from "./graph-context/vector.js";
 import { createEmbedder } from "./graph-context/embedder.js";
 import { buildClaimDocuments } from "./graph-context/documents.js";
 import { findSimilarClaims, type SimilarClaimMatch } from "./dedupe/find-similar-claims.js";
+import { auditClaimRelevance, type RelevanceAuditResult } from "./relevance-audit.js";
 
 export type { GraphContextResult } from "./graph-context/types.js";
 export type { ClaimAnchorAuditResult } from "./code-anchors/types.js";
+export type { RelevanceAuditResult } from "./relevance-audit.js";
 
 export interface RepoRef {
   repo_root?: string;
@@ -127,11 +129,24 @@ export class KnowledgeGraphService {
 
   async contextGraph(input: RepoRef, query: string): Promise<GraphContextResult> {
     const initialized = this.requireRepo(input);
-    return this.contextBuilder.build(initialized.repo_id, this.repository.readGraphView(initialized.repo_id), query, {
-      config: this.contextConfig,
-      warnOnCreatedEmbeddings: true,
-      repoRoot: input.repo_root,
-    });
+    const result = await this.contextBuilder.build(
+      initialized.repo_id,
+      this.repository.readGraphView(initialized.repo_id),
+      query,
+      {
+        config: this.contextConfig,
+        warnOnCreatedEmbeddings: true,
+        repoRoot: input.repo_root,
+      },
+    );
+    // Usefulness can't be judged at write time, only at read time: this is
+    // the one place the system observes a claim actually being useful to an
+    // agent, so the relevance audit has real evidence instead of a guess.
+    this.repository.recordClaimRetrievals(
+      initialized.repo_id,
+      result.claims.map((claim) => claim.object.id),
+    );
+    return result;
   }
 
   async auditCodeAnchors(input: RepoRef): Promise<ClaimAnchorAuditResult> {
@@ -142,6 +157,16 @@ export class KnowledgeGraphService {
       claims.map((claim) => claim.id),
     );
     return auditClaimCodeAnchors(input.repo_root, claims, new CodeAnchorResolver(), baselineFingerprints);
+  }
+
+  auditRelevance(input: RepoRef, options?: { minAgeDays?: number }): RelevanceAuditResult {
+    const initialized = this.requireRepo(input);
+    const graph = this.repository.readGraphView(initialized.repo_id);
+    const stats = this.repository.readClaimRelevanceStats(
+      initialized.repo_id,
+      graph.claims.map((claim) => claim.id),
+    );
+    return auditClaimRelevance(graph.claims, graph.edges, stats, options);
   }
 
   async validateProposal(input: RepoRef, proposal: unknown): Promise<ProposalReviewResult> {

--- a/libs/knowledge-graph/validate-proposal.ts
+++ b/libs/knowledge-graph/validate-proposal.ts
@@ -73,6 +73,15 @@ export function validateProposal(
     if (!isNonEmptyString(flow.name)) errors.push(`Flow ${stringId(flow.id)} needs a name.`);
   }
 
+  const claimIdsWithEvidence = new Set(
+    edges
+      .filter(
+        (edge): edge is Record<string, unknown> =>
+          isRecord(edge) && edge.kind === "evidenced_by" && edge.from_type === "claim" && isNonEmptyString(edge.from_id),
+      )
+      .map((edge) => String(edge.from_id)),
+  );
+
   for (const claim of claims) {
     if (!isRecord(claim)) {
       errors.push("Every claim must be an object.");
@@ -84,6 +93,7 @@ export function validateProposal(
     if (!claimTruths.has(String(claim.truth))) errors.push(`Claim ${stringId(claim.id)} has invalid truth.`);
     if (!claimIntents.has(String(claim.intent))) errors.push(`Claim ${stringId(claim.id)} has invalid intent.`);
     validateClaimCodeAnchors(claim, errors);
+    validateClaimIsSubstantiated(claim, claimIdsWithEvidence, errors);
   }
 
   for (const source of sources) {
@@ -211,6 +221,31 @@ function validateClaimCodeAnchors(claim: Record<string, unknown>, errors: string
     }
     seen.add(key);
   }
+}
+
+// A claim with truth "unknown" that isn't tracking a task/question, and has
+// neither a code anchor nor an evidenced_by edge, has nothing tying it to a
+// verifiable source. This is exactly the "claims based only on vague
+// conversation" case the memory-update instructions ask the agent not to
+// store; enforcing it here means a sloppy or truncated agent run can't
+// silently skip that judgment call.
+function validateClaimIsSubstantiated(
+  claim: Record<string, unknown>,
+  claimIdsWithEvidence: Set<string>,
+  errors: string[],
+): void {
+  if (claim.truth !== "unknown") return;
+  if (claim.kind === "task" || claim.kind === "question") return;
+
+  const anchors = claim.code_anchors;
+  const hasAnchors = Array.isArray(anchors) && anchors.length > 0;
+  const hasEvidence = isNonEmptyString(claim.id) && claimIdsWithEvidence.has(claim.id);
+  if (hasAnchors || hasEvidence) return;
+
+  errors.push(
+    `Claim ${stringId(claim.id)} has truth "unknown" and kind "${String(claim.kind)}" but no code_anchors and no evidenced_by edge: ` +
+      "either attach evidence, add anchors, mark it code_verified/source_verified, or use kind 'task'/'question' for genuinely unresolved items.",
+  );
 }
 
 function isAbsoluteOrLineAnchor(file: string): boolean {

--- a/libs/storage/sqlite/migrate.ts
+++ b/libs/storage/sqlite/migrate.ts
@@ -8,6 +8,7 @@ export function migrate(db: Database.Database): void {
   migrateGraphObjectTables(db);
   migrateSourceMemberships(db);
   migrateClaimAnchorFingerprints(db);
+  migrateClaimRetrievalStats(db);
 }
 
 function migrateReposTable(db: Database.Database): void {
@@ -342,6 +343,30 @@ function migrateClaimAnchorFingerprints(db: Database.Database): void {
   if (columns.some((column) => column.name === "anchor_fingerprints")) return;
   try {
     db.exec("ALTER TABLE claims ADD COLUMN anchor_fingerprints TEXT");
+  } catch (error: unknown) {
+    if (error instanceof Error && /duplicate column name/i.test(error.message)) return;
+    throw error;
+  }
+}
+
+// Tracks, per claim, how many times it has been returned by `graph context`
+// and when it was last returned. Used by the relevance audit to find claims
+// that have never once been useful to a future agent, instead of guessing
+// usefulness at proposal time. Nullable/zero-default: claims written before
+// this column exists start with no retrieval history, which is the correct
+// "never observed as retrieved" state, not an error condition.
+function migrateClaimRetrievalStats(db: Database.Database): void {
+  const columns = db.prepare("PRAGMA table_info(claims)").all() as Array<{ name: string }>;
+  const hasRetrievalCount = columns.some((column) => column.name === "retrieval_count");
+  const hasLastRetrievedAt = columns.some((column) => column.name === "last_retrieved_at");
+  if (hasRetrievalCount && hasLastRetrievedAt) return;
+  try {
+    if (!hasRetrievalCount) {
+      db.exec("ALTER TABLE claims ADD COLUMN retrieval_count INTEGER NOT NULL DEFAULT 0");
+    }
+    if (!hasLastRetrievedAt) {
+      db.exec("ALTER TABLE claims ADD COLUMN last_retrieved_at TEXT");
+    }
   } catch (error: unknown) {
     if (error instanceof Error && /duplicate column name/i.test(error.message)) return;
     throw error;

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -79,6 +79,12 @@ export interface ClaimProvenanceRecord {
   memory_commit_id: string;
 }
 
+export interface ClaimRelevanceStats {
+  retrieval_count: number;
+  last_retrieved_at: string | null;
+  created_at: string | null;
+}
+
 export class SqliteRepository {
   constructor(private readonly db: Database.Database) {}
 
@@ -249,6 +255,60 @@ export class SqliteRepository {
       fingerprints.set(row.id, JSON.parse(row.anchor_fingerprints) as Record<string, string>);
     }
     return fingerprints;
+  }
+
+  // Records that `graph context` returned these claims to an agent. This is
+  // the only positive usefulness signal the system has: instead of guessing
+  // at proposal time whether a claim will matter later, the relevance audit
+  // later asks whether it actually got used.
+  recordClaimRetrievals(repoId: string, claimIds: string[], retrievedAt: string = new Date().toISOString()): void {
+    if (claimIds.length === 0) return;
+    const update = this.db.prepare(
+      `UPDATE claims
+       SET retrieval_count = retrieval_count + 1, last_retrieved_at = ?
+       WHERE repo_id = ? AND id = ?`,
+    );
+    const runAll = this.db.transaction((ids: string[]) => {
+      for (const id of ids) update.run(retrievedAt, repoId, id);
+    });
+    runAll(claimIds);
+  }
+
+  // Retrieval stats plus the earliest known creation time (from graph
+  // membership provenance) for each claim, keyed by claim id. Used by the
+  // relevance audit to find claims that are both old and never retrieved.
+  readClaimRelevanceStats(repoId: string, ids: string[]): Map<string, ClaimRelevanceStats> {
+    const stats = new Map<string, ClaimRelevanceStats>();
+    if (ids.length === 0) return stats;
+
+    const rows = this.db
+      .prepare(
+        `SELECT id, retrieval_count, last_retrieved_at
+         FROM claims
+         WHERE repo_id = ? AND id IN (${placeholders(ids)})`,
+      )
+      .all(repoId, ...ids) as Array<{ id: string; retrieval_count: number; last_retrieved_at: string | null }>;
+
+    const createdAtRows = this.db
+      .prepare(
+        `SELECT gm.subject_id AS claim_id, MIN(mc.created_at) AS created_at
+         FROM graph_memberships gm
+         JOIN memory_commits mc ON mc.id = gm.memory_commit_id
+         JOIN graph_scopes gs ON gs.id = gm.scope_id
+         WHERE gm.subject_type = 'claim' AND gs.repo_id = ? AND gm.subject_id IN (${placeholders(ids)})
+         GROUP BY gm.subject_id`,
+      )
+      .all(repoId, ...ids) as Array<{ claim_id: string; created_at: string | null }>;
+    const createdAtByClaim = new Map(createdAtRows.map((row) => [row.claim_id, row.created_at]));
+
+    for (const row of rows) {
+      stats.set(row.id, {
+        retrieval_count: row.retrieval_count,
+        last_retrieved_at: row.last_retrieved_at,
+        created_at: createdAtByClaim.get(row.id) ?? null,
+      });
+    }
+    return stats;
   }
 
   readGraphView(repoId: string): {

--- a/libs/storage/sqlite/schema.ts
+++ b/libs/storage/sqlite/schema.ts
@@ -52,6 +52,8 @@ CREATE TABLE IF NOT EXISTS claims (
   intent TEXT NOT NULL,
   code_anchors TEXT,
   anchor_fingerprints TEXT,
+  retrieval_count INTEGER NOT NULL DEFAULT 0,
+  last_retrieved_at TEXT,
   PRIMARY KEY(repo_id, id)
 );
 

--- a/scripts/check-relevance-audit-e2e.js
+++ b/scripts/check-relevance-audit-e2e.js
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url);
+const { openDatabase } = await import(new URL("dist/libs/storage/sqlite/db.js", root));
+const { SqliteRepository } = await import(new URL("dist/libs/storage/sqlite/repository.js", root));
+const { KnowledgeGraphService } = await import(new URL("dist/libs/knowledge-graph/service.js", root));
+
+const tmp = mkdtempSync(join(tmpdir(), "greplica-relevance-audit-e2e-"));
+const db = openDatabase(join(tmp, "relevance.db"));
+const repository = new SqliteRepository(db);
+const service = new KnowledgeGraphService(repository, undefined, {
+  ensureForGraph: async () => ({ created: 0, reused: 0, provider: "local", model: "test", dimensions: 0 }),
+});
+
+const repo = { repo_root: join(tmp, "repo"), repo_name: "relevance-e2e", default_branch: "main" };
+const initialized = service.initRepo(repo);
+
+const applyResult = await service.applyProposal(repo, {
+  title: "Seed two unresolved-but-unsubstantiated claims",
+  creates: {
+    claims: [
+      { id: "claim.retrieved", kind: "task", text: "Follow up on retrieval tracking.", truth: "unknown", intent: "unknown" },
+      { id: "claim.not_retrieved", kind: "task", text: "Follow up, never retrieved.", truth: "unknown", intent: "unknown" },
+    ],
+  },
+});
+assert.ok(applyResult.memory_commit_id, "proposal must apply cleanly");
+
+// Backdate both claims' provenance so they clear the default 30-day min age.
+db.prepare(
+  `UPDATE memory_commits SET created_at = '2020-01-01T00:00:00.000Z' WHERE id = ?`,
+).run(applyResult.memory_commit_id);
+
+// Directly exercise the repository-level retrieval recording (this is what
+// contextGraph() calls internally after a graph-context query returns claims).
+repository.recordClaimRetrievals(initialized.repo_id, ["claim.retrieved"]);
+
+const before = repository.readClaimRelevanceStats(initialized.repo_id, ["claim.retrieved", "claim.not_retrieved"]);
+assert.equal(before.get("claim.retrieved").retrieval_count, 1, "retrieval_count must increment");
+assert.ok(before.get("claim.retrieved").last_retrieved_at !== null, "last_retrieved_at must be set");
+assert.equal(before.get("claim.not_retrieved").retrieval_count, 0, "unrelated claim must be untouched");
+
+// Calling it again must increment further, not overwrite.
+repository.recordClaimRetrievals(initialized.repo_id, ["claim.retrieved"]);
+const after = repository.readClaimRelevanceStats(initialized.repo_id, ["claim.retrieved"]);
+assert.equal(after.get("claim.retrieved").retrieval_count, 2, "retrieval_count must accumulate across calls");
+
+const audit = service.auditRelevance(repo);
+const flaggedIds = new Set([
+  ...audit.unsubstantiated_never_retrieved.map((issue) => issue.claim_id),
+  ...audit.substantiated_never_retrieved.map((issue) => issue.claim_id),
+]);
+assert.ok(!flaggedIds.has("claim.retrieved"), "a retrieved claim must not be flagged by the audit");
+assert.ok(flaggedIds.has("claim.not_retrieved"), "an old, never-retrieved, unsubstantiated task claim must be flagged");
+
+console.log("check-relevance-audit-e2e: ok");

--- a/scripts/check-relevance-audit.js
+++ b/scripts/check-relevance-audit.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+
+const root = new URL("..", import.meta.url);
+const { auditClaimRelevance } = await import(new URL("dist/libs/knowledge-graph/relevance-audit.js", root));
+
+const now = new Date("2026-07-14T00:00:00.000Z");
+const oldCreatedAt = "2026-05-01T00:00:00.000Z"; // > 30 days before `now`
+const recentCreatedAt = "2026-07-10T00:00:00.000Z"; // < 30 days before `now`
+
+const claims = [
+  { id: "claim.old_bare", kind: "fact", text: "Old, never retrieved, no anchor, no evidence.", truth: "unknown", intent: "unknown" },
+  {
+    id: "claim.old_anchored",
+    kind: "fact",
+    text: "Old, never retrieved, but has a code anchor.",
+    truth: "code_verified",
+    intent: "intended",
+    code_anchors: [{ file: "libs/example.ts", symbol: "example" }],
+  },
+  { id: "claim.old_evidenced", kind: "decision", text: "Old, never retrieved, but has evidence.", truth: "source_verified", intent: "intended" },
+  { id: "claim.recent_bare", kind: "fact", text: "Recent and never retrieved, but too young to flag.", truth: "unknown", intent: "unknown" },
+  { id: "claim.old_retrieved", kind: "fact", text: "Old but has been retrieved.", truth: "unknown", intent: "unknown" },
+];
+
+const edges = [
+  { id: "edge.1", from_id: "claim.old_evidenced", from_type: "claim", to_id: "source.1", to_type: "source", kind: "evidenced_by" },
+];
+
+const stats = new Map([
+  ["claim.old_bare", { retrieval_count: 0, last_retrieved_at: null, created_at: oldCreatedAt }],
+  ["claim.old_anchored", { retrieval_count: 0, last_retrieved_at: null, created_at: oldCreatedAt }],
+  ["claim.old_evidenced", { retrieval_count: 0, last_retrieved_at: null, created_at: oldCreatedAt }],
+  ["claim.recent_bare", { retrieval_count: 0, last_retrieved_at: null, created_at: recentCreatedAt }],
+  ["claim.old_retrieved", { retrieval_count: 3, last_retrieved_at: "2026-07-12T00:00:00.000Z", created_at: oldCreatedAt }],
+]);
+
+const result = auditClaimRelevance(claims, edges, stats, { now });
+
+assert.deepEqual(
+  result.unsubstantiated_never_retrieved.map((issue) => issue.claim_id),
+  ["claim.old_bare"],
+  `expected only claim.old_bare to be unsubstantiated, got: ${JSON.stringify(result.unsubstantiated_never_retrieved)}`,
+);
+
+const substantiatedIds = result.substantiated_never_retrieved.map((issue) => issue.claim_id).sort();
+assert.deepEqual(
+  substantiatedIds,
+  ["claim.old_anchored", "claim.old_evidenced"],
+  `expected the anchored and evidenced claims to be substantiated-but-unretrieved, got: ${JSON.stringify(substantiatedIds)}`,
+);
+
+const flaggedIds = new Set([
+  ...result.unsubstantiated_never_retrieved.map((issue) => issue.claim_id),
+  ...result.substantiated_never_retrieved.map((issue) => issue.claim_id),
+]);
+assert.ok(!flaggedIds.has("claim.recent_bare"), "a claim younger than min-age-days must not be flagged");
+assert.ok(!flaggedIds.has("claim.old_retrieved"), "a claim that has been retrieved must not be flagged");
+
+// A claim with no known creation time (pre-migration data) still gets
+// evaluated rather than silently skipped forever.
+const unknownAgeResult = auditClaimRelevance(
+  [{ id: "claim.unknown_age", kind: "fact", text: "No provenance row.", truth: "unknown", intent: "unknown" }],
+  [],
+  new Map([["claim.unknown_age", { retrieval_count: 0, last_retrieved_at: null, created_at: null }]]),
+  { now },
+);
+assert.equal(unknownAgeResult.unsubstantiated_never_retrieved.length, 1, "claims with unknown age must still be audited, not skipped");
+assert.equal(unknownAgeResult.unsubstantiated_never_retrieved[0].age_days, null);
+
+console.log("check-relevance-audit: ok");


### PR DESCRIPTION
Problem
Whether a memory claim is worth keeping is currently decided entirely by prose instructions in skills/greplica-update-working-memory/SKILL.md. Nothing in code enforces it: validate-proposal.ts only checks that claim.text is a non-empty string, and the existing dedupe check (find-similar-claims.ts) only catches near-duplicate wording, not low-value-but-unique noise. If the agent writing a proposal ignores or misapplies the skill's judgment calls, there's no backstop before a claim becomes permanent memory.
What this adds

Usage tracking. claims gains retrieval_count / last_retrieved_at. Every graph context query now records which claims it returned — the only real signal for "was this claim ever useful," gathered at read time instead of guessed at write time.
greplica graph audit relevance [--min-age-days <n>] — a new advisory audit (mirrors graph audit anchors) that surfaces claims that are old (30+ days by default), never retrieved, and splits them into unsubstantiated (no anchor, no evidence — high-confidence prune candidates) vs. substantiated (has backing, lower priority, human should still glance at it). Never fails the build; it's a prompt for a human, not a gate.
Write-time validation. validate-proposal.ts now rejects an unknown-truth claim that isn't kind: task/question and has neither code_anchors nor an evidenced_by edge — exactly the "vague conversation" case the skill instructions already say not to store, now enforced structurally rather than by trusting the prompt.

Testing

tsc --noEmit clean.
All existing check scripts still pass (verified against real better-sqlite3, not skipped).
New rule checked against all 10 real unknown-truth claims across evals/cases/**/*.proposal.json fixtures — 0 false positives.
New check-relevance-audit.js (pure logic) and check-relevance-audit-e2e.js (real SQLite round-trip: apply → backdate → record retrieval → audit) both pass.

Not covered / follow-up
The 30-day default threshold is a guess, not tuned against real retrieval data — worth revisiting once this has run against live usage.