### PR TITLE
fix(code-anchors): wire up bundled tree-sitter grammars missing from …

### DIFF
--- a/libs/knowledge-graph/code-anchors/resolver.ts
+++ b/libs/knowledge-graph/code-anchors/resolver.ts
@@ -33,6 +33,8 @@ const wasmByExtension = new Map<string, string>([
   [".cc", "tree-sitter-cpp.wasm"],
   [".cxx", "tree-sitter-cpp.wasm"],
   [".hpp", "tree-sitter-cpp.wasm"],
+  [".hh", "tree-sitter-cpp.wasm"],
+  [".hxx", "tree-sitter-cpp.wasm"],
   [".cs", "tree-sitter-c_sharp.wasm"],
   [".php", "tree-sitter-php.wasm"],
   [".rb", "tree-sitter-ruby.wasm"],
@@ -47,6 +49,13 @@ const wasmByExtension = new Map<string, string>([
   [".sh", "tree-sitter-bash.wasm"],
   [".bash", "tree-sitter-bash.wasm"],
   [".json", "tree-sitter-json.wasm"],
+  [".toml", "tree-sitter-toml.wasm"],
+  [".css", "tree-sitter-css.wasm"],
+  [".html", "tree-sitter-html.wasm"],
+  [".ex", "tree-sitter-elixir.wasm"],
+  [".exs", "tree-sitter-elixir.wasm"],
+  [".sol", "tree-sitter-solidity.wasm"],
+  [".zig", "tree-sitter-zig.wasm"],
 ]);
 
 const cFamilyExtensions = new Set([

--- a/scripts/check-anchor-drift.js
+++ b/scripts/check-anchor-drift.js
@@ -39,4 +39,49 @@ assert.deepEqual(await driftedIds("def foo():\n\n    # returns the threshold\n  
 const noBaseline = await auditClaimCodeAnchors(repo, [claim], new CodeAnchorResolver());
 assert.deepEqual(noBaseline.drifted, []);
 
+// Extensions with a bundled tree-sitter grammar (toml, css, html, ...) must
+// get the same comment-insensitive fingerprint as languages like Python,
+// instead of falling back to whitespace-only normalization.
+async function assertCommentInsensitive(fileName, anchorSymbol, base, commentOnlyEdit, semanticEdit) {
+  const filePath = join(repo, fileName);
+  const anchor = { file: fileName, symbol: anchorSymbol };
+  const drift = { id: `claim.${fileName}`, kind: "fact", text: "value is set", truth: "code_verified", intent: "intended", code_anchors: [anchor] };
+
+  writeFileSync(filePath, base);
+  const baselineFp = new Map([[drift.id, await fingerprintClaimAnchors(repo, [anchor], new CodeAnchorResolver())]]);
+
+  async function driftedFor(variant) {
+    writeFileSync(filePath, variant);
+    const result = await auditClaimCodeAnchors(repo, [drift], new CodeAnchorResolver(), baselineFp);
+    return result.drifted.map((issue) => issue.claim_id);
+  }
+
+  assert.deepEqual(await driftedFor(commentOnlyEdit), [], `${fileName}: comment-only edit should not drift`);
+  assert.deepEqual(await driftedFor(semanticEdit), [drift.id], `${fileName}: real value change should drift`);
+}
+
+await assertCommentInsensitive(
+  "Cargo.toml",
+  undefined,
+  "# threshold\nlimit = 3\n",
+  "# the configured threshold\nlimit = 3\n",
+  "# threshold\nlimit = 8\n",
+);
+
+await assertCommentInsensitive(
+  "theme.css",
+  undefined,
+  "/* threshold */\n.limit { z-index: 3; }\n",
+  "/* the configured threshold */\n.limit { z-index: 3; }\n",
+  "/* threshold */\n.limit { z-index: 8; }\n",
+);
+
+await assertCommentInsensitive(
+  "index.html",
+  undefined,
+  "<!-- threshold -->\n<div data-limit=\"3\"></div>\n",
+  "<!-- the configured threshold -->\n<div data-limit=\"3\"></div>\n",
+  "<!-- threshold -->\n<div data-limit=\"8\"></div>\n",
+);
+
 console.log("check-anchor-drift: ok");

--- a/scripts/check-anchor-drift.js
+++ b/scripts/check-anchor-drift.js
@@ -84,4 +84,40 @@ await assertCommentInsensitive(
   "<!-- threshold -->\n<div data-limit=\"8\"></div>\n",
 );
 
+for (const fileName of ["settings.ex", "settings.exs"]) {
+  await assertCommentInsensitive(
+    fileName,
+    undefined,
+    "# threshold\nlimit = 3\n",
+    "# the configured threshold\nlimit = 3\n",
+    "# threshold\nlimit = 8\n",
+  );
+}
+
+await assertCommentInsensitive(
+  "Limits.sol",
+  undefined,
+  "// threshold\ncontract Limits { uint256 constant LIMIT = 3; }\n",
+  "// the configured threshold\ncontract Limits { uint256 constant LIMIT = 3; }\n",
+  "// threshold\ncontract Limits { uint256 constant LIMIT = 8; }\n",
+);
+
+await assertCommentInsensitive(
+  "limits.zig",
+  undefined,
+  "// threshold\nconst limit: u8 = 3;\n",
+  "// the configured threshold\nconst limit: u8 = 3;\n",
+  "// threshold\nconst limit: u8 = 8;\n",
+);
+
+for (const fileName of ["limits.hh", "limits.hxx"]) {
+  await assertCommentInsensitive(
+    fileName,
+    undefined,
+    "// threshold\nconstexpr int limit = 3;\n",
+    "// the configured threshold\nconstexpr int limit = 3;\n",
+    "// threshold\nconstexpr int limit = 8;\n",
+  );
+}
+
 console.log("check-anchor-drift: ok");


### PR DESCRIPTION
#162 
## What this fixes

`codeSignatureForAnchor` in `libs/knowledge-graph/code-anchors/resolver.ts`
documents a guarantee: comment edits and reformatting should never change
an anchor's drift fingerprint, because the signature is built from the
non-comment tokens of the tree-sitter parse tree. That guarantee only
applied to the ~25 extensions listed in `wasmByExtension`. Everything else
fell through to:

```js
// No grammar available (e.g. Markdown, SQL): fall back to the span text
// with only whitespace normalized.
return normalizeLines(sliceLines(source, startLine, endLine));
```

— whitespace-normalized, but not comment-stripped. So a comment-only edit
in, say, a `Cargo.toml` or `styles.css` anchored by a claim would get
reported as `drifted` by `auditClaimCodeAnchors`, exactly the false
positive the tree-sitter path exists to prevent.

This isn't a "let's add a new dependency" fix — `tree-sitter-wasms`
(already a direct dependency) ships prebuilt grammars for several
extensions that were simply never wired into the map, confirmed via
`npm pack tree-sitter-wasms@0.1.13` and inspecting `package/out/`.

## What this adds

`wasmByExtension` gains:
- `.toml`, `.css`, `.html`
- `.ex` / `.exs` (elixir)
- `.sol` (solidity), `.zig`
- `.hh` / `.hxx` aligned with the cpp grammar already used for `.hpp`
  (previously only `.hpp` got a grammar; `.hh`/`.hxx` silently used the
  comment-sensitive fallback despite being in the same C-family symbol
  fallback set)

## What I verified before including each one

I didn't just check that a grammar loads — I ran comment-only vs.
semantic-value edits through the actual fingerprint path for every
candidate extension. Two were dropped as a result:

- **`.yaml`/`.yml` — excluded.** `tree-sitter-yaml.wasm` in the pinned
  `tree-sitter-wasms@0.1.13` throws `TypeError: resolved is not a
  function` when `parser.parse()` is called, under the pinned
  `web-tree-sitter@0.24.7`. Wiring it up would make `codeSignatureForAnchor`
  return `undefined` for every YAML anchor, which `hasDrifted` treats as
  "not comparable" — i.e. drift detection would silently stop firing for
  YAML entirely. That's worse than today's comment-sensitive fallback, so
  it's left out. Worth its own issue if someone wants to chase the ABI
  mismatch or pin a different grammar build.
- **`.vue` — excluded.** Parses without error, but the embedded
  `<script>` block's JS comments aren't surfaced as `comment`-typed nodes
  by this grammar, so wiring it up wouldn't actually deliver the
  comment-insensitivity this PR is about. Not a regression, just not a
  real fix, so I didn't claim it as one.
- **`.css` — included, with one disclosed gap.** CSS's `integer_value`
  nodes store a unit (e.g. `px`, `%`) as a child but the leading number as
  text on the parent, which the existing leaf-only `collectCodeTokens`
  walker doesn't capture (pre-existing behavior of that walker, not
  introduced here). A unit-suffixed numeric-only edit like
  `width: 3px` -> `width: 8px` won't register as drift in isolation,
  while unitless numbers, colors, selectors, and keywords do. Still a net
  improvement over full comment/whitespace sensitivity, just not airtight
  for that one token shape. The regression test uses `z-index` (a plain
  integer, no unit) to avoid asserting something that isn't true yet.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `node scripts/check-anchor-drift.js` — passes, including new cases for
  `.toml`, `.css`, `.html` covering both "comment-only edit doesn't drift"
  and "real value change does drift"
- Full `npm test` wasn't runnable end-to-end in my environment
  (`check-install-options.js` needs a native `better-sqlite3` build,
  which needs network access I didn't have) — unrelated to this change,
  flagging in case CI surfaces something local run couldn't.

## Scope

Two files only: `resolver.ts` (the fix) and `check-anchor-drift.js` (the
regression coverage). No new dependency, no docs to update (README/docs
don't list a supported-language table anywhere I could find).