### PR TITLE
fix(eval): run tar with relative paths so the SWE-chat harness works on Windows

### DIFF
--- a/evals/swechat-plan/build-memory.ts
+++ b/evals/swechat-plan/build-memory.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   type CommandResult,
@@ -236,7 +236,9 @@ async function prepareTargetRepo(context: Context): Promise<void> {
   const response = await fetch(`https://codeload.github.com/${context.config.repo.full_name}/tar.gz/${context.config.repo.base_commit}`);
   if (!response.ok) throw new Error(`Failed to download base archive: ${response.status} ${response.statusText}`);
   writeFileSync(archivePath, Buffer.from(await response.arrayBuffer()));
-  const extract = run(["tar", "-xzf", archivePath, "-C", extractDir], context.repoRoot, process.env);
+  // Run tar from the run directory with relative paths: GNU tar interprets
+  // absolute Windows paths ("C:\...") as remote host specs and fails.
+  const extract = run(["tar", "-xzf", relative(context.runDir, archivePath), "-C", relative(context.runDir, extractDir)], context.runDir, process.env);
   if (extract.exit_code !== 0) throw new Error(`Failed to extract base archive: ${extract.stderr ?? extract.stdout ?? ""}`);
   const roots = readdirSync(extractDir, { withFileTypes: true }).filter((entry) => entry.isDirectory());
   if (roots.length !== 1) throw new Error(`Expected one archive root in ${extractDir}, found ${roots.length}`);

--- a/evals/swechat-plan/run.ts
+++ b/evals/swechat-plan/run.ts
@@ -277,7 +277,9 @@ async function prepareTargetRepo(context: RunContext): Promise<CommandResult[]> 
   const response = await fetch(`https://codeload.github.com/${context.config.repo.full_name}/tar.gz/${context.config.repo.base_commit}`);
   if (!response.ok) throw new Error(`Failed to download base archive: ${response.status} ${response.statusText}`);
   writeFileSync(archivePath, Buffer.from(await response.arrayBuffer()));
-  const extract = run(["tar", "-xzf", archivePath, "-C", extractDir], context.repoRoot, process.env);
+  // Run tar from the run directory with relative paths: GNU tar interprets
+  // absolute Windows paths ("C:\...") as remote host specs and fails.
+  const extract = run(["tar", "-xzf", relative(context.runDir, archivePath), "-C", relative(context.runDir, extractDir)], context.runDir, process.env);
   if (extract.exit_code !== 0) throw new Error(`Failed to extract base archive: ${extract.stderr ?? extract.stdout ?? ""}`);
   const roots = readdirSync(extractDir, { withFileTypes: true }).filter((entry) => entry.isDirectory());
   if (roots.length !== 1) throw new Error(`Expected one archive root in ${extractDir}, found ${roots.length}`);


### PR DESCRIPTION
While building the notes benchmark arm (#160) I hit the SWE-chat harness failing on Windows at the base-archive extraction step for every runner, including `baseline --fixture-only`:

```
tar: Child returned status 128
tar: Error is not recoverable: exiting now
```

**Cause**: GNU tar interprets absolute Windows paths (`C:\...`) passed to `-f`/`-C` as remote host specs (`host:path`). `prepareTargetRepo` in `run.ts` and `build-memory.ts` passes both the archive path and the extract dir as absolute paths.

**Fix**: invoke tar from the run directory with paths relative to it. No behavior change on Unix; no GNU-specific flags (`--force-local` would break bsdtar on macOS).

**Verified on Windows**: `--runner baseline --fixture-only` now completes ("Fixture prep passed") where it previously crashed at extraction; `npm run typecheck` and `npm run build` clean; `git diff --check` clean.

Note: `scripts/memory-build/collect-repo-snapshot.ts` has the same pattern — left untouched to keep this scoped to the eval harness, happy to fix it there too if wanted.