### PR TITLE
feat(eval): agent-maintained notes arm for the SWE-chat planning benchmark

### DIFF
--- a/evals/swechat-plan/build-memory.ts
+++ b/evals/swechat-plan/build-memory.ts
@@ -47,7 +47,7 @@ interface CaseConfig {
   };
 }
 
-interface SessionSpec {
+export interface SessionSpec {
   index: number;
   sessionId: string;
   createdAt: string;
@@ -87,7 +87,7 @@ interface Replay {
   edits: ExtractedEdits;
 }
 
-interface ExtractedEdits {
+export interface ExtractedEdits {
   files: Array<{ path: string; original: string; final: string; editCount: number }>;
   warnings: string[];
 }
@@ -416,7 +416,7 @@ function sessionSpecs(context: Context): SessionSpec[] {
   }));
 }
 
-function extractClaudeEdits(transcript: string, repoDirName: string): ExtractedEdits {
+export function extractClaudeEdits(transcript: string, repoDirName: string): ExtractedEdits {
   const states = new Map<string, { original: string; current: string; editCount: number }>();
   const warnings: string[] = [];
   for (const [lineIndex, line] of transcript.split("\n").entries()) {
@@ -461,7 +461,7 @@ function extractClaudeEdits(transcript: string, repoDirName: string): ExtractedE
   };
 }
 
-function claudeTranscriptToMarkdown(transcript: string, spec: SessionSpec): string {
+export function claudeTranscriptToMarkdown(transcript: string, spec: SessionSpec): string {
   const sections = [
     "# Historical SWE-chat Session Transcript",
     "",

--- a/evals/swechat-plan/build-notes.ts
+++ b/evals/swechat-plan/build-notes.ts
@@ -7,7 +7,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   findRepoRoot,
@@ -189,7 +189,9 @@ async function prepareTargetRepo(context: Context): Promise<void> {
   const response = await fetch(`https://codeload.github.com/${context.config.repo.full_name}/tar.gz/${context.config.repo.base_commit}`);
   if (!response.ok) throw new Error(`Failed to download base archive: ${response.status} ${response.statusText}`);
   writeFileSync(archivePath, Buffer.from(await response.arrayBuffer()));
-  const extract = run(["tar", "-xzf", archivePath, "-C", extractDir], context.repoRoot, process.env);
+  // Run tar from the run directory with relative paths: GNU tar interprets
+  // absolute Windows paths ("C:\...") as remote host specs and fails.
+  const extract = run(["tar", "-xzf", relative(context.runDir, archivePath), "-C", relative(context.runDir, extractDir)], context.runDir, process.env);
   if (extract.exit_code !== 0) throw new Error(`Failed to extract base archive: ${extract.stderr ?? extract.stdout ?? ""}`);
   const roots = readdirSync(extractDir, { withFileTypes: true }).filter((entry) => entry.isDirectory());
   if (roots.length !== 1) throw new Error(`Expected one archive root in ${extractDir}, found ${roots.length}`);

--- a/evals/swechat-plan/build-notes.ts
+++ b/evals/swechat-plan/build-notes.ts
@@ -1,0 +1,331 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  findRepoRoot,
+  readJson,
+  run,
+  runOrThrow,
+  timestamp,
+  valueAfter,
+  writeJson,
+} from "../lib/common.js";
+import { runCodexAgent } from "../../libs/agent-runner/codex.js";
+import type { AgentRunResult } from "../../libs/agent-runner/types.js";
+import { loadRepoEnv } from "../../libs/env/load-local-env.js";
+import {
+  claudeTranscriptToMarkdown,
+  extractClaudeEdits,
+  type ExtractedEdits,
+  type SessionSpec,
+} from "./build-memory.js";
+
+interface CaseConfig {
+  case_id: string;
+  dataset: {
+    prior_sessions?: Array<{
+      session_id: string;
+      created_at?: string;
+      checkpoint_id?: string;
+      title?: string;
+    }>;
+    transcript_root?: string;
+  };
+  repo: {
+    full_name: string;
+    base_commit: string;
+  };
+  notes?: {
+    seed_path?: string;
+  };
+}
+
+interface Replay {
+  spec: SessionSpec;
+  transcriptMarkdownPath: string;
+  edits: ExtractedEdits;
+}
+
+interface Args {
+  caseId: string;
+  agentModel?: string;
+  runRoot?: string;
+  fixtureOnly: boolean;
+}
+
+interface Context {
+  repoRoot: string;
+  caseDir: string;
+  runDir: string;
+  targetRepoDir: string;
+  transcriptMarkdownDir: string;
+  codexHomeDir: string;
+  notesRepoPath: string;
+  storedNotesPath: string;
+  storedManifestPath: string;
+  config: CaseConfig;
+}
+
+interface GenerationStep {
+  kind: "bootstrap" | "update";
+  session_id?: string;
+  generation: AgentRunResult;
+  notes_chars: number;
+}
+
+export async function main(argv = process.argv.slice(2), defaultCaseId?: string): Promise<void> {
+  const args = parseArgs(argv, defaultCaseId);
+  const context = prepareRun(args);
+  const model = args.agentModel ?? "gpt-5.5";
+  const replays = prepareReplayArtifacts(context);
+
+  if (args.fixtureOnly) {
+    writeJson(resolve(context.runDir, "manifest.json"), buildManifest(context, model, replays, []));
+    console.log("SWE-chat notes generation fixture prep passed.");
+    console.log(`Run directory: ${context.runDir}`);
+    return;
+  }
+
+  await prepareTargetRepo(context);
+  commitCleanRepoSnapshot(context, `repo snapshot ${context.config.repo.base_commit}`);
+
+  const steps: GenerationStep[] = [];
+  const bootstrap = await runNotesAgent(context, model, bootstrapNotesPrompt(context), "00-bootstrap");
+  steps.push({ kind: "bootstrap", generation: bootstrap, notes_chars: readNotes(context).length });
+  commitCleanRepoSnapshot(context, "bootstrap agent notes");
+
+  for (const replay of replays) {
+    prepareSessionOriginalWorkingTree(context, replay);
+    applyPostSessionWorkingTree(context, replay);
+    const label = `${String(replay.spec.index).padStart(2, "0")}-${replay.spec.sessionId.slice(0, 8)}`;
+    const generation = await runNotesAgent(context, model, updateNotesPrompt(context, replay), label);
+    steps.push({ kind: "update", session_id: replay.spec.sessionId, generation, notes_chars: readNotes(context).length });
+    commitCleanRepoSnapshot(context, `agent notes after session ${replay.spec.sessionId}`);
+  }
+
+  const notes = readNotes(context);
+  if (notes.trim().length === 0) throw new Error(`Notes generation produced an empty ${context.notesRepoPath}.`);
+  mkdirSync(dirname(context.storedNotesPath), { recursive: true });
+  writeFileSync(context.storedNotesPath, notes);
+  const manifest = buildManifest(context, model, replays, steps, notes);
+  writeJson(resolve(context.runDir, "manifest.json"), manifest);
+  writeJson(context.storedManifestPath, manifest);
+
+  console.log("SWE-chat notes generation passed.");
+  console.log(`Run directory: ${context.runDir}`);
+  console.log(`Stored notes: ${context.storedNotesPath}`);
+}
+
+function prepareRun(args: Args): Context {
+  const repoRoot = findRepoRoot(import.meta.url);
+  loadRepoEnv(repoRoot);
+  const caseDir = resolve(repoRoot, "evals/cases", args.caseId);
+  const config = readJson<CaseConfig>(resolve(caseDir, "case.json"));
+  if (config.case_id !== args.caseId) throw new Error(`Unexpected case id in case.json: ${config.case_id}`);
+  const runDir = resolve(args.runRoot ?? resolve(repoRoot, "eval-runs", timestamp(), config.case_id, "build-notes"));
+  mkdirSync(runDir, { recursive: true });
+  const storedNotesPath = resolve(caseDir, config.notes?.seed_path ?? "notes-seeds/agent-notes.md");
+  return {
+    repoRoot,
+    caseDir,
+    runDir,
+    targetRepoDir: resolve(runDir, "target-repo"),
+    transcriptMarkdownDir: resolve(runDir, "transcripts"),
+    codexHomeDir: resolve(runDir, "notes-codex-home"),
+    notesRepoPath: "docs/agent-notes.md",
+    storedNotesPath,
+    storedManifestPath: resolve(dirname(storedNotesPath), "manifest.json"),
+    config,
+  };
+}
+
+function prepareReplayArtifacts(context: Context): Replay[] {
+  mkdirSync(context.transcriptMarkdownDir, { recursive: true });
+  return sessionSpecs(context).map((spec) => {
+    const transcriptPath = resolve(
+      context.repoRoot,
+      context.config.dataset.transcript_root ?? ".context/swechat-data/transcripts",
+      `${spec.sessionId}.jsonl`,
+    );
+    if (!existsSync(transcriptPath)) throw new Error(`Missing transcript: ${transcriptPath}`);
+    const transcript = readFileSync(transcriptPath, "utf8");
+    const transcriptMarkdownPath = resolve(
+      context.transcriptMarkdownDir,
+      `${String(spec.index).padStart(2, "0")}-${spec.sessionId.slice(0, 8)}.messages.md`,
+    );
+    writeFileSync(transcriptMarkdownPath, claudeTranscriptToMarkdown(transcript, spec));
+    const edits = extractClaudeEdits(transcript, repoName(context.config.repo.full_name));
+    if (edits.files.length === 0) edits.warnings.push("no successful file edits reconstructed; replay is transcript-only");
+    return { spec, transcriptMarkdownPath, edits };
+  });
+}
+
+function sessionSpecs(context: Context): SessionSpec[] {
+  const sessions = context.config.dataset.prior_sessions ?? [];
+  if (sessions.length === 0) throw new Error(`Case ${context.config.case_id} has no prior sessions for notes generation.`);
+  return sessions.map((session, index) => ({
+    index: index + 1,
+    sessionId: session.session_id,
+    createdAt: session.created_at ?? "",
+    checkpointId: session.checkpoint_id ?? "",
+    title: session.title ?? "",
+  }));
+}
+
+async function prepareTargetRepo(context: Context): Promise<void> {
+  rmSync(context.targetRepoDir, { recursive: true, force: true });
+  const archivePath = resolve(context.runDir, "base-source.tar.gz");
+  const extractDir = resolve(context.runDir, "base-source");
+  rmSync(extractDir, { recursive: true, force: true });
+  mkdirSync(extractDir, { recursive: true });
+  const response = await fetch(`https://codeload.github.com/${context.config.repo.full_name}/tar.gz/${context.config.repo.base_commit}`);
+  if (!response.ok) throw new Error(`Failed to download base archive: ${response.status} ${response.statusText}`);
+  writeFileSync(archivePath, Buffer.from(await response.arrayBuffer()));
+  const extract = run(["tar", "-xzf", archivePath, "-C", extractDir], context.repoRoot, process.env);
+  if (extract.exit_code !== 0) throw new Error(`Failed to extract base archive: ${extract.stderr ?? extract.stdout ?? ""}`);
+  const roots = readdirSync(extractDir, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+  if (roots.length !== 1) throw new Error(`Expected one archive root in ${extractDir}, found ${roots.length}`);
+  renameSync(resolve(extractDir, roots[0]?.name ?? ""), context.targetRepoDir);
+  runOrThrow(["git", "init", "-q"], context.targetRepoDir);
+  runOrThrow(["git", "remote", "add", "origin", `swechat-eval://${context.config.repo.full_name}`], context.targetRepoDir);
+}
+
+function commitCleanRepoSnapshot(context: Context, message: string): void {
+  runOrThrow(["git", "add", "-A"], context.targetRepoDir);
+  runOrThrow(
+    ["git", "-c", "user.email=swechat-notes@example.invalid", "-c", "user.name=SWE-chat Notes Replay", "commit", "-q", "--allow-empty", "--no-gpg-sign", "-m", message],
+    context.targetRepoDir,
+  );
+}
+
+function prepareSessionOriginalWorkingTree(context: Context, replay: Replay): void {
+  run(["git", "reset", "--hard"], context.targetRepoDir, process.env);
+  run(["git", "clean", "-fd"], context.targetRepoDir, process.env);
+  for (const file of replay.edits.files) writeRepoFile(context.targetRepoDir, file.path, file.original);
+  commitCleanRepoSnapshot(context, `original session file state ${replay.spec.sessionId}`);
+}
+
+function applyPostSessionWorkingTree(context: Context, replay: Replay): void {
+  for (const file of replay.edits.files) writeRepoFile(context.targetRepoDir, file.path, file.final);
+}
+
+async function runNotesAgent(context: Context, model: string, prompt: string, label: string): Promise<AgentRunResult> {
+  mkdirSync(context.codexHomeDir, { recursive: true });
+  const result = await runCodexAgent({
+    cwd: context.targetRepoDir,
+    env: { ...process.env, CODEX_HOME: context.codexHomeDir },
+    model,
+    prompt,
+    transcriptPath: resolve(context.runDir, `${label}-agent-events.jsonl`),
+    finalMessagePath: resolve(context.runDir, `${label}-final-message.txt`),
+  });
+  if (result.exit_code !== 0) throw new Error(`Notes agent failed for ${label} with exit code ${String(result.exit_code)}.`);
+  if (readNotes(context).trim().length === 0) throw new Error(`Notes agent did not write ${context.notesRepoPath} for ${label}.`);
+  return result;
+}
+
+function bootstrapNotesPrompt(context: Context): string {
+  return `You are preparing repository notes for future coding agents.
+
+Task: explore this repository and create ${context.notesRepoPath} (create the docs directory if it is missing) - a single Markdown file of durable engineering notes that a future agent should read before starting a task here.
+
+Guidelines:
+- Capture repo identity, the major components and where they live, key workflows and commands, and important constraints or gotchas.
+- Prefer concrete facts with file paths over vague prose.
+- Keep the file shallow and navigation-focused, not an exhaustive inventory.
+- Do not modify any file other than ${context.notesRepoPath}. Do not commit.
+- Do not use git history, the network, or any external tool.
+
+This is a full ${context.config.repo.full_name} checkout at the benchmark base snapshot.`;
+}
+
+function updateNotesPrompt(context: Context, replay: Replay): string {
+  const changeFact = replay.edits.files.length > 0
+    ? "The historical session's code changes have already been applied to this working tree as uncommitted changes."
+    : "No code edits were reconstructed for this historical session; treat it as transcript-only evidence and do not invent a patch.";
+  return `You are updating repository notes after a completed coding session.
+
+${context.notesRepoPath} contains notes from earlier sessions. The transcript of a historical coding session on this repository is at:
+${replay.transcriptMarkdownPath}
+
+${changeFact}
+
+Task: read the transcript and update ${context.notesRepoPath} with the durable learnings from this session that a future agent should know - decisions, constraints, gotchas, corrected assumptions, and where the relevant code lives.
+
+Guidelines:
+- Edit and reorganize the notes freely, but keep them in this single file.
+- Keep existing notes that are still true; correct anything the session proved wrong.
+- Prefer concrete facts with file paths over session narration.
+- Do not modify any file other than ${context.notesRepoPath}. Do not commit.
+- Do not use git history, the network, or any external tool.`;
+}
+
+function readNotes(context: Context): string {
+  try {
+    return readFileSync(resolve(context.targetRepoDir, context.notesRepoPath), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function buildManifest(context: Context, model: string, replays: Replay[], steps: GenerationStep[], notes?: string) {
+  const chars = notes?.length ?? 0;
+  return {
+    case_id: context.config.case_id,
+    notes_path: relativeSeedPath(context),
+    model,
+    generated_at: new Date().toISOString(),
+    sessions: replays.map((replay) => ({ session_id: replay.spec.sessionId, title: replay.spec.title })),
+    steps: steps.map((step) => ({
+      kind: step.kind,
+      session_id: step.session_id,
+      notes_chars: step.notes_chars,
+      total_tokens: step.generation.total_tokens,
+      tool_calls: step.generation.tool_calls,
+    })),
+    stats: {
+      notes_chars: chars,
+      notes_estimated_tokens: Math.ceil(chars / 4),
+    },
+  };
+}
+
+function relativeSeedPath(context: Context): string {
+  return context.config.notes?.seed_path ?? "notes-seeds/agent-notes.md";
+}
+
+function repoName(fullName: string): string {
+  return fullName.split("/").pop() ?? fullName;
+}
+
+function writeRepoFile(repoDir: string, path: string, content: string): void {
+  const fullPath = resolve(repoDir, path);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content);
+}
+
+function parseArgs(argv: string[], defaultCaseId?: string): Args {
+  const caseId = valueAfter(argv, "--case") ?? defaultCaseId;
+  if (!caseId) throw new Error("Usage: swechat-plan build-notes --case <case-id>");
+  return {
+    caseId,
+    agentModel: valueAfter(argv, "--agent-model"),
+    runRoot: valueAfter(argv, "--run-root"),
+    fixtureOnly: argv.includes("--fixture-only"),
+  };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/evals/swechat-plan/run.ts
+++ b/evals/swechat-plan/run.ts
@@ -25,7 +25,7 @@ import { runCodexAgent } from "../../libs/agent-runner/codex.js";
 import type { AgentRunResult } from "../../libs/agent-runner/types.js";
 import { loadRepoEnv } from "../../libs/env/load-local-env.js";
 
-type RunnerName = "baseline" | "greplica" | "docs";
+type RunnerName = "baseline" | "greplica" | "docs" | "notes";
 type JudgeKey =
   | "is_actionable_engineering_plan"
   | "identifies_relevant_systems"
@@ -58,6 +58,9 @@ interface CaseConfig {
   memory?: {
     manifest_path?: string;
   };
+  notes?: {
+    seed_path?: string;
+  };
 }
 
 interface Args {
@@ -79,6 +82,9 @@ interface RunContext {
   codexHomeDir: string;
   docsMemoryDir: string;
   docsMemoryStatsPath: string;
+  notesSeedPath: string;
+  notesMemoryPath: string;
+  notesMemoryStatsPath: string;
   transcriptPath: string;
   finalPlanPath: string;
   judgeInputPath: string;
@@ -100,6 +106,9 @@ interface TranscriptAudit {
   first_docs_memory_command?: string;
   docs_memory_commands?: string[];
   docs_memory_first_navigation_used?: boolean;
+  first_notes_memory_command?: string;
+  notes_memory_commands?: string[];
+  notes_memory_first_navigation_used?: boolean;
 }
 
 interface DocsMemoryStats {
@@ -110,6 +119,12 @@ interface DocsMemoryStats {
   raw_proposal_chars: number;
   raw_proposal_estimated_tokens: number;
   largest_files: Array<{ path: string; chars: number }>;
+}
+
+interface NotesMemoryStats {
+  path: string;
+  notes_chars: number;
+  notes_estimated_tokens: number;
 }
 
 interface JudgeChecks extends Record<JudgeKey, boolean> {
@@ -152,6 +167,7 @@ export async function main(argv = process.argv.slice(2), defaultCaseId?: string)
 
   const seedCommands = args.runner === "greplica" || args.runner === "docs" ? seedGreplicaMemory(context) : [];
   const docsMemorySetup = args.runner === "docs" ? setupDocsMemory(context) : null;
+  const notesMemorySetup = args.runner === "notes" ? setupNotesMemory(context) : null;
   installToolGuards(context.guardDir, args.runner, context.greplicaCommand);
   const generation = await runPlanningAgent(context, args);
   const changedFiles = changedFilesInRepo(context.targetRepoDir);
@@ -212,6 +228,9 @@ export async function main(argv = process.argv.slice(2), defaultCaseId?: string)
     docs_memory_dir: docsMemorySetup?.stats.directory,
     docs_memory_stats_path: docsMemorySetup === null ? undefined : context.docsMemoryStatsPath,
     docs_memory_stats: docsMemorySetup?.stats,
+    notes_memory_path: notesMemorySetup?.path,
+    notes_memory_stats_path: notesMemorySetup === null ? undefined : context.notesMemoryStatsPath,
+    notes_memory_stats: notesMemorySetup ?? undefined,
     fixture_prep: fixturePrep,
     generation,
     final_plan_path: context.finalPlanPath,
@@ -256,6 +275,9 @@ function prepareRun(args: Args): RunContext {
     codexHomeDir: resolve(runDir, "greplica-setup-codex-home"),
     docsMemoryDir: resolve(runDir, "target-repo", "greplica-memory-docs"),
     docsMemoryStatsPath: resolve(runDir, "docs-memory-stats.json"),
+    notesSeedPath: resolve(caseDir, config.notes?.seed_path ?? "notes-seeds/agent-notes.md"),
+    notesMemoryPath: resolve(runDir, "target-repo", "docs", "agent-notes.md"),
+    notesMemoryStatsPath: resolve(runDir, "notes-memory-stats.json"),
     transcriptPath: resolve(runDir, "agent-events.jsonl"),
     finalPlanPath: resolve(runDir, "final-plan.md"),
     judgeInputPath: resolve(runDir, "judge-input.json"),
@@ -358,6 +380,23 @@ function collectDocsMemoryStats(context: RunContext): DocsMemoryStats {
   };
 }
 
+function setupNotesMemory(context: RunContext): NotesMemoryStats {
+  if (!existsSync(context.notesSeedPath)) {
+    throw new Error(`Notes seed missing: ${context.notesSeedPath}. Generate it with swechat-plan build-notes --case ${context.config.case_id}.`);
+  }
+  const notes = readFileSync(context.notesSeedPath, "utf8");
+  if (notes.trim().length === 0) throw new Error(`Notes seed is empty: ${context.notesSeedPath}`);
+  mkdirSync(dirname(context.notesMemoryPath), { recursive: true });
+  writeFileSync(context.notesMemoryPath, notes);
+  const stats: NotesMemoryStats = {
+    path: relative(context.runDir, context.notesMemoryPath),
+    notes_chars: notes.length,
+    notes_estimated_tokens: Math.ceil(notes.length / 4),
+  };
+  writeJson(context.notesMemoryStatsPath, stats);
+  return stats;
+}
+
 async function runPlanningAgent(context: RunContext, args: Args): Promise<AgentRunResult> {
   return runCodexAgent({
     cwd: context.targetRepoDir,
@@ -387,7 +426,12 @@ function agentPrompt(context: RunContext, runner: RunnerName): string {
 - Treat the docs as navigation context, then verify only the repo files needed for the plan.
 - Do not use Greplica commands.
 - Do not use CodeGraph commands.`
-      : `- Do not use Greplica commands or Greplica memory.
+      : runner === "notes"
+        ? `- Use docs/agent-notes.md as your repo memory map: read it before broad manual exploration.
+- Treat the notes as remembered navigation context rather than final truth, then verify only the repo files needed for the plan.
+- Do not use Greplica commands.
+- Do not use CodeGraph commands.`
+        : `- Do not use Greplica commands or Greplica memory.
 - Do not use CodeGraph commands.`;
   return `You are running a local-only planning benchmark.
 
@@ -448,6 +492,8 @@ function auditTranscript(transcriptPath: string, runner: RunnerName): Transcript
   const greplica_context_commands: string[] = [];
   let first_docs_memory_command: string | undefined;
   const docs_memory_commands: string[] = [];
+  let first_notes_memory_command: string | undefined;
+  const notes_memory_commands: string[] = [];
   for (const [index, line] of readOptional(transcriptPath).split("\n").entries()) {
     if (!line.trim()) continue;
     let event: unknown;
@@ -465,6 +511,10 @@ function auditTranscript(transcriptPath: string, runner: RunnerName): Transcript
         first_docs_memory_command ??= command;
         docs_memory_commands.push(command);
       }
+      if (commandTouchesNotesMemory(command)) {
+        first_notes_memory_command ??= command;
+        notes_memory_commands.push(command);
+      }
       const violation = auditCommand(command, runner);
       if (violation) violations.push(`line ${index + 1}: ${violation}: ${command}`);
     }
@@ -479,6 +529,9 @@ function auditTranscript(transcriptPath: string, runner: RunnerName): Transcript
     first_docs_memory_command,
     docs_memory_commands,
     docs_memory_first_navigation_used: runner === "docs" && first_command !== undefined && commandTouchesDocsMemory(first_command),
+    first_notes_memory_command,
+    notes_memory_commands,
+    notes_memory_first_navigation_used: runner === "notes" && first_command !== undefined && commandTouchesNotesMemory(first_command),
   };
 }
 
@@ -495,6 +548,7 @@ function auditCommand(command: string, runner: RunnerName): string | undefined {
     return "forbidden_codegraph_command";
   }
   if (normalized.includes("greplica-memory-docs") && runner !== "docs") return "forbidden_docs_memory_access";
+  if (normalized.includes("agent-notes.md") && runner !== "notes") return "forbidden_notes_memory_access";
   if (/\bnpx\s+.*codegraph\b/.test(normalized) || /\bnpm\s+(exec|install)\b.*codegraph\b/.test(normalized)) return "forbidden_codegraph_registry_or_setup";
   if (/\bgit\s+(clone|fetch|pull|log|show|reflog|blame|bisect)\b/.test(normalized)) return "forbidden_git_history_or_network";
   if (normalized.includes(".context/swechat") || normalized.includes("judge-input") || normalized.includes("case.json") || normalized.includes("judge.md")) return "hidden_eval_artifact_access";
@@ -504,6 +558,10 @@ function auditCommand(command: string, runner: RunnerName): string | undefined {
 
 function commandTouchesDocsMemory(command: string): boolean {
   return command.toLowerCase().includes("greplica-memory-docs");
+}
+
+function commandTouchesNotesMemory(command: string): boolean {
+  return command.toLowerCase().includes("agent-notes.md");
 }
 
 function commandInvokesTool(command: string, tool: "greplica" | "codegraph"): boolean {
@@ -640,9 +698,9 @@ function extractOutputText(body: Record<string, unknown>): string {
 
 function parseArgs(argv: string[], defaultCaseId?: string): Args {
   const caseId = valueAfter(argv, "--case") ?? defaultCaseId;
-  if (!caseId) throw new Error("Usage: swechat-plan run --case <case-id> --runner baseline|greplica|docs");
+  if (!caseId) throw new Error("Usage: swechat-plan run --case <case-id> --runner baseline|greplica|docs|notes");
   const runner = valueAfter(argv, "--runner") ?? "baseline";
-  if (runner !== "baseline" && runner !== "greplica" && runner !== "docs") throw new Error("Only --runner baseline|greplica|docs is supported.");
+  if (runner !== "baseline" && runner !== "greplica" && runner !== "docs" && runner !== "notes") throw new Error("Only --runner baseline|greplica|docs|notes is supported.");
   return {
     caseId,
     runner,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eval:search-current": "npm run build && node dist/evals/cases/search-current-repo-at-8038fe8/run.js",
     "eval:swechat-plan": "npm run build && node dist/evals/swechat-plan/run.js",
     "eval:swechat-plan-build-memory": "npm run build && node dist/evals/swechat-plan/build-memory.js",
+    "eval:swechat-plan-build-notes": "npm run build && node dist/evals/swechat-plan/build-notes.js",
     "eval:transcript-backfill-insights": "npm run build && node dist/evals/cases/transcript-backfill-insights/run.js --judge openai",
     "eval:claim-dedupe-threshold-calibration": "npm run build && node dist/evals/cases/claim-dedupe-threshold-calibration/run.js",
     "eval:update-working-memory-source-evidence": "npm run build && node dist/evals/cases/update-working-memory-source-evidence-at-0438915/run.js",


### PR DESCRIPTION
Follows up on the Discord thread about the docs-folder comparison for the roadmap benchmark item — builds directly on the SWE-chat planning harness from #139.

## What this adds

A fourth benchmark arm answering "how does Greplica compare with a docs folder maintained by an agent": alongside `baseline`, `greplica`, and the graph-export `docs` arm, `--runner notes` has the planning agent navigate from a `docs/agent-notes.md` that an agent maintained across the **same prior sessions** used to build the Greplica memory seeds.

That gives the benchmark both docs baselines:
- `docs` — Greplica's knowledge exported to markdown (structured memory, flat presentation)
- `notes` — what developers actually do today: an agent keeping its own notes file session by session, no Greplica involved

## How it works

**`evals/swechat-plan/build-notes.ts`** (mirror of `build-memory.ts`): replays the case's prior sessions in chronological order using the same transcript-to-markdown conversion and reconstructed session edits, but instead of writing Greplica proposals the agent maintains a single `agent-notes.md` (bootstrap pass on the base snapshot first, then one update per session). The final notes are stored as a checked-in `notes-seeds/agent-notes.md` plus a manifest with per-step token/size stats, parallel to `memory-seeds/`.

One subtlety: the replay machinery does `git reset --hard && git clean -fd` between sessions, which would delete an untracked notes file — so notes are committed into the replay snapshots after each step.

**`run.ts`**: `--runner notes` copies the case's notes seed to `docs/agent-notes.md` in the target repo, prompts the agent to use it as its memory map (mirroring the docs-arm prompt shape), keeps greplica/codegraph blocked exactly like baseline, and extends the transcript audit: `first_notes_memory_command` / `notes_memory_first_navigation_used` for the notes arm, and a `forbidden_notes_memory_access` violation if any other runner touches the file. Notes size stats (chars / estimated tokens) are recorded next to the docs-arm stats for storage-cost comparison.

**`build-memory.ts`**: only change is exporting the transcript/edit replay helpers so `build-notes` reuses them instead of duplicating ~100 lines.

## Checks run locally

- `npm run typecheck` — clean
- `npm run build` — clean
- `--runner notes --fixture-only` reaches fixture prep; `--runner bogus` rejected with the updated usage line
- `git diff --check` — clean

Honest caveat: I couldn't run the arms end-to-end here — that needs the SWE-chat transcript root (`.context/swechat-data`) and an OpenAI key, and additionally the harness's `tar -C <absolute path>` step doesn't work on Windows (GNU tar treats `C:\...` as a remote host — pre-existing, hits `baseline` the same way; happy to fix separately). Typecheck, build, and the argument/setup paths are verified.

## To produce numbers

1. `npm run eval:swechat-plan-build-notes -- --case <case-id>` once per case (needs transcript root + key) to generate the checked-in `notes-seeds/`
2. `npm run eval:swechat-plan -- --case <case-id> --runner notes`

I can generate and check in the notes seeds for the four #139 cases if you can share the transcript root setup — or if it's easier, run build-notes on your side and I'll take it from there. Also happy to adjust the notes-agent prompts if you want the notes arm handicapped/equipped differently.