### PR TITLE
Add managed repository memory support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm audit --omit=dev --audit-level=high

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -4,7 +4,6 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { isatty } from "node:tty";
 import { basename, dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { createLocalKnowledgeGraphService, KnowledgeGraphService } from "../../libs/knowledge-graph/service.js";
 import type { ClaimAnchorAuditResult, RepoRef } from "../../libs/knowledge-graph/service.js";
 import { envVarSource, loadRepoEnv, type LoadedRepoEnv } from "../../libs/env/load-local-env.js";
 import {
@@ -13,7 +12,8 @@ import {
   type EmbeddingConfig,
   type GreplicaConfig,
 } from "../../libs/config/greplica-config.js";
-import { graphContextConfigFromGreplicaConfig } from "../../libs/knowledge-graph/graph-context/config.js";
+import { createGraphMemoryProvider } from "../../libs/knowledge-graph/provider-factory.js";
+import type { GraphMemoryProvider } from "../../libs/knowledge-graph/provider.js";
 import { createEmbedder } from "../../libs/knowledge-graph/graph-context/embedder.js";
 import { renderGraphContextMarkdown } from "../../libs/knowledge-graph/graph-context/render.js";
 import { buildGraphFolderExport } from "../../libs/knowledge-graph/folder-export.js";
@@ -24,18 +24,50 @@ import { installPlatforms, installPlatformUsage } from "../../libs/install/paths
 import type { InstallEmbedding, InstallPlatform } from "../../libs/install/paths.js";
 import { hookCwd, hookEventName, hookSessionId, hookTranscriptPath, readHookInput } from "../../libs/hooks/hook-input.js";
 import { greplicaHookGuidance } from "../../libs/hooks/guidance.js";
-import { HookSessionStore } from "../../libs/hooks/session-state.js";
+import { createLocalAgentRuntimeStore, type LocalAgentRuntimeStore } from "../../libs/hooks/runtime-store.js";
 import { runHookWorker, shouldRunAutoMemoryUpdates, startHookWorker } from "../../libs/hooks/worker.js";
 import { withLocalModelLock } from "../../libs/knowledge-graph/graph-context/local-model-lock.js";
-import { openDatabase } from "../../libs/storage/sqlite/db.js";
-import { SqliteRepository as SqliteKnowledgeGraphRepository } from "../../libs/storage/sqlite/repository.js";
+import { defaultDatabasePath, openDatabase } from "../../libs/storage/sqlite/db.js";
+import { RepoInstallationStore } from "../../libs/install/repo-installation-store.js";
 import { detectRepoContext } from "./repo-context.js";
+import {
+  resolveManagedInstall,
+  runInviteAccept,
+  runInviteList,
+  runInviteRevoke,
+  runLogin,
+  runLogout,
+  runOrgCreate,
+  runOrgInvite,
+  runOrgLeave,
+  runOrgList,
+  runOrgMembers,
+  runOrgRemoveMember,
+  runOrgRole,
+  runRepoAccessDecision,
+  runRepoAccessList,
+  runRepoAccessRequest,
+  runRepoArchive,
+  runRepoConnect,
+  runRepoCreate,
+  runRepoDiscovery,
+  runRepoEnrollGithub,
+  runRepoGithubInstall,
+  runRepoGrantMemoryAdmin,
+  runRepoInviteReader,
+  runRepoLinkGithub,
+  runRepoList,
+  runRepoPublish,
+  runRepoRestore,
+  runRepoRevokeMemoryAdmin,
+  runWhoami,
+} from "./managed-cli.js";
 
 interface CommandContext {
   repo: RepoRef;
   env: LoadedRepoEnv;
   config: GreplicaConfig;
-  service: KnowledgeGraphService;
+  service: GraphMemoryProvider;
 }
 
 type CommandContextProvider = () => CommandContext;
@@ -61,10 +93,55 @@ const cliCommands = [
   {
     key: "install",
     path: ["install"],
-    usage: `install --platform ${installPlatformUsage} --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]`,
+    usage: `install --mode local|managed [--platform ${installPlatformUsage}] [--embedding local|openai] [--managed-repo <id>] [--hooks enabled|disabled] [--auto-memory enabled|disabled]`,
     handler: runInstallCommand,
     showInTopLevelHelp: true,
   },
+  {
+    key: "uninstall",
+    path: ["uninstall"],
+    usage: "uninstall",
+    handler: runUninstallCommand,
+    showInTopLevelHelp: true,
+  },
+  {
+    key: "repoStatus",
+    path: ["repo", "status"],
+    usage: "repo status",
+    handler: runRepoStatusCommand,
+    showInTopLevelHelp: true,
+  },
+  { key: "login", path: ["login"], usage: "login [--api-url <url>]", handler: runLogin, showInTopLevelHelp: true },
+  { key: "logout", path: ["logout"], usage: "logout", handler: runLogout, showInTopLevelHelp: true },
+  { key: "whoami", path: ["whoami"], usage: "whoami", handler: runWhoami, showInTopLevelHelp: true },
+  { key: "orgCreate", path: ["org", "create"], usage: "org create --name <name> [--slug <slug>]", handler: runOrgCreate, showInTopLevelHelp: true },
+  { key: "orgList", path: ["org", "list"], usage: "org list", handler: runOrgList, showInTopLevelHelp: true },
+  { key: "orgInvite", path: ["org", "invite"], usage: "org invite --org <id> --github-user <login>", handler: runOrgInvite, showInTopLevelHelp: true },
+  { key: "orgMembers", path: ["org", "members"], usage: "org members --org <id>", handler: runOrgMembers, showInTopLevelHelp: true },
+  { key: "orgRole", path: ["org", "role"], usage: "org role --org <id> --user <id> --role admin|member|guest", handler: runOrgRole, showInTopLevelHelp: true },
+  { key: "orgRemoveMember", path: ["org", "remove-member"], usage: "org remove-member --org <id> --user <id>", handler: runOrgRemoveMember, showInTopLevelHelp: true },
+  { key: "orgLeave", path: ["org", "leave"], usage: "org leave --org <id>", handler: runOrgLeave, showInTopLevelHelp: true },
+  { key: "inviteList", path: ["invite", "list"], usage: "invite list", handler: runInviteList, showInTopLevelHelp: true },
+  { key: "inviteAccept", path: ["invite", "accept"], usage: "invite accept <id>", handler: runInviteAccept, showInTopLevelHelp: true },
+  { key: "inviteRevoke", path: ["invite", "revoke"], usage: "invite revoke <id>", handler: runInviteRevoke, showInTopLevelHelp: true },
+  { key: "repoCreate", path: ["repo", "create"], usage: "repo create --org <id> --name <name>", handler: runRepoCreate, showInTopLevelHelp: true },
+  { key: "repoList", path: ["repo", "list"], usage: "repo list", handler: runRepoList, showInTopLevelHelp: true },
+  { key: "repoConnect", path: ["repo", "connect"], usage: "repo connect --managed-repo <id> [--confirm-mode-switch] [--confirm-rebind]", handler: runRepoConnect, showInTopLevelHelp: true },
+  { key: "repoRebind", path: ["repo", "rebind"], usage: "repo rebind --managed-repo <id> --confirm-rebind", handler: runRepoConnect, showInTopLevelHelp: true },
+  { key: "repoGithubInstall", path: ["repo", "github-install"], usage: "repo github-install", handler: runRepoGithubInstall, showInTopLevelHelp: true },
+  { key: "repoEnrollGithub", path: ["repo", "enroll-github"], usage: "repo enroll-github --org <id> --installation <id> --github-repo <id> [--name <name>]", handler: runRepoEnrollGithub, showInTopLevelHelp: true },
+  { key: "repoLinkGithub", path: ["repo", "link-github"], usage: "repo link-github --installation <id> --github-repo <id>", handler: runRepoLinkGithub, showInTopLevelHelp: true },
+  { key: "repoArchive", path: ["repo", "archive"], usage: "repo archive", handler: runRepoArchive, showInTopLevelHelp: true },
+  { key: "repoRestore", path: ["repo", "restore"], usage: "repo restore", handler: runRepoRestore, showInTopLevelHelp: true },
+  { key: "repoDiscovery", path: ["repo", "discovery"], usage: "repo discovery --discovery listed|unlisted", handler: runRepoDiscovery, showInTopLevelHelp: true },
+  { key: "repoInviteReader", path: ["repo", "invite-reader"], usage: "repo invite-reader --github-user <login>", handler: runRepoInviteReader, showInTopLevelHelp: true },
+  { key: "repoGrantMemoryAdmin", path: ["repo", "grant-memory-admin"], usage: "repo grant-memory-admin --user <id>", handler: runRepoGrantMemoryAdmin, showInTopLevelHelp: true },
+  { key: "repoRevokeMemoryAdmin", path: ["repo", "revoke-memory-admin"], usage: "repo revoke-memory-admin --user <id>", handler: runRepoRevokeMemoryAdmin, showInTopLevelHelp: true },
+  { key: "repoAccessRequest", path: ["repo", "request-access"], usage: "repo request-access --managed-repo <id>", handler: runRepoAccessRequest, showInTopLevelHelp: true },
+  { key: "repoAccessList", path: ["repo", "access-requests"], usage: "repo access-requests", handler: runRepoAccessList, showInTopLevelHelp: true },
+  { key: "repoAccessApprove", path: ["repo", "approve-access"], usage: "repo approve-access --request <id>", handler: (args) => runRepoAccessDecision(args, "approve"), showInTopLevelHelp: true },
+  { key: "repoAccessDeny", path: ["repo", "deny-access"], usage: "repo deny-access --request <id>", handler: (args) => runRepoAccessDecision(args, "deny"), showInTopLevelHelp: true },
+  { key: "repoPublish", path: ["repo", "publish"], usage: "repo publish --from-local", handler: runRepoPublish, showInTopLevelHelp: true },
   {
     key: "config",
     path: ["config"],
@@ -140,7 +217,7 @@ const cliCommands = [
     key: "sessionMarkMemoryCurrent",
     path: ["session", "mark-memory-current"],
     usage: "session mark-memory-current --session-ref <ref>",
-    handler: withCommandContext(runSessionMarkMemoryCurrent),
+    handler: runSessionMarkMemoryCurrent,
     showInTopLevelHelp: true,
   },
   {
@@ -244,16 +321,67 @@ function isQueryAwareHelpRequest(args: string[]): boolean {
 
 async function runInstallCommand(args: string[]): Promise<void> {
   const options = parseInstallArgs(args);
+  const repo = detectRepoContext();
+  const managed = options.mode === "managed"
+    ? await resolveManagedInstall(repo, options.managedRepoId)
+    : undefined;
+  if (managed?.pending === true) return;
+  if (options.mode === "managed" && managed?.repository === undefined) {
+    throw new Error("Managed installation did not resolve a repository.");
+  }
   const result = await installGreplica({
     ...options,
-    repo: detectRepoContext(),
+    repo,
+    managedRepoId: managed?.repository?.id,
+    managedRole: managed?.repository?.effective_role,
+    managedAccessStatus: managed?.repository?.access_status,
   });
   printInstallResult(result);
 }
 
-function runGraphReadCommand(_args: string[], getContext: CommandContextProvider): void {
-  const { repo, service } = getContext();
-  const graph = service.readGraph(repo);
+function runUninstallCommand(args: string[]): void {
+  if (args.length > 0) throw new Error(usage("uninstall"));
+  const repo = detectRepoContext();
+  const db = openDatabase();
+  try {
+    const installation = new RepoInstallationStore(db).deactivate(repo);
+    console.log(`Deactivated Greplica for ${installation.repoName}.`);
+    console.log("Local graph, sessions, and managed binding were preserved.");
+  } finally {
+    db.close();
+  }
+}
+
+function runRepoStatusCommand(args: string[]): void {
+  if (args.length > 0) throw new Error(usage("repoStatus"));
+  const repo = detectRepoContext();
+  const db = openDatabase();
+  try {
+    const installation = new RepoInstallationStore(db).find(repo);
+    if (installation === undefined) {
+      console.log("Greplica is not installed for this repository.");
+      return;
+    }
+    console.log(`Repository: ${installation.repoName}`);
+    console.log(`Key: ${installation.repoKey}`);
+    console.log(`Status: ${installation.status}`);
+    console.log(`Mode: ${installation.activeMode}`);
+    console.log(`Hooks: ${installation.hooksEnabled ? "enabled" : "disabled"}`);
+    console.log(`Automatic memory updates: ${installation.autoMemoryUpdates ? "enabled" : "disabled"}`);
+    if (installation.managedRepoId !== undefined) console.log(`Managed repository: ${installation.managedRepoId}`);
+    if (installation.managedRole !== undefined) console.log(`Managed role: ${installation.managedRole}`);
+    if (installation.managedAccessStatus !== undefined) console.log(`Managed access: ${installation.managedAccessStatus}`);
+    if (installation.managedAccessRefreshedAt !== undefined) {
+      console.log(`Managed access refreshed: ${installation.managedAccessRefreshedAt}`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+async function runGraphReadCommand(_args: string[], getContext: CommandContextProvider): Promise<void> {
+  const { service } = getContext();
+  const graph = await service.readGraph();
   console.log("Current graph view: main + working");
   printSection("Components", graph.components, (item) => `${named(item)} ${anchor(item)}`.trim());
   printSection("Flows", graph.flows, named);
@@ -266,8 +394,8 @@ async function runGraphContextCommand(args: string[], getContext: CommandContext
   const output = parseGraphContextOutput(args);
   const query = args.filter((arg) => arg !== "--debug").join(" ").trim();
   if (query.length === 0) throw new Error(usage("graphContext"));
-  const { repo, service } = getContext();
-  const result = await service.contextGraph(repo, query);
+  const { service } = getContext();
+  const result = await service.contextGraph(query);
   if (output === "debug") {
     console.log(JSON.stringify(result, null, 2));
   } else {
@@ -276,25 +404,25 @@ async function runGraphContextCommand(args: string[], getContext: CommandContext
 }
 
 async function runGraphAuditAnchorsCommand(_args: string[], getContext: CommandContextProvider): Promise<void> {
-  const { repo, service } = getContext();
-  const result = await service.auditCodeAnchors(repo);
+  const { service } = getContext();
+  const result = await service.auditCodeAnchors();
   printAnchorAudit(result);
   if (anchorAuditIssueCount(result) > 0) process.exitCode = 1;
 }
 
-function runGraphExportCommand(args: string[], getContext: CommandContextProvider): void {
+async function runGraphExportCommand(args: string[], getContext: CommandContextProvider): Promise<void> {
   const outputDir = requireFile(args[0], usage("graphExport"));
-  const { repo, service } = getContext();
-  const files = buildGraphFolderExport(service.readGraph(repo));
+  const { service } = getContext();
+  const files = buildGraphFolderExport(await service.readGraph());
   writeGraphFolderExport(outputDir, files);
   console.log(`Exported current graph view to ${outputDir}`);
   console.log(`Files: ${files.length}`);
 }
 
-function runGraphViewCommand(args: string[], getContext: CommandContextProvider): void {
+async function runGraphViewCommand(args: string[], getContext: CommandContextProvider): Promise<void> {
   const options = parseGraphViewArgs(args);
   const { repo, service } = getContext();
-  const graph = service.readGraph(repo);
+  const graph = await service.readGraph();
   if (graph.components.length === 0) {
     console.log("No components to visualise. Bootstrap memory first.");
     process.exitCode = 1;
@@ -303,7 +431,7 @@ function runGraphViewCommand(args: string[], getContext: CommandContextProvider)
 
   const outputPath = options.outputPath ?? defaultGraphViewOutputPath(repo.repo_name);
   mkdirSync(dirname(outputPath), { recursive: true });
-  const html = service.buildGraphView(repo);
+  const html = await service.buildGraphView();
   writeFileSync(outputPath, html, "utf8");
   console.log(`Wrote graph view to ${outputPath}`);
 
@@ -314,9 +442,9 @@ function runGraphViewCommand(args: string[], getContext: CommandContextProvider)
 
 async function runProposalValidateCommand(args: string[], getContext: CommandContextProvider): Promise<void> {
   const file = requireFile(args[0], usage("proposalValidate"));
-  const { repo, service } = getContext();
+  const { service } = getContext();
   const proposal = readProposal(file);
-  const result = await service.validateProposal(repo, proposal);
+  const result = await service.reviewProposal(proposal);
   if (result.valid) {
     console.log("Proposal is valid.");
     for (const [claimId, matches] of Object.entries(result.duplicate_warnings)) {
@@ -336,9 +464,8 @@ async function runProposalValidateCommand(args: string[], getContext: CommandCon
 async function runProposalApplyCommand(args: string[], getContext: CommandContextProvider): Promise<void> {
   const file = requireFile(args[0], usage("proposalApply"));
   const { repo, service } = getContext();
-  const installed = service.requireRepo(repo);
   const proposal = readProposal(file);
-  const result = await service.applyProposal(repo, proposal);
+  const result = await service.applyProposal(proposal);
   console.log("Applied proposal to working memory.");
   console.log(`Memory commit: ${result.memory_commit_id}`);
   console.log(`Scope: ${result.scope_id}`);
@@ -350,7 +477,7 @@ async function runProposalApplyCommand(args: string[], getContext: CommandContex
   console.log(`Embeddings checked: ${result.embedding_status.checked_objects}`);
   console.log(`Embeddings created: ${result.embedding_status.created}`);
   console.log(`Embeddings reused: ${result.embedding_status.reused}`);
-  markProposalApplyMemoryUpdated(installed.repo_id, proposal);
+  markProposalApplyMemoryUpdated(repo, proposal);
 }
 
 function printAnchorAudit(result: ClaimAnchorAuditResult): void {
@@ -390,7 +517,7 @@ function createCommandContext(): CommandContext {
   const repo = detectRepoContext();
   const env = loadRepoEnv(repo.repo_root ?? process.cwd());
   const config = ensureGreplicaConfig();
-  const service = createLocalKnowledgeGraphService(graphContextConfigFromGreplicaConfig(config));
+  const service = createGraphMemoryProvider(repo, config);
   return { repo, env, config, service };
 }
 
@@ -421,31 +548,24 @@ function runHookIngest(args: string[]): void {
   const cwd = hookCwd(hook) ?? process.cwd();
   const transcriptPath = runner.transcriptPathFromHook?.(hook) ?? hookTranscriptPath(hook);
   const repo = detectRepoContext(cwd);
-  const db = openDatabase();
+  const config = ensureGreplicaConfig();
+  const runtimeStore = createLocalAgentRuntimeStore(config.session);
   try {
-    const repository = new SqliteKnowledgeGraphRepository(db);
-    const service = new KnowledgeGraphService(repository);
-    let installed: ReturnType<KnowledgeGraphService["requireRepo"]>;
-    try {
-      installed = service.requireRepo(repo);
-    } catch {
-      return;
-    }
-    const sessionStore = new HookSessionStore(db);
-    const result = sessionStore.recordHook({
+    const result = runtimeStore.recordHook({
+      repo,
       platform,
-      repoId: installed.repo_id,
       sessionId: hookSessionId(hook),
       transcriptPath,
       cwd,
       eventName,
     });
-    if (shouldRunAutoMemoryUpdates(ensureGreplicaConfig())) startHookWorker();
+    if (result === undefined) return;
+    if (shouldRunAutoMemoryUpdates(result.installation)) startHookWorker();
 
     if (!result.shouldInjectGuidance) return;
     console.log(JSON.stringify(hookGuidanceOutput(platform, greplicaHookGuidance)));
   } finally {
-    db.close();
+    runtimeStore.close();
   }
 }
 
@@ -460,13 +580,13 @@ function hookGuidanceOutput(platform: InstallPlatform, additionalContext: string
   };
 }
 
-function runSessionMarkMemoryCurrent(args: string[], getContext: CommandContextProvider): void {
+function runSessionMarkMemoryCurrent(args: string[]): void {
   const sessionRef = parseRequiredOption(args, "--session-ref", usage("sessionMarkMemoryCurrent"));
-  const { repo, service } = getContext();
-  const installed = service.requireRepo(repo);
-  const db = openDatabase();
+  const repo = detectRepoContext();
+  const config = ensureGreplicaConfig();
+  const runtimeStore = createLocalAgentRuntimeStore(config.session);
   try {
-    const marked = markMemoryCurrentFromSessionRef(new HookSessionStore(db), installed.repo_id, sessionRef);
+    const marked = markMemoryCurrentFromSessionRef(runtimeStore, repo, sessionRef);
     if (marked) {
       console.log("Marked session memory current.");
       return;
@@ -474,7 +594,7 @@ function runSessionMarkMemoryCurrent(args: string[], getContext: CommandContextP
     console.log(`No tracked session matched ${sessionRef}`);
     process.exitCode = 1;
   } finally {
-    db.close();
+    runtimeStore.close();
   }
 }
 
@@ -496,27 +616,22 @@ function runTranscriptBundle(args: string[]): void {
   }
 }
 
-function markProposalApplyMemoryUpdated(repoId: string, proposal: unknown): void {
+function markProposalApplyMemoryUpdated(repo: RepoRef, proposal: unknown): void {
   const sessionRefs = sessionRefsFromProposal(proposal);
   if (sessionRefs.length === 0) return;
 
-  const db = openDatabase();
+  const runtimeStore = createLocalAgentRuntimeStore(ensureGreplicaConfig().session);
   try {
-    const sessionStore = new HookSessionStore(db);
-    for (const sessionRef of sessionRefs) markMemoryCurrentFromSessionRef(sessionStore, repoId, sessionRef);
+    for (const sessionRef of sessionRefs) markMemoryCurrentFromSessionRef(runtimeStore, repo, sessionRef);
   } finally {
-    db.close();
+    runtimeStore.close();
   }
 }
 
-function markMemoryCurrentFromSessionRef(sessionStore: HookSessionStore, repoId: string, sessionRef: string): boolean {
+function markMemoryCurrentFromSessionRef(runtimeStore: LocalAgentRuntimeStore, repo: RepoRef, sessionRef: string): boolean {
   const identity = sessionIdentityFromSourceRef(sessionRef);
   if (identity === undefined) return false;
-  return sessionStore.markMemoryCurrent({
-    repoId,
-    platform: identity.platform,
-    sessionId: identity.sessionId,
-  });
+  return runtimeStore.markMemoryCurrent(repo, identity.platform, identity.sessionId);
 }
 
 function sessionIdentityFromSourceRef(ref: string): { platform: InstallPlatform; sessionId: string } | undefined {
@@ -568,24 +683,18 @@ async function runDoctor(args: string[], getContext: CommandContextProvider): Pr
   console.log(`Remote: ${context.repo.remote_url ?? "none"}`);
   console.log(`Default branch: ${context.repo.default_branch}`);
 
-  try {
-    const result = context.service.requireRepo(context.repo);
-    console.log(`Database: ${result.database_path}`);
-    console.log("Memory state: ready");
-    console.log(`Main scope: ${result.main_scope_id}`);
-    console.log(`Working scope: ${result.working_scope_id}`);
-  } catch (error: unknown) {
-    ready = false;
-    const message = error instanceof Error ? error.message : String(error);
-    console.log(message.startsWith("Greplica is not installed") ? "Memory state: not installed" : "Memory state: failed");
-    console.log(message);
-  }
+  const installation = context.service.installation;
+  console.log(`Database: ${resolve(defaultDatabasePath())}`);
+  console.log("Memory state: ready");
+  console.log(`Mode: ${installation.activeMode}`);
+  if (installation.managedRepoId !== undefined) console.log(`Managed repository: ${installation.managedRepoId}`);
+  if (installation.managedRole !== undefined) console.log(`Managed role: ${installation.managedRole}`);
 
   console.log(`Config: ${displayConfigPath()}`);
-  printEmbeddingConfig(context.config.embedding);
+  if (installation.activeMode === "local") printEmbeddingConfig(context.config.embedding);
   printSessionConfig(context.config.session);
 
-  if (context.config.embedding.provider === "openai") {
+  if (installation.activeMode === "local" && context.config.embedding.provider === "openai") {
     const source = envVarSource("OPENAI_API_KEY", context.env);
     if (source === undefined) {
       ready = false;
@@ -598,7 +707,7 @@ async function runDoctor(args: string[], getContext: CommandContextProvider): Pr
     }
   }
 
-  if (args.includes("--check-embeddings") || args.includes("--check-openai")) {
+  if (installation.activeMode === "local" && (args.includes("--check-embeddings") || args.includes("--check-openai"))) {
     ready = (await checkEmbeddings(context.config.embedding)) && ready;
   }
 
@@ -655,7 +764,8 @@ function runConfigCommand(args: string[]): void {
   console.log("- stopThreshold: run background memory update after this many Stop hooks since memory was current.");
   console.log("- timeThresholdMinutes: run after this much time if the session has activity not covered by current memory.");
   console.log("- currentGraceMinutes: skip time-based updates when memory was marked current close to last activity.");
-  console.log("- autoMemoryUpdates: run background memory updates from hooks. Guidance injection can still run when this is false.");
+  console.log("- hooks and automatic memory updates are configured per repository.");
+  console.log(`Managed API: ${config.managed.apiUrl}`);
   console.log("");
   console.log("Common embedding examples:");
   console.log("- local MPNet base: provider=local, model=all-mpnet-base-v2, dimensions=768, batchSize=16");
@@ -663,14 +773,37 @@ function runConfigCommand(args: string[]): void {
   console.log("- OpenAI small: provider=openai, model=text-embedding-3-small, dimensions=1536, batchSize=100");
 }
 
-function parseInstallArgs(args: string[]): { platform: InstallPlatform; embedding: InstallEmbedding; hooks: boolean; autoMemoryUpdates: boolean } {
+function parseInstallArgs(args: string[]): {
+  mode: "local" | "managed";
+  platform?: InstallPlatform;
+  embedding?: InstallEmbedding;
+  managedRepoId?: string;
+  hooks: boolean;
+  autoMemoryUpdates: boolean;
+  allowModeSwitch: boolean;
+  allowRebind: boolean;
+} {
+  let mode: "local" | "managed" = "local";
+  let modeSeen = false;
   let platform: InstallPlatform | undefined;
   let embedding: InstallEmbedding | undefined;
+  let managedRepoId: string | undefined;
   let hooks: boolean | undefined;
   let autoMemoryUpdates: boolean | undefined;
+  let allowModeSwitch = false;
+  let allowRebind = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (arg === "--mode" || arg.startsWith("--mode=")) {
+      if (modeSeen) throw new Error(`Specify --mode only once.\n${usage("install")}`);
+      const value = arg === "--mode" ? requireFlagValue(args, index, "--mode") : arg.slice("--mode=".length);
+      if (value !== "local" && value !== "managed") throw new Error(`Invalid --mode ${value}.\n${usage("install")}`);
+      mode = value;
+      modeSeen = true;
+      if (arg === "--mode") index += 1;
+      continue;
+    }
     if (arg === "--platform") {
       if (platform !== undefined) throw new Error(`Specify --platform only once.\n${usage("install")}`);
       platform = parseInstallPlatform(requireFlagValue(args, index, "--platform"));
@@ -691,6 +824,22 @@ function parseInstallArgs(args: string[]): { platform: InstallPlatform; embeddin
     if (arg.startsWith("--embedding=")) {
       if (embedding !== undefined) throw new Error(`Specify --embedding only once.\n${usage("install")}`);
       embedding = parseInstallEmbedding(arg.slice("--embedding=".length));
+      continue;
+    }
+    if (arg === "--managed-repo" || arg.startsWith("--managed-repo=")) {
+      if (managedRepoId !== undefined) throw new Error(`Specify --managed-repo only once.\n${usage("install")}`);
+      managedRepoId = arg === "--managed-repo"
+        ? requireFlagValue(args, index, "--managed-repo")
+        : arg.slice("--managed-repo=".length);
+      if (arg === "--managed-repo") index += 1;
+      continue;
+    }
+    if (arg === "--confirm-mode-switch") {
+      allowModeSwitch = true;
+      continue;
+    }
+    if (arg === "--confirm-rebind") {
+      allowRebind = true;
       continue;
     }
     if (arg === "--hooks") {
@@ -718,15 +867,24 @@ function parseInstallArgs(args: string[]): { platform: InstallPlatform; embeddin
     throw new Error(usage("install"));
   }
 
-  if (platform === undefined || embedding === undefined) throw new Error(usage("install"));
+  if (mode === "managed" && embedding !== undefined) {
+    throw new Error(`Managed installations do not accept --embedding.\n${usage("install")}`);
+  }
+  if (mode === "local" && managedRepoId !== undefined) {
+    throw new Error(`--managed-repo requires --mode managed.\n${usage("install")}`);
+  }
   if (hooks === false && autoMemoryUpdates === true) {
     throw new Error(`--auto-memory enabled requires --hooks enabled.\n${usage("install")}`);
   }
   return {
+    mode,
     platform,
-    embedding,
+    embedding: mode === "local" ? (embedding ?? "local") : undefined,
+    managedRepoId,
     hooks: hooks ?? true,
     autoMemoryUpdates: hooks === false ? false : autoMemoryUpdates ?? true,
+    allowModeSwitch,
+    allowRebind,
   };
 }
 
@@ -810,6 +968,7 @@ function parseEnabledFlag(value: string): boolean {
 
 function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>): void {
   console.log(`Installed Greplica for ${platformDisplayName(result.platform)}.`);
+  console.log(`Mode: ${result.mode}.`);
   console.log(`Skills: ${result.skills.length} installed.`);
   if (result.hooks !== undefined) {
     console.log(`Hooks: installed for ${result.hooks.events.join(", ")}.`);
@@ -822,8 +981,13 @@ function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>)
     console.log(`Project rules: ${result.rules.configFiles.join(", ")}`);
     console.log("- note: reload your editor if the new project rule does not appear immediately.");
   }
-  console.log(`Automatic memory updates: ${result.session.autoMemoryUpdates ? "enabled" : "disabled"}.`);
-  console.log(`Embedding: ${result.embedding}.`);
+  if (result.mode === "managed" && result.autoMemoryUpdates && result.installation.managedRole !== "memory_admin") {
+    console.log("Automatic memory updates: enabled when memory_admin access is granted.");
+  } else {
+    console.log(`Automatic memory updates: ${result.autoMemoryUpdates ? "enabled" : "disabled"}.`);
+  }
+  if (result.embedding !== undefined) console.log(`Embedding: ${result.embedding}.`);
+  if (result.installation.managedRepoId !== undefined) console.log(`Managed repository: ${result.installation.managedRepoId}.`);
   console.log(`Config: ${result.configFile}`);
   console.log(`Database: ${result.databasePath}`);
   console.log("");
@@ -839,9 +1003,9 @@ function printInstallResult(result: Awaited<ReturnType<typeof installGreplica>>)
     console.log("");
   }
   console.log("- Ask the agent to use greplica-bootstrap once for repos that do not have memory yet.");
-  if (result.embedding === "local") {
+  if (result.mode === "local" && result.embedding === "local") {
     console.log(`- Optional later: greplica install --platform ${result.platform} --embedding openai`);
-  } else {
+  } else if (result.mode === "local") {
     console.log(`- Optional later: greplica install --platform ${result.platform} --embedding local`);
   }
   for (const note of result.notes) console.log(`- ${note}`);
@@ -868,7 +1032,6 @@ function printSessionConfig(config: GreplicaConfig["session"]): void {
   console.log(`Session stop threshold: ${config.stopThreshold}`);
   console.log(`Session time threshold minutes: ${config.timeThresholdMinutes}`);
   console.log(`Session current grace minutes: ${config.currentGraceMinutes}`);
-  console.log(`Session automatic memory updates: ${config.autoMemoryUpdates ? "enabled" : "disabled"}`);
 }
 
 function displayConfigPath(): string {

--- a/apps/cli/managed-cli.ts
+++ b/apps/cli/managed-cli.ts
@@ -1,0 +1,526 @@
+import { execFileSync, spawn } from "node:child_process";
+import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
+import {
+  deleteManagedCredentials,
+  readManagedCredentials,
+} from "../../libs/config/managed-credentials.js";
+import {
+  ensureGreplicaConfig,
+  updateManagedApiUrl,
+  type GreplicaConfig,
+} from "../../libs/config/greplica-config.js";
+import { RepoInstallationStore } from "../../libs/install/repo-installation-store.js";
+import { ManagedControlClient } from "../../libs/managed/control-client.js";
+import type { ManagedRepository } from "../../libs/managed/protocol.js";
+import { createLocalKnowledgeGraphService, type RepoRef } from "../../libs/knowledge-graph/service.js";
+import { graphContextConfigFromGreplicaConfig } from "../../libs/knowledge-graph/graph-context/config.js";
+import { fingerprintClaimAnchors } from "../../libs/knowledge-graph/code-anchors/fingerprint.js";
+import { openDatabase } from "../../libs/storage/sqlite/db.js";
+import { detectRepoContext } from "./repo-context.js";
+
+export interface ManagedInstallResolution {
+  repository?: ManagedRepository;
+  pending: boolean;
+}
+
+export async function runLogin(args: string[]): Promise<void> {
+  const apiUrl = optional(args, "--api-url");
+  if (apiUrl !== undefined) updateManagedApiUrl(apiUrl);
+  const config = ensureGreplicaConfig();
+  const client = new ManagedControlClient(config);
+  const start = await client.startDeviceLogin();
+  console.log(`Open ${start.verification_uri}`);
+  console.log(`GitHub code: ${start.user_code}`);
+  openUrl(start.verification_uri);
+  const deadline = Date.now() + start.expires_in * 1000;
+  let interval = start.interval;
+  while (Date.now() < deadline) {
+    await sleep(interval * 1000);
+    const poll = await client.pollDeviceLogin(start.device_code);
+    if (poll.status === "pending") {
+      interval = poll.interval;
+      continue;
+    }
+    const previous = readManagedCredentials();
+    if (previous !== undefined && previous.user.id !== poll.user.id) invalidateRoleCache();
+    client.setAuthenticatedUser(poll);
+    console.log(`Logged in as ${poll.user.github_login}.`);
+    return;
+  }
+  throw new Error("GitHub device login expired. Run 'greplica login' again.");
+}
+
+export function runLogout(args: string[]): void {
+  requireNoArgs(args, "Usage: greplica logout");
+  deleteManagedCredentials();
+  console.log("Logged out of managed Greplica on this machine.");
+}
+
+export async function runWhoami(args: string[]): Promise<void> {
+  requireNoArgs(args, "Usage: greplica whoami");
+  const { user } = await controlClient().whoami();
+  console.log(`${user.github_login} (${user.github_user_id})`);
+  console.log(`Managed user: ${user.id}`);
+}
+
+export async function runOrgCreate(args: string[]): Promise<void> {
+  const organization = await controlClient().createOrg(required(args, "--name"), optional(args, "--slug"));
+  printOrganization(organization);
+}
+
+export async function runOrgList(args: string[]): Promise<void> {
+  requireNoArgs(args, "Usage: greplica org list");
+  for (const organization of await controlClient().listOrgs()) printOrganization(organization);
+}
+
+export async function runOrgInvite(args: string[]): Promise<void> {
+  const invitation = await controlClient().inviteOrgMember(required(args, "--org"), required(args, "--github-user"));
+  console.log(`Invitation ${invitation.id} targets ${invitation.target_github_login}.`);
+}
+
+export async function runOrgMembers(args: string[]): Promise<void> {
+  const members = await controlClient().listOrgMembers(required(args, "--org"));
+  for (const member of members) console.log(`${member.user.github_login}\t${member.role}\t${member.user.id}`);
+}
+
+export async function runOrgRole(args: string[]): Promise<void> {
+  const role = required(args, "--role");
+  if (role !== "admin" && role !== "member" && role !== "guest") throw new Error("--role must be admin, member, or guest.");
+  const member = await controlClient().updateOrgRole(required(args, "--org"), required(args, "--user"), role);
+  console.log(`${member.user.github_login} is now ${member.role}.`);
+}
+
+export async function runOrgRemoveMember(args: string[]): Promise<void> {
+  const result = await controlClient().removeOrgMember(required(args, "--org"), required(args, "--user"));
+  console.log(result.removed ? "Organization member removed." : "Organization member was not present.");
+}
+
+export async function runOrgLeave(args: string[]): Promise<void> {
+  const result = await controlClient().leaveOrg(required(args, "--org"));
+  console.log(result.removed ? "Left organization." : "Organization membership was not present.");
+}
+
+export async function runInviteList(args: string[]): Promise<void> {
+  requireNoArgs(args, "Usage: greplica invite list");
+  for (const invite of await controlClient().listInvites()) {
+    console.log(`${invite.id}\t${invite.kind}\t${invite.repo_id ?? invite.org_id}\t${invite.target_github_login}`);
+  }
+}
+
+export async function runInviteAccept(args: string[]): Promise<void> {
+  const invite = await controlClient().acceptInvite(requiredPositional(args, "Usage: greplica invite accept <id>"));
+  console.log(`Accepted ${invite.kind} invitation ${invite.id}.`);
+}
+
+export async function runInviteRevoke(args: string[]): Promise<void> {
+  const invite = await controlClient().revokeInvite(requiredPositional(args, "Usage: greplica invite revoke <id>"));
+  console.log(`Revoked invitation ${invite.id}.`);
+}
+
+export async function runRepoCreate(args: string[]): Promise<void> {
+  printRepository(await controlClient().createGenericRepo(required(args, "--org"), required(args, "--name")));
+}
+
+export async function runRepoList(args: string[]): Promise<void> {
+  requireNoArgs(args, "Usage: greplica repo list");
+  for (const repository of await controlClient().listRepos()) printRepository(repository);
+}
+
+export async function runRepoConnect(args: string[]): Promise<void> {
+  const managedRepoId = required(args, "--managed-repo");
+  const allowModeSwitch = args.includes("--confirm-mode-switch");
+  const allowRebind = args.includes("--confirm-rebind");
+  const client = controlClient();
+  const repository = (await client.listRepos()).find((candidate) => candidate.id === managedRepoId);
+  if (repository === undefined) throw new Error("Managed repository is not accessible.");
+  const repo = detectRepoContext();
+  const db = openDatabase();
+  try {
+    const store = new RepoInstallationStore(db);
+    const existing = store.find(repo);
+    if (existing === undefined) throw new Error("Run 'greplica install --mode managed' before connecting this folder.");
+    const installation = store.activateManaged(repo, {
+      managedRepoId: repository.id,
+      managedRole: repository.effective_role,
+      managedAccessStatus: repository.access_status,
+      hooksEnabled: existing.hooksEnabled,
+      autoMemoryUpdates: existing.autoMemoryUpdates,
+      allowModeSwitch,
+      allowRebind,
+    });
+    console.log(`Connected ${installation.repoName} to ${repository.name} (${repository.id}).`);
+  } finally {
+    db.close();
+  }
+}
+
+export async function runRepoArchive(args: string[]): Promise<void> {
+  printRepository(await controlClient().archiveRepo(repoBinding().managedRepoId));
+}
+
+export async function runRepoRestore(args: string[]): Promise<void> {
+  printRepository(await controlClient().restoreRepo(repoBinding().managedRepoId));
+}
+
+export async function runRepoDiscovery(args: string[]): Promise<void> {
+  const discovery = required(args, "--discovery");
+  if (discovery !== "listed" && discovery !== "unlisted") throw new Error("--discovery must be listed or unlisted.");
+  printRepository(await controlClient().setDiscovery(repoBinding().managedRepoId, discovery));
+}
+
+export async function runRepoGithubInstall(args: string[]): Promise<void> {
+  requireNoArgs(args, "Usage: greplica repo github-install");
+  const installationId = await completeGithubInstallation(controlClient());
+  console.log(`GitHub App installation ${installationId} connected.`);
+}
+
+async function completeGithubInstallation(client: ManagedControlClient): Promise<string> {
+  const start = await client.startGithubInstallation();
+  console.log(`Open ${start.url}`);
+  openUrl(start.url);
+  const deadline = Date.now() + 15 * 60 * 1000;
+  while (Date.now() < deadline) {
+    await sleep(2000);
+    const poll = await client.pollGithubInstallation(start.setup_id);
+    if (poll.status === "pending") continue;
+    return poll.installation_id;
+  }
+  throw new Error("GitHub App installation expired. Start it again.");
+}
+
+export async function runRepoEnrollGithub(args: string[]): Promise<void> {
+  printRepository(await controlClient().enrollGithubRepo(
+    required(args, "--org"),
+    required(args, "--installation"),
+    required(args, "--github-repo"),
+    optional(args, "--name"),
+  ));
+}
+
+export async function runRepoLinkGithub(args: string[]): Promise<void> {
+  const binding = repoBinding();
+  printRepository(await controlClient().linkGithubRepo(
+    binding.managedRepoId,
+    required(args, "--installation"),
+    required(args, "--github-repo"),
+  ));
+}
+
+export async function runRepoInviteReader(args: string[]): Promise<void> {
+  const invite = await controlClient().inviteRepoReader(repoBinding().managedRepoId, required(args, "--github-user"));
+  console.log(`Reader invitation ${invite.id} targets ${invite.target_github_login}.`);
+}
+
+export async function runRepoGrantMemoryAdmin(args: string[]): Promise<void> {
+  const grant = await controlClient().grantRepoRole(repoBinding().managedRepoId, required(args, "--user"), "memory_admin");
+  console.log(`${grant.user.github_login} is now memory_admin for this memory.`);
+}
+
+export async function runRepoRevokeMemoryAdmin(args: string[]): Promise<void> {
+  const result = await controlClient().revokeRepoRole(repoBinding().managedRepoId, required(args, "--user"), "memory_admin");
+  console.log(result.revoked ? "memory_admin grant revoked." : "No memory_admin grant existed.");
+}
+
+export async function runRepoAccessRequest(args: string[]): Promise<void> {
+  const request = await controlClient().requestAccess(required(args, "--managed-repo"));
+  console.log(`Access request ${request.id} is ${request.status}.`);
+}
+
+export async function runRepoAccessList(args: string[]): Promise<void> {
+  for (const request of await controlClient().listAccessRequests(repoBinding().managedRepoId)) {
+    console.log(`${request.id}\t${request.status}\t${request.user.github_login}\t${request.user.id}`);
+  }
+}
+
+export async function runRepoAccessDecision(args: string[], decision: "approve" | "deny"): Promise<void> {
+  const request = await controlClient().decideAccessRequest(
+    repoBinding().managedRepoId,
+    required(args, "--request"),
+    decision,
+  );
+  console.log(`Access request ${request.id} is ${request.status}.`);
+}
+
+export async function runRepoPublish(args: string[]): Promise<void> {
+  if (!args.includes("--from-local")) throw new Error("Usage: greplica repo publish --from-local");
+  const repo = detectRepoContext();
+  const binding = repoBinding(repo);
+  const config = ensureGreplicaConfig();
+  const service = createLocalKnowledgeGraphService(graphContextConfigFromGreplicaConfig(config));
+  try {
+    const graph = service.readGraph(repo);
+    const auditResult = await service.auditCodeAnchors(repo);
+    const errors = auditResult.missing_anchors.length + auditResult.missing_files.length + auditResult.missing_symbols.length +
+      auditResult.ambiguous_symbols.length + auditResult.unsupported_languages.length;
+    if (errors > 0) throw new Error("Local memory has invalid code anchors. Run 'greplica graph audit anchors' before publishing.");
+    const fingerprints: Record<string, Record<string, string>> = {};
+    for (const claim of graph.claims) {
+      if (claim.code_anchors === undefined || claim.code_anchors.length === 0) continue;
+      const values = await fingerprintClaimAnchors(repo.repo_root, claim.code_anchors);
+      if (Object.keys(values).length > 0) fingerprints[claim.id] = values;
+    }
+    const result = await controlClient(config).importLocalGraph(
+      binding.managedRepoId,
+      graph,
+      { result: auditResult, fingerprints },
+      gitState(repo.repo_root),
+    );
+    console.log("Published one local memory snapshot into managed main memory.");
+    console.log(JSON.stringify(result, null, 2));
+  } finally {
+    service.close();
+  }
+}
+
+export async function resolveManagedInstall(
+  repo: RepoRef,
+  requestedId?: string,
+): Promise<ManagedInstallResolution> {
+  await ensureAuthenticated();
+  const client = controlClient();
+  const accessible = await client.listRepos();
+  if (requestedId !== undefined) {
+    const repository = accessible.find((candidate) => candidate.id === requestedId);
+    if (repository !== undefined) return { repository, pending: false };
+    const invites = await client.listInvites();
+    const invite = invites.find((candidate) => candidate.repo_id === requestedId);
+    if (invite !== undefined) {
+      if (!stdin.isTTY) throw new Error("Accept the targeted invitation first with 'greplica invite accept'.");
+      if (await confirm(`Accept reader invitation for ${requestedId}?`)) {
+        await client.acceptInvite(invite.id);
+        return resolveManagedInstall(repo, requestedId);
+      }
+    }
+    throw new Error("Requested managed repository is not accessible.");
+  }
+
+  if (!stdin.isTTY) throw new Error("Non-interactive managed installation requires --managed-repo.");
+  const github = await publicGithubIdentity(repo.remote_url);
+  if (github !== undefined) {
+    const matches = await client.connectRepos(github.id, github.parentId);
+    const accessibleIds = new Set(accessible.map((candidate) => candidate.id));
+    const accessibleMatches = matches.filter((candidate) => accessibleIds.has(candidate.id));
+    if (accessibleMatches.length === 1) return { repository: accessibleMatches[0], pending: false };
+    if (accessibleMatches.length > 1) {
+      return { repository: await chooseRepository(accessibleMatches), pending: false };
+    }
+    const invites = await client.listInvites();
+    const invitedMatches = matches.filter((candidate) => invites.some((invite) => invite.repo_id === candidate.id));
+    if (invitedMatches.length > 0) {
+      const pending = invitedMatches.length === 1
+        ? invitedMatches[0]
+        : await chooseRepository(invitedMatches);
+      const invite = invites.find((candidate) => candidate.repo_id === pending.id);
+      if (invite !== undefined && await confirm(`Accept reader invitation for ${pending.name}?`)) {
+        await client.acceptInvite(invite.id);
+        return resolveManagedInstall(repo, pending.id);
+      }
+    }
+    const requestable = matches.filter((candidate) => !invitedMatches.some((invited) => invited.id === candidate.id));
+    if (requestable.length > 0) {
+      const pending = requestable.length === 1
+        ? requestable[0]
+        : await chooseRepository(requestable);
+      if (await confirm(`Request reader access to ${pending.name}?`)) {
+        const request = await client.requestAccess(pending.id);
+        console.log(`Access request ${request.id} is pending; no local repository state was created.`);
+        return { pending: true };
+      }
+    }
+  }
+
+  if (accessible.length > 0) {
+    const selected = await chooseRepository(accessible, true);
+    if (selected !== undefined) return { repository: selected, pending: false };
+  }
+
+  const coordinates = githubCoordinates(repo.remote_url);
+  if (coordinates !== undefined && await confirm(`Enroll GitHub memory for ${coordinates.owner}/${coordinates.repo}?`)) {
+    const organization = await chooseOrCreateAdminOrganization(client);
+    const installationId = await completeGithubInstallation(client);
+    const githubRepositoryId = github?.parentId ?? github?.id ?? await prompt("GitHub numeric repository ID: ");
+    if (githubRepositoryId.length === 0) throw new Error("GitHub repository ID is required for enrollment.");
+    return {
+      repository: await client.enrollGithubRepo(organization.id, installationId, githubRepositoryId, repo.repo_name),
+      pending: false,
+    };
+  }
+
+  if (await confirm("Create a generic managed memory now?")) {
+    const organization = await chooseOrCreateAdminOrganization(client);
+    const name = await prompt(`Memory name [${repo.repo_name}]: `) || repo.repo_name;
+    return { repository: await client.createGenericRepo(organization.id, name), pending: false };
+  }
+  throw new Error("No accessible managed memory was found. Ask an org admin for an invite or enroll a repository.");
+}
+
+function controlClient(config: GreplicaConfig = ensureGreplicaConfig()): ManagedControlClient {
+  return new ManagedControlClient(config);
+}
+
+async function ensureAuthenticated(): Promise<void> {
+  try {
+    await controlClient().whoami();
+  } catch (error: unknown) {
+    if (error instanceof Error && /not authenticated|invalid or expired/i.test(error.message)) {
+      await runLogin([]);
+      return;
+    }
+    throw error;
+  }
+}
+
+function repoBinding(repo = detectRepoContext()): { managedRepoId: string } {
+  const db = openDatabase();
+  try {
+    const installation = new RepoInstallationStore(db).find(repo);
+    if (installation?.managedRepoId === undefined) throw new Error("This repository has no managed memory binding.");
+    return { managedRepoId: installation.managedRepoId };
+  } finally {
+    db.close();
+  }
+}
+
+async function publicGithubIdentity(remoteUrl: string | undefined): Promise<{ id: string; parentId?: string } | undefined> {
+  const coordinates = githubCoordinates(remoteUrl);
+  if (coordinates === undefined) return undefined;
+  try {
+    const response = await fetch(`https://api.github.com/repos/${coordinates.owner}/${coordinates.repo}`, {
+      headers: { accept: "application/vnd.github+json", "user-agent": "greplica-cli" },
+    });
+    if (!response.ok) return undefined;
+    const value = await response.json() as { id?: number; parent?: { id?: number } };
+    if (typeof value.id !== "number") return undefined;
+    return { id: String(value.id), parentId: typeof value.parent?.id === "number" ? String(value.parent.id) : undefined };
+  } catch {
+    return undefined;
+  }
+}
+
+function githubCoordinates(remoteUrl: string | undefined): { owner: string; repo: string } | undefined {
+  if (remoteUrl === undefined) return undefined;
+  const match = remoteUrl.match(/github\.com[/:]([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  return match === null ? undefined : { owner: match[1], repo: match[2] };
+}
+
+function chooseRepository(repositories: ManagedRepository[]): Promise<ManagedRepository>;
+function chooseRepository(repositories: ManagedRepository[], allowCreation: true): Promise<ManagedRepository | undefined>;
+async function chooseRepository(
+  repositories: ManagedRepository[],
+  allowCreation = false,
+): Promise<ManagedRepository | undefined> {
+  console.log("Available managed memory:");
+  repositories.forEach((repository, index) => console.log(`${index + 1}. ${repository.name} (${repository.id})`));
+  if (allowCreation) console.log(`${repositories.length + 1}. Create or enroll another memory`);
+  const index = Number(await prompt("Select memory: ")) - 1;
+  if (allowCreation && index === repositories.length) return undefined;
+  const selected = repositories[index];
+  if (selected === undefined) throw new Error("Invalid managed memory selection.");
+  return selected;
+}
+
+async function chooseOrCreateAdminOrganization(client: ManagedControlClient): Promise<{ id: string; name: string }> {
+  const organizations = (await client.listOrgs()).filter((organization) => organization.role === "admin");
+  if (organizations.length === 1) return organizations[0];
+  if (organizations.length > 1) {
+    organizations.forEach((organization, index) => console.log(`${index + 1}. ${organization.name} (${organization.id})`));
+    console.log(`${organizations.length + 1}. Create organization`);
+    const index = Number(await prompt("Select organization: ")) - 1;
+    if (index >= 0 && index < organizations.length) return organizations[index];
+    if (index !== organizations.length) throw new Error("Invalid organization selection.");
+  } else if (!await confirm("Create an organization for this memory?")) {
+    throw new Error("Organization admin access is required to create managed memory.");
+  }
+  const name = await prompt("Organization name: ");
+  if (name.length === 0) throw new Error("Organization name is required.");
+  return client.createOrg(name);
+}
+
+async function confirm(question: string): Promise<boolean> {
+  return /^(y|yes)$/i.test(await prompt(`${question} [y/N] `));
+}
+
+async function prompt(question: string): Promise<string> {
+  const readline = createInterface({ input: stdin, output: stdout });
+  try {
+    return (await readline.question(question)).trim();
+  } finally {
+    readline.close();
+  }
+}
+
+function required(args: string[], name: string): string {
+  const value = optional(args, name);
+  if (value === undefined) throw new Error(`Missing ${name}.`);
+  return value;
+}
+
+function optional(args: string[], name: string): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === name) {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("--")) throw new Error(`Missing value for ${name}.`);
+      return value;
+    }
+    if (args[index]?.startsWith(`${name}=`)) return args[index]?.slice(name.length + 1);
+  }
+  return undefined;
+}
+
+function requiredPositional(args: string[], usage: string): string {
+  const value = args.find((arg) => !arg.startsWith("--"));
+  if (value === undefined) throw new Error(usage);
+  return value;
+}
+
+function requireNoArgs(args: string[], usage: string): void {
+  if (args.length > 0) throw new Error(usage);
+}
+
+function printOrganization(organization: { id: string; name: string; slug: string; role: string }): void {
+  console.log(`${organization.name}\t${organization.role}\t${organization.id}\t${organization.slug}`);
+}
+
+function printRepository(repository: ManagedRepository): void {
+  const source = repository.github_source?.full_name ?? "generic";
+  console.log(`${repository.name}\t${repository.effective_role}\t${repository.access_status}\t${repository.id}\t${source}`);
+}
+
+function openUrl(url: string): void {
+  const command = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    child.unref();
+  } catch {}
+}
+
+function invalidateRoleCache(): void {
+  const db = openDatabase();
+  try {
+    new RepoInstallationStore(db).invalidateManagedRoleCache();
+  } finally {
+    db.close();
+  }
+}
+
+function gitState(repoRoot: string | undefined): { git_head?: string; branch?: string; dirty?: boolean } | undefined {
+  if (repoRoot === undefined) return undefined;
+  const git = (args: string[]) => {
+    try {
+      return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    } catch {
+      return undefined;
+    }
+  };
+  const gitHead = git(["rev-parse", "HEAD"]);
+  const branch = git(["branch", "--show-current"]);
+  const status = git(["status", "--porcelain"]);
+  if (gitHead === undefined && branch === undefined && status === undefined) return undefined;
+  return { git_head: gitHead || undefined, branch: branch || undefined, dirty: status !== undefined && status.length > 0 };
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/libs/config/greplica-config.ts
+++ b/libs/config/greplica-config.ts
@@ -12,16 +12,20 @@ export interface EmbeddingConfig {
 }
 
 export interface GreplicaConfig {
-  version: 1;
+  version: 2;
   embedding: EmbeddingConfig;
   session: SessionConfig;
+  managed: ManagedServerConfig;
 }
 
 export interface SessionConfig {
   stopThreshold: number;
   timeThresholdMinutes: number;
   currentGraceMinutes: number;
-  autoMemoryUpdates: boolean;
+}
+
+export interface ManagedServerConfig {
+  apiUrl: string;
 }
 
 export interface EmbeddingConfigInput {
@@ -50,13 +54,13 @@ export const defaultSessionConfig: SessionConfig = {
   stopThreshold: 7,
   timeThresholdMinutes: 40,
   currentGraceMinutes: 5,
-  autoMemoryUpdates: true,
 };
 
 export const defaultGreplicaConfig: GreplicaConfig = {
-  version: 1,
+  version: 2,
   embedding: { ...embeddingDefaults.local },
   session: { ...defaultSessionConfig },
+  managed: { apiUrl: "https://api.greplica.com" },
 };
 
 export function defaultEmbeddingConfig(provider: EmbeddingProvider): EmbeddingConfig {
@@ -72,7 +76,10 @@ export function ensureGreplicaConfig(path = greplicaConfigPath()): GreplicaConfi
     writeGreplicaConfig(defaultGreplicaConfig, path);
     return cloneConfig(defaultGreplicaConfig);
   }
-  return readGreplicaConfig(path);
+  const config = readGreplicaConfig(path);
+  const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (!isRecord(raw) || raw.version !== 2) writeGreplicaConfig(config, path);
+  return config;
 }
 
 export function readGreplicaConfig(path = greplicaConfigPath()): GreplicaConfig {
@@ -98,7 +105,7 @@ export function updateEmbeddingConfig(input: EmbeddingConfigInput, path = grepli
   const existing = readGreplicaConfig(path);
   const base = defaultEmbeddingConfig(input.provider);
   const config: GreplicaConfig = {
-    version: 1,
+    version: 2,
     embedding: {
       ...base,
       model: input.model ?? base.model,
@@ -106,6 +113,7 @@ export function updateEmbeddingConfig(input: EmbeddingConfigInput, path = grepli
       batchSize: input.batchSize ?? base.batchSize,
     },
     session: existing.session,
+    managed: existing.managed,
   };
   writeGreplicaConfig(config, path);
   return config;
@@ -114,7 +122,9 @@ export function updateEmbeddingConfig(input: EmbeddingConfigInput, path = grepli
 function normalizeConfig(value: unknown, path: string): GreplicaConfig {
   if (!isRecord(value)) throw new Error(`Invalid Greplica config at ${path}: expected an object.`);
   const version = value.version === undefined ? 1 : value.version;
-  if (version !== 1) throw new Error(`Invalid Greplica config at ${path}: unsupported version ${String(version)}.`);
+  if (version !== 1 && version !== 2) {
+    throw new Error(`Invalid Greplica config at ${path}: unsupported version ${String(version)}.`);
+  }
 
   const embeddingValue = value.embedding;
   if (!isRecord(embeddingValue)) {
@@ -127,9 +137,10 @@ function normalizeConfig(value: unknown, path: string): GreplicaConfig {
   const dimensions = parsePositiveInteger(embeddingValue.dimensions, defaults.dimensions, "embedding.dimensions", path);
   const batchSize = parsePositiveInteger(embeddingValue.batchSize, defaults.batchSize, "embedding.batchSize", path);
   const session = normalizeSessionConfig(value.session, path);
+  const managed = normalizeManagedConfig(value.managed, path);
 
   return {
-    version: 1,
+    version: 2,
     embedding: {
       provider,
       model,
@@ -137,6 +148,7 @@ function normalizeConfig(value: unknown, path: string): GreplicaConfig {
       batchSize,
     },
     session,
+    managed,
   };
 }
 
@@ -157,7 +169,14 @@ function normalizeSessionConfig(value: unknown, path: string): SessionConfig {
       "session.currentGraceMinutes",
       path,
     ),
-    autoMemoryUpdates: parseBoolean(value.autoMemoryUpdates, defaultSessionConfig.autoMemoryUpdates, "session.autoMemoryUpdates", path),
+  };
+}
+
+function normalizeManagedConfig(value: unknown, path: string): ManagedServerConfig {
+  if (value === undefined) return { ...defaultGreplicaConfig.managed };
+  if (!isRecord(value)) throw new Error(`Invalid Greplica config at ${path}: managed must be an object.`);
+  return {
+    apiUrl: parseString(value.apiUrl, defaultGreplicaConfig.managed.apiUrl, "managed.apiUrl", path).replace(/\/+$/, ""),
   };
 }
 
@@ -179,12 +198,6 @@ function parsePositiveInteger(value: unknown, fallback: number, field: string, p
   throw new Error(`Invalid Greplica config at ${path}: ${field} must be a positive integer.`);
 }
 
-function parseBoolean(value: unknown, fallback: boolean, field: string, path: string): boolean {
-  if (value === undefined) return fallback;
-  if (typeof value === "boolean") return value;
-  throw new Error(`Invalid Greplica config at ${path}: ${field} must be a boolean.`);
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -194,5 +207,19 @@ function cloneConfig(config: GreplicaConfig): GreplicaConfig {
     version: config.version,
     embedding: { ...config.embedding },
     session: { ...config.session },
+    managed: { ...config.managed },
   };
+}
+
+export function updateManagedApiUrl(apiUrl: string, path = greplicaConfigPath()): GreplicaConfig {
+  const trimmed = apiUrl.trim().replace(/\/+$/, "");
+  if (trimmed.length === 0) throw new Error("Managed API URL must be non-empty.");
+  const config = readGreplicaConfig(path);
+  config.managed.apiUrl = trimmed;
+  writeGreplicaConfig(config, path);
+  return config;
+}
+
+export function managedApiUrl(config: GreplicaConfig): string {
+  return (process.env.GREPLICA_MANAGED_API_URL ?? config.managed.apiUrl).replace(/\/+$/, "");
 }

--- a/libs/config/managed-credentials.ts
+++ b/libs/config/managed-credentials.ts
@@ -1,0 +1,73 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { greplicaHome } from "./greplica-home.js";
+
+export interface ManagedUserIdentity {
+  id: string;
+  githubLogin: string;
+  githubUserId: string;
+}
+
+export interface ManagedCredentials {
+  version: 1;
+  token: string;
+  user: ManagedUserIdentity;
+}
+
+export function managedCredentialsPath(): string {
+  return join(greplicaHome(), "credentials.json");
+}
+
+export function managedToken(credentials = readManagedCredentials()): string | undefined {
+  return process.env.GREPLICA_MANAGED_TOKEN ?? process.env.GREPLICA_API_TOKEN ?? credentials?.token;
+}
+
+export function readManagedCredentials(path = managedCredentialsPath()): ManagedCredentials | undefined {
+  if (!existsSync(path)) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error: unknown) {
+    throw new Error(`Invalid Greplica credentials at ${path}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!isRecord(parsed) || parsed.version !== 1 || typeof parsed.token !== "string" || !isRecord(parsed.user)) {
+    throw new Error(`Invalid Greplica credentials at ${path}.`);
+  }
+  if (
+    typeof parsed.user.id !== "string" ||
+    typeof parsed.user.githubLogin !== "string" ||
+    typeof parsed.user.githubUserId !== "string"
+  ) {
+    throw new Error(`Invalid Greplica credentials at ${path}.`);
+  }
+  return {
+    version: 1,
+    token: parsed.token,
+    user: {
+      id: parsed.user.id,
+      githubLogin: parsed.user.githubLogin,
+      githubUserId: parsed.user.githubUserId,
+    },
+  };
+}
+
+export function writeManagedCredentials(credentials: ManagedCredentials, path = managedCredentialsPath()): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const temporaryPath = `${path}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(credentials, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    chmodSync(temporaryPath, 0o600);
+    renameSync(temporaryPath, path);
+    chmodSync(path, 0o600);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+}
+
+export function deleteManagedCredentials(path = managedCredentialsPath()): void {
+  rmSync(path, { force: true });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/libs/hooks/runtime-store.ts
+++ b/libs/hooks/runtime-store.ts
@@ -1,0 +1,99 @@
+import type Database from "better-sqlite3";
+import type { SessionConfig } from "../config/greplica-config.js";
+import type { InstallPlatform } from "../install/paths.js";
+import {
+  canScheduleMemoryUpdates,
+  RepoInstallationStore,
+  type RepoInstallation,
+} from "../install/repo-installation-store.js";
+import type { RepoRef } from "../knowledge-graph/service.js";
+import { openDatabase } from "../storage/sqlite/db.js";
+import { HookSessionStore, shouldAttemptUpdate } from "./session-state.js";
+import type { AgentSession, ClaimedMemoryUpdateAttempt, RecordHookResult } from "./types.js";
+
+export interface RecordHookEventInput {
+  repo: RepoRef;
+  platform: InstallPlatform;
+  sessionId?: string;
+  transcriptPath?: string;
+  cwd?: string;
+  eventName?: string;
+}
+
+export interface RuntimeHookResult extends RecordHookResult {
+  installation: RepoInstallation;
+}
+
+export class LocalAgentRuntimeStore {
+  private readonly installations: RepoInstallationStore;
+  private readonly sessions: HookSessionStore;
+
+  constructor(
+    private readonly db: Database.Database = openDatabase(),
+    private readonly sessionConfig?: SessionConfig,
+    private readonly ownsDatabase = false,
+  ) {
+    this.installations = new RepoInstallationStore(db);
+    this.sessions = new HookSessionStore(db, sessionConfig);
+  }
+
+  recordHook(input: RecordHookEventInput): RuntimeHookResult | undefined {
+    const installation = this.installations.find(input.repo);
+    if (installation === undefined || installation.status !== "active" || !installation.hooksEnabled) return undefined;
+    const result = this.sessions.recordHook({
+      platform: input.platform,
+      repoId: installation.id,
+      sessionId: input.sessionId,
+      transcriptPath: input.transcriptPath,
+      cwd: input.cwd,
+      eventName: input.eventName,
+    });
+    return { ...result, installation };
+  }
+
+  claimDueMemoryUpdateAttempts(now = new Date()): ClaimedMemoryUpdateAttempt[] {
+    const sessions = this.db
+      .prepare(
+        `SELECT agent_sessions.*
+         FROM agent_sessions
+         JOIN repos ON repos.id = agent_sessions.repo_id
+         WHERE repos.status = 'active'
+           AND repos.hooks_enabled = 1
+           AND repos.auto_memory_updates = 1
+           AND (
+             repos.active_mode = 'local'
+             OR (
+               repos.active_mode = 'managed'
+               AND repos.managed_role = 'memory_admin'
+               AND repos.managed_access_status = 'active'
+             )
+           )
+         ORDER BY agent_sessions.last_seen_at, agent_sessions.platform, agent_sessions.session_id`,
+      )
+      .all() as AgentSession[];
+    const due: ClaimedMemoryUpdateAttempt[] = [];
+    for (const session of sessions) {
+      const reason = shouldAttemptUpdate(session, now, this.sessionConfig);
+      if (reason !== undefined) due.push({ session, reason });
+    }
+    return due;
+  }
+
+  markMemoryCurrent(repo: RepoRef, platform: InstallPlatform, sessionId: string | undefined): boolean {
+    if (sessionId === undefined || sessionId.length === 0) return false;
+    const installation = this.installations.require(repo);
+    return this.sessions.markMemoryCurrent({ repoId: installation.id, platform, sessionId });
+  }
+
+  shouldSchedule(installation: RepoInstallation): boolean {
+    return canScheduleMemoryUpdates(installation);
+  }
+
+  close(): void {
+    if (this.ownsDatabase) this.db.close();
+  }
+}
+
+export function createLocalAgentRuntimeStore(sessionConfig?: SessionConfig): LocalAgentRuntimeStore {
+  return new LocalAgentRuntimeStore(openDatabase(), sessionConfig, true);
+}

--- a/libs/hooks/worker.ts
+++ b/libs/hooks/worker.ts
@@ -3,9 +3,10 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ClaimedMemoryUpdateAttempt } from "./types.js";
-import { HookSessionStore } from "./session-state.js";
+import { LocalAgentRuntimeStore } from "./runtime-store.js";
 import { WorkerLease } from "../utils/worker-lease.js";
-import { ensureGreplicaConfig, type GreplicaConfig } from "../config/greplica-config.js";
+import { ensureGreplicaConfig } from "../config/greplica-config.js";
+import { canScheduleMemoryUpdates, type RepoInstallation } from "../install/repo-installation-store.js";
 import { platformInstaller } from "../install/platforms/index.js";
 import { openDatabase } from "../storage/sqlite/db.js";
 
@@ -28,8 +29,8 @@ export function startHookWorker(): void {
   }
 }
 
-export function shouldRunAutoMemoryUpdates(config: Pick<GreplicaConfig, "session">): boolean {
-  return config.session.autoMemoryUpdates;
+export function shouldRunAutoMemoryUpdates(installation: RepoInstallation): boolean {
+  return canScheduleMemoryUpdates(installation);
 }
 
 export async function runHookWorker(): Promise<void> {
@@ -47,9 +48,9 @@ export async function runHookWorker(): Promise<void> {
     heartbeat.unref();
 
     const config = ensureGreplicaConfig();
-    const sessionStore = new HookSessionStore(db, config.session);
+    const runtimeStore = new LocalAgentRuntimeStore(db, config.session);
     if (!lease.renew()) return;
-    const attempts = sessionStore.claimDueMemoryUpdateAttempts();
+    const attempts = runtimeStore.claimDueMemoryUpdateAttempts();
     for (const attempt of attempts) {
       if (!leaseValid || !lease.renew()) return;
       await maybeUpdateWorkingMemory(attempt);

--- a/libs/install/install.ts
+++ b/libs/install/install.ts
@@ -1,81 +1,154 @@
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { envVarSource, loadRepoEnv } from "../env/load-local-env.js";
-import { greplicaConfigPath, updateEmbeddingConfig, writeGreplicaConfig, type EmbeddingProvider, type SessionConfig } from "../config/greplica-config.js";
-import { graphContextConfigFromGreplicaConfig } from "../knowledge-graph/graph-context/config.js";
-import { createLocalKnowledgeGraphService } from "../knowledge-graph/service.js";
-import type { RepoRef } from "../knowledge-graph/service.js";
-import { installPlatform, type HookInstallResult, type RuleInstallResult } from "./platforms/index.js";
 import {
-  type InstallEmbedding,
-  type InstallPlatform,
-} from "./paths.js";
+  ensureGreplicaConfig,
+  greplicaConfigPath,
+  updateEmbeddingConfig,
+  type EmbeddingProvider,
+} from "../config/greplica-config.js";
+import { graphContextConfigFromGreplicaConfig } from "../knowledge-graph/graph-context/config.js";
+import { createLocalKnowledgeGraphService, type RepoRef } from "../knowledge-graph/service.js";
+import { defaultDatabasePath, openDatabase } from "../storage/sqlite/db.js";
+import type { ManagedAccessStatus, ManagedRepoRole, RepoMode } from "../storage/sqlite/repository.js";
+import { RepoInstallationStore, type RepoInstallation } from "./repo-installation-store.js";
+import { PlatformIntegrationStore } from "./platform-integration-store.js";
+import { installPlatform, type HookInstallResult, type RuleInstallResult } from "./platforms/index.js";
+import { type InstallEmbedding, type InstallPlatform } from "./paths.js";
 
 export interface InstallOptions {
-  platform: InstallPlatform;
-  embedding: InstallEmbedding;
+  mode: RepoMode;
+  platform?: InstallPlatform;
+  embedding?: InstallEmbedding;
   hooks: boolean;
   autoMemoryUpdates: boolean;
   repo: RepoRef;
+  managedRepoId?: string;
+  managedRole?: ManagedRepoRole;
+  managedAccessStatus?: ManagedAccessStatus;
+  allowModeSwitch?: boolean;
+  allowRebind?: boolean;
 }
 
 export interface InstallResult {
+  mode: RepoMode;
   platform: InstallPlatform;
   skills: string[];
   hooks?: HookInstallResult;
   rules?: RuleInstallResult;
   hooksRequested: boolean;
-  embedding: InstallEmbedding;
-  session: SessionConfig;
+  embedding?: InstallEmbedding;
+  autoMemoryUpdates: boolean;
   configFile: string;
   databasePath: string;
+  installation: RepoInstallation;
   notes: string[];
 }
 
 export async function installGreplica(options: InstallOptions): Promise<InstallResult> {
-  const embedding = configureEmbedding(options.embedding, options.repo);
-  embedding.config.session.autoMemoryUpdates = options.autoMemoryUpdates;
-  writeGreplicaConfig(embedding.config);
-  const service = createLocalKnowledgeGraphService(graphContextConfigFromGreplicaConfig(embedding.config));
-  try {
-    const init = service.initRepo(options.repo);
-    const platformInstall = installPlatform(options.platform, {
-      repoRoot: options.repo.repo_root ?? process.cwd(),
-      hooks: options.hooks,
-    });
-    const supportsAutoMemoryUpdates = platformInstall.hooks !== undefined && platformInstall.supportsAutoMemoryUpdates !== false;
-    if (!supportsAutoMemoryUpdates && embedding.config.session.autoMemoryUpdates) {
-      embedding.config.session.autoMemoryUpdates = false;
-      writeGreplicaConfig(embedding.config);
-    }
-
-    const notes: string[] = [];
-    if (options.autoMemoryUpdates && !supportsAutoMemoryUpdates && platformInstall.hooks !== undefined) {
-      notes.push(`${platformDisplayName(options.platform)} automatic memory updates are not supported yet; installed hooks still record session activity.`);
-    }
-    if (options.embedding === "local") {
-      if (startLocalEmbeddingPrewarm()) {
-        notes.push("Local embedding model prewarm was queued in the background; if another prewarm is already running, this one will skip. The first query may still download the model if prewarm has not finished.");
-      } else {
-        notes.push("Local embeddings were configured, but background prewarm could not be started; the first query may download the local model.");
-      }
-    }
-
-    return {
-      platform: options.platform,
-      skills: platformInstall.skills,
-      hooks: platformInstall.hooks,
-      rules: platformInstall.rules,
-      hooksRequested: options.hooks,
-      embedding: options.embedding,
-      session: embedding.config.session,
-      configFile: embedding.configPath,
-      databasePath: init.database_path,
-      notes,
-    };
-  } finally {
-    service.close();
+  if (options.mode === "managed" && options.embedding !== undefined) {
+    throw new Error("Managed installations use server-owned embeddings; omit --embedding.");
   }
+  if (options.mode === "managed" && options.managedRepoId === undefined) {
+    throw new Error("Managed installation requires a selected managed repository.");
+  }
+
+  const validationDb = openDatabase();
+  try {
+    new RepoInstallationStore(validationDb).assertCanActivate(options.repo, options.mode, {
+      managedRepoId: options.managedRepoId,
+      allowModeSwitch: options.allowModeSwitch,
+      allowRebind: options.allowRebind,
+    });
+  } finally {
+    validationDb.close();
+  }
+
+  const config = options.mode === "local"
+    ? configureEmbedding(options.embedding ?? "local", options.repo).config
+    : ensureGreplicaConfig();
+
+  let localInit: ReturnType<ReturnType<typeof createLocalKnowledgeGraphService>["initRepo"]> | undefined;
+  if (options.mode === "local") {
+    const service = createLocalKnowledgeGraphService(graphContextConfigFromGreplicaConfig(config));
+    try {
+      localInit = service.initRepo(options.repo);
+    } finally {
+      service.close();
+    }
+  }
+
+  const platformDb = openDatabase();
+  let platform: InstallPlatform;
+  try {
+    const integrations = new PlatformIntegrationStore(platformDb);
+    platform = options.platform ?? integrations.preferred() ?? missingPlatform();
+  } finally {
+    platformDb.close();
+  }
+  const platformInstall = installPlatform(platform, {
+    repoRoot: options.repo.repo_root ?? process.cwd(),
+    hooks: options.hooks,
+  });
+  const supportsAutoMemoryUpdates = platformInstall.hooks !== undefined && platformInstall.supportsAutoMemoryUpdates !== false;
+  const autoMemoryUpdates = options.hooks && options.autoMemoryUpdates && supportsAutoMemoryUpdates;
+  const db = openDatabase();
+  let installation: RepoInstallation;
+  try {
+    const store = new RepoInstallationStore(db);
+    new PlatformIntegrationStore(db).record(platform);
+    installation = options.mode === "local"
+      ? store.activateLocal(options.repo, {
+          hooksEnabled: options.hooks,
+          autoMemoryUpdates,
+          allowModeSwitch: options.allowModeSwitch,
+        })
+      : store.activateManaged(options.repo, {
+          managedRepoId: options.managedRepoId as string,
+          managedRole: options.managedRole ?? "reader",
+          managedAccessStatus: options.managedAccessStatus ?? "active",
+          hooksEnabled: options.hooks,
+          autoMemoryUpdates,
+          allowModeSwitch: options.allowModeSwitch,
+          allowRebind: options.allowRebind,
+        });
+  } finally {
+    db.close();
+  }
+
+  const notes: string[] = [];
+  if (options.autoMemoryUpdates && !supportsAutoMemoryUpdates && platformInstall.hooks !== undefined) {
+    notes.push(`${platformDisplayName(platform)} automatic memory updates are not supported yet; installed hooks still record session activity.`);
+  }
+  if (options.mode === "managed" && options.managedRole !== "memory_admin" && options.autoMemoryUpdates) {
+    notes.push("Managed reader access records session guidance but does not schedule memory updates.");
+  }
+  if (options.mode === "local" && options.embedding === "local") {
+    if (startLocalEmbeddingPrewarm()) {
+      notes.push("Local embedding model prewarm was queued in the background; if another prewarm is already running, this one will skip. The first query may still download the model if prewarm has not finished.");
+    } else {
+      notes.push("Local embeddings were configured, but background prewarm could not be started; the first query may download the local model.");
+    }
+  }
+
+  return {
+    mode: options.mode,
+    platform,
+    skills: platformInstall.skills,
+    hooks: platformInstall.hooks,
+    rules: platformInstall.rules,
+    hooksRequested: options.hooks,
+    embedding: options.mode === "local" ? (options.embedding ?? "local") : undefined,
+    autoMemoryUpdates,
+    configFile: resolve(greplicaConfigPath()),
+    databasePath: localInit?.database_path ?? defaultDatabasePath(),
+    installation,
+    notes,
+  };
+}
+
+function missingPlatform(): never {
+  throw new Error("--platform is required until at least one global platform integration has been installed.");
 }
 
 export function platformDisplayName(platform: InstallPlatform): string {
@@ -89,7 +162,7 @@ export function platformDisplayName(platform: InstallPlatform): string {
   return "Claude Code";
 }
 
-function configureEmbedding(provider: EmbeddingProvider, repo: RepoRef): { config: ReturnType<typeof updateEmbeddingConfig>; configPath: string } {
+function configureEmbedding(provider: EmbeddingProvider, repo: RepoRef): { config: ReturnType<typeof updateEmbeddingConfig> } {
   const repoRoot = repo.repo_root ?? process.cwd();
   if (provider === "openai") {
     const env = loadRepoEnv(repoRoot);
@@ -97,12 +170,7 @@ function configureEmbedding(provider: EmbeddingProvider, repo: RepoRef): { confi
       throw new Error("OPENAI_API_KEY is required for --embedding openai. Set it in the shell, target-root .env.local, or target-root .env.");
     }
   }
-
-  const config = updateEmbeddingConfig({ provider });
-  return {
-    config,
-    configPath: resolve(greplicaConfigPath()),
-  };
+  return { config: updateEmbeddingConfig({ provider }) };
 }
 
 function startLocalEmbeddingPrewarm(): boolean {
@@ -116,9 +184,7 @@ function startLocalEmbeddingPrewarm(): boolean {
       stdio: "ignore",
       env: process.env,
     });
-    child.on("error", () => {
-      // Local model prewarm is best-effort; install should never fail because of it.
-    });
+    child.on("error", () => {});
     child.unref();
     return true;
   } catch {

--- a/libs/install/paths.ts
+++ b/libs/install/paths.ts
@@ -7,7 +7,7 @@ export type InstallEmbedding = "local" | "openai";
 
 export const installPlatforms = ["codex", "claude", "copilot", "cursor", "opencode", "openhands", "factory-droid", "antigravity"] as const satisfies readonly InstallPlatform[];
 export const installPlatformUsage = installPlatforms.join("|");
-export const installCommandSuggestion = `greplica install --platform <${installPlatformUsage}> --embedding local`;
+export const installCommandSuggestion = `greplica install --mode local --platform <${installPlatformUsage}> --embedding local`;
 
 export const skillNames = ["greplica-bootstrap", "greplica-update-working-memory", "greplica-fast-session-bootstrap"] as const;
 export type SkillName = (typeof skillNames)[number];

--- a/libs/install/platform-integration-store.ts
+++ b/libs/install/platform-integration-store.ts
@@ -1,0 +1,28 @@
+import type Database from "better-sqlite3";
+import type { InstallPlatform } from "./paths.js";
+
+export class PlatformIntegrationStore {
+  constructor(private readonly db: Database.Database) {}
+
+  record(platform: InstallPlatform): void {
+    const now = new Date().toISOString();
+    this.db.prepare(
+      `INSERT INTO platform_integrations (platform, installed_at, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(platform) DO UPDATE SET updated_at = excluded.updated_at`,
+    ).run(platform, now, now);
+  }
+
+  preferred(): InstallPlatform | undefined {
+    const row = this.db.prepare(
+      "SELECT platform FROM platform_integrations ORDER BY updated_at DESC, platform LIMIT 1",
+    ).get() as { platform: InstallPlatform } | undefined;
+    return row?.platform;
+  }
+
+  list(): InstallPlatform[] {
+    return (this.db.prepare("SELECT platform FROM platform_integrations ORDER BY platform").all() as Array<{
+      platform: InstallPlatform;
+    }>).map((row) => row.platform);
+  }
+}

--- a/libs/install/repo-identity.ts
+++ b/libs/install/repo-identity.ts
@@ -1,0 +1,57 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface RepoIdentityInput {
+  repo_root?: string;
+  remote_url?: string;
+}
+
+export function canonicalRepoKey(input: RepoIdentityInput): string {
+  if (input.remote_url !== undefined && input.remote_url.trim().length > 0) {
+    return `git:${canonicalRemote(input.remote_url)}`;
+  }
+  if (input.repo_root !== undefined && input.repo_root.trim().length > 0) {
+    return `path:${canonicalRepoPath(input.repo_root)}`;
+  }
+  throw new Error("Repo memory needs either a remote URL or a root path.");
+}
+
+export function canonicalRepoPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+export function canonicalRemote(remoteUrl: string): string {
+  const trimmed = remoteUrl.trim().replace(/^git\+/, "");
+  const scp = trimmed.match(/^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/);
+  if (scp !== null && !trimmed.includes("://") && !looksLikeWindowsPath(trimmed)) {
+    return normalizeRemoteParts(scp[1], scp[2]);
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "file:") return `file${canonicalRepoPath(decodeURIComponent(url.pathname))}`;
+    return normalizeRemoteParts(url.hostname, url.pathname, url.port);
+  } catch {
+    return trimmed.replace(/\/+$/, "").replace(/\.git$/i, "");
+  }
+}
+
+function normalizeRemoteParts(host: string, rawPath: string, port = ""): string {
+  const normalizedHost = host.toLowerCase();
+  const normalizedPort = port.length > 0 && !isDefaultPort(port) ? `:${port}` : "";
+  let path = rawPath.replace(/^\/+|\/+$/g, "").replace(/\.git$/i, "");
+  if (normalizedHost === "github.com") path = path.toLowerCase();
+  return `${normalizedHost}${normalizedPort}/${path}`;
+}
+
+function isDefaultPort(port: string): boolean {
+  return port === "22" || port === "80" || port === "443";
+}
+
+function looksLikeWindowsPath(value: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(value);
+}

--- a/libs/install/repo-installation-store.ts
+++ b/libs/install/repo-installation-store.ts
@@ -1,0 +1,241 @@
+import type Database from "better-sqlite3";
+import type { RepoRef } from "../knowledge-graph/service.js";
+import { installCommandSuggestion } from "./paths.js";
+import {
+  SqliteRepository,
+  type ManagedAccessStatus,
+  type ManagedRepoRole,
+  type RepoMode,
+  type RepoRecord,
+  type RepoStatus,
+} from "../storage/sqlite/repository.js";
+
+export interface RepoInstallation {
+  id: string;
+  repoKey: string;
+  remoteUrl?: string;
+  rootPath?: string;
+  repoName: string;
+  defaultBranch: string;
+  status: RepoStatus;
+  activeMode: RepoMode;
+  managedRepoId?: string;
+  managedRole?: ManagedRepoRole;
+  managedAccessStatus?: ManagedAccessStatus;
+  managedAccessRefreshedAt?: string;
+  hooksEnabled: boolean;
+  autoMemoryUpdates: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ActivateRepoOptions {
+  hooksEnabled: boolean;
+  autoMemoryUpdates: boolean;
+  allowModeSwitch?: boolean;
+}
+
+export interface ActivateManagedRepoOptions extends ActivateRepoOptions {
+  managedRepoId: string;
+  managedRole: ManagedRepoRole;
+  managedAccessStatus?: ManagedAccessStatus;
+  allowRebind?: boolean;
+}
+
+export class RepoInstallationStore {
+  private readonly repository: SqliteRepository;
+
+  constructor(private readonly db: Database.Database) {
+    this.repository = new SqliteRepository(db);
+  }
+
+  find(input: RepoRef): RepoInstallation | undefined {
+    const row = this.repository.getRepo(input);
+    return row === undefined ? undefined : toInstallation(row);
+  }
+
+  require(input: RepoRef): RepoInstallation {
+    const installation = this.find(input);
+    if (installation === undefined || installation.status !== "active") {
+      throw new Error(
+        `Greplica is not installed for this repo, or its installation is inactive. Run ${installCommandSuggestion} here first.`,
+      );
+    }
+    return installation;
+  }
+
+  assertCanActivate(
+    input: RepoRef,
+    nextMode: RepoMode,
+    options: { managedRepoId?: string; allowModeSwitch?: boolean; allowRebind?: boolean } = {},
+  ): void {
+    const repo = this.repository.getRepo(input);
+    if (repo === undefined) return;
+    this.assertModeSwitch(repo, nextMode, options.allowModeSwitch === true);
+    if (
+      nextMode === "managed" &&
+      options.managedRepoId !== undefined &&
+      repo.managed_repo_id !== null &&
+      repo.managed_repo_id !== options.managedRepoId &&
+      options.allowRebind !== true
+    ) {
+      throw new Error("This repository is already bound to another managed memory. Re-run with explicit rebind confirmation.");
+    }
+  }
+
+  activateLocal(input: RepoRef, options: ActivateRepoOptions): RepoInstallation {
+    this.assertCanActivate(input, "local", options);
+    const { repo } = this.repository.upsertRepo(input);
+    return this.updateActivation(repo.id, {
+      status: "active",
+      activeMode: "local",
+      hooksEnabled: options.hooksEnabled,
+      autoMemoryUpdates: options.hooksEnabled && options.autoMemoryUpdates,
+    });
+  }
+
+  activateManaged(input: RepoRef, options: ActivateManagedRepoOptions): RepoInstallation {
+    this.assertCanActivate(input, "managed", options);
+    const { repo } = this.repository.upsertRepo(input);
+    const refreshedAt = new Date().toISOString();
+    return this.updateActivation(repo.id, {
+      status: "active",
+      activeMode: "managed",
+      managedRepoId: options.managedRepoId,
+      managedRole: options.managedRole,
+      managedAccessStatus: options.managedAccessStatus ?? "active",
+      managedAccessRefreshedAt: refreshedAt,
+      hooksEnabled: options.hooksEnabled,
+      autoMemoryUpdates: options.hooksEnabled && options.autoMemoryUpdates,
+    });
+  }
+
+  deactivate(input: RepoRef): RepoInstallation {
+    const repo = this.repository.requireRepo(input);
+    return this.updateActivation(repo.id, { status: "inactive" });
+  }
+
+  updateManagedAccess(
+    managedRepoId: string,
+    role: ManagedRepoRole | undefined,
+    accessStatus: ManagedAccessStatus,
+    refreshedAt = new Date(),
+  ): RepoInstallation[] {
+    const before = this.db
+      .prepare("SELECT * FROM repos WHERE managed_repo_id = ?")
+      .all(managedRepoId) as RepoRecord[];
+    this.db
+      .prepare(
+        `UPDATE repos
+         SET managed_role = ?, managed_access_status = ?, managed_access_refreshed_at = ?, updated_at = ?
+         WHERE managed_repo_id = ?`,
+      )
+      .run(role ?? null, accessStatus, refreshedAt.toISOString(), refreshedAt.toISOString(), managedRepoId);
+
+    if (role === "memory_admin" && before.some((row) => row.managed_role !== "memory_admin")) {
+      this.db
+        .prepare(
+          `UPDATE agent_sessions
+           SET last_memory_current_at = ?, stops_since_memory_current = 0
+           WHERE repo_id IN (SELECT id FROM repos WHERE managed_repo_id = ?)`,
+        )
+        .run(refreshedAt.toISOString(), managedRepoId);
+    }
+
+    return (this.db.prepare("SELECT * FROM repos WHERE managed_repo_id = ?").all(managedRepoId) as RepoRecord[])
+      .map(toInstallation);
+  }
+
+  invalidateManagedRoleCache(): void {
+    const now = new Date().toISOString();
+    this.db
+      .prepare(
+        `UPDATE repos
+         SET managed_role = NULL, managed_access_status = NULL,
+             managed_access_refreshed_at = NULL, updated_at = ?
+         WHERE managed_repo_id IS NOT NULL`,
+      )
+      .run(now);
+  }
+
+  list(): RepoInstallation[] {
+    return (this.db.prepare("SELECT * FROM repos ORDER BY repo_name, id").all() as RepoRecord[]).map(toInstallation);
+  }
+
+  private assertModeSwitch(repo: RepoRecord, nextMode: RepoMode, allowed: boolean): void {
+    if (repo.active_mode !== nextMode && !allowed) {
+      throw new Error(
+        `This repository is active in ${repo.active_mode} mode. Re-run with explicit mode-switch confirmation to use ${nextMode} mode.`,
+      );
+    }
+  }
+
+  private updateActivation(
+    repoId: string,
+    update: {
+      status?: RepoStatus;
+      activeMode?: RepoMode;
+      managedRepoId?: string;
+      managedRole?: ManagedRepoRole;
+      managedAccessStatus?: ManagedAccessStatus;
+      managedAccessRefreshedAt?: string;
+      hooksEnabled?: boolean;
+      autoMemoryUpdates?: boolean;
+    },
+  ): RepoInstallation {
+    const existing = this.db.prepare("SELECT * FROM repos WHERE id = ?").get(repoId) as RepoRecord | undefined;
+    if (existing === undefined) throw new Error(`Repository installation ${repoId} is missing.`);
+    const next = {
+      id: repoId,
+      status: update.status ?? existing.status,
+      active_mode: update.activeMode ?? existing.active_mode,
+      managed_repo_id: update.managedRepoId ?? existing.managed_repo_id,
+      managed_role: update.managedRole ?? existing.managed_role,
+      managed_access_status: update.managedAccessStatus ?? existing.managed_access_status,
+      managed_access_refreshed_at: update.managedAccessRefreshedAt ?? existing.managed_access_refreshed_at,
+      hooks_enabled: update.hooksEnabled === undefined ? existing.hooks_enabled : Number(update.hooksEnabled),
+      auto_memory_updates:
+        update.autoMemoryUpdates === undefined ? existing.auto_memory_updates : Number(update.autoMemoryUpdates),
+      updated_at: new Date().toISOString(),
+    };
+    this.db
+      .prepare(
+        `UPDATE repos
+         SET status = @status, active_mode = @active_mode, managed_repo_id = @managed_repo_id,
+             managed_role = @managed_role, managed_access_status = @managed_access_status,
+             managed_access_refreshed_at = @managed_access_refreshed_at,
+             hooks_enabled = @hooks_enabled, auto_memory_updates = @auto_memory_updates,
+             updated_at = @updated_at
+         WHERE id = @id`,
+      )
+      .run(next);
+    return toInstallation(this.db.prepare("SELECT * FROM repos WHERE id = ?").get(repoId) as RepoRecord);
+  }
+}
+
+export function canScheduleMemoryUpdates(installation: RepoInstallation): boolean {
+  if (installation.status !== "active" || !installation.hooksEnabled || !installation.autoMemoryUpdates) return false;
+  if (installation.activeMode === "local") return true;
+  return installation.managedRole === "memory_admin" && installation.managedAccessStatus === "active";
+}
+
+function toInstallation(row: RepoRecord): RepoInstallation {
+  return {
+    id: row.id,
+    repoKey: row.repo_key,
+    remoteUrl: row.remote_url ?? undefined,
+    rootPath: row.root_path ?? undefined,
+    repoName: row.repo_name,
+    defaultBranch: row.default_branch,
+    status: row.status,
+    activeMode: row.active_mode,
+    managedRepoId: row.managed_repo_id ?? undefined,
+    managedRole: row.managed_role ?? undefined,
+    managedAccessStatus: row.managed_access_status ?? undefined,
+    managedAccessRefreshedAt: row.managed_access_refreshed_at ?? undefined,
+    hooksEnabled: row.hooks_enabled === 1,
+    autoMemoryUpdates: row.auto_memory_updates === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/libs/knowledge-graph/graph-context/context-builder.ts
+++ b/libs/knowledge-graph/graph-context/context-builder.ts
@@ -24,6 +24,7 @@ export interface BuildGraphContextOptions {
   warnOnCreatedEmbeddings?: boolean;
   config?: GraphContextConfig;
   repoRoot?: string;
+  resolveCodeAnchors?: boolean;
 }
 
 interface ExistingEmbedding {
@@ -34,7 +35,7 @@ interface ExistingEmbedding {
 export class GraphContextBuilder {
   private readonly codeAnchorResolver = new CodeAnchorResolver();
 
-  constructor(private readonly repository: SqliteRepository) {}
+  constructor(private readonly repository?: SqliteRepository) {}
 
   async build(repoId: string, graph: GraphReadResult, query: string, options: BuildGraphContextOptions = {}): Promise<GraphContextResult> {
     const config = options.config ?? graphContextConfig;
@@ -50,10 +51,30 @@ export class GraphContextBuilder {
     }
 
     const queryEmbedding = await embedder.embed(query);
+    const embeddings = this.loadEmbeddings(repoId, config);
+    return this.buildFromVectors(graph, query, queryEmbedding, embeddings, {
+      ...options,
+      config,
+      embeddingStatus,
+    });
+  }
+
+  async buildFromVectors(
+    graph: GraphReadResult,
+    query: string,
+    queryEmbedding: number[],
+    embeddings: Map<string, Float32Array>,
+    options: BuildGraphContextOptions & { embeddingStatus: EmbeddingStatus },
+  ): Promise<GraphContextResult> {
+    const config = options.config ?? graphContextConfig;
+    const claimDocuments = buildClaimDocuments(graph);
+    const componentDocuments = buildComponentDocuments(graph);
+    const flowDocuments = buildFlowDocuments(graph);
+    const evidenceByClaim = buildEvidenceByClaim(graph);
     const baseRanked = {
-      claims: this.rankDocuments(repoId, query, queryEmbedding, claimDocuments, config),
-      components: this.rankDocuments(repoId, query, queryEmbedding, componentDocuments, config),
-      flows: this.rankDocuments(repoId, query, queryEmbedding, flowDocuments, config),
+      claims: this.rankDocuments(query, queryEmbedding, claimDocuments, embeddings, config),
+      components: this.rankDocuments(query, queryEmbedding, componentDocuments, embeddings, config),
+      flows: this.rankDocuments(query, queryEmbedding, flowDocuments, embeddings, config),
     };
     const ranked = applyGraphRanking(baseRanked, graph, config);
     const selectedClaims = await selectClaims(
@@ -62,6 +83,7 @@ export class GraphContextBuilder {
       config,
       this.codeAnchorResolver,
       options.repoRoot,
+      options.resolveCodeAnchors ?? true,
     );
     const selectedComponents = selectGraphObjects(
       ranked.components,
@@ -80,7 +102,7 @@ export class GraphContextBuilder {
     return {
       query,
       search_config_version: config.version,
-      embedding_status: embeddingStatus,
+      embedding_status: options.embeddingStatus,
       claims: selectedClaims,
       components: selectedComponents,
       flows: selectedFlows,
@@ -114,8 +136,9 @@ export class GraphContextBuilder {
     embedder: Embedder,
     config: GraphContextConfig,
   ): Promise<EmbeddingStatus> {
+    const repository = this.requireRepository();
     const existing = new Set(
-      this.repository
+      repository
         .listGraphObjectEmbeddings({
           repo_id: repoId,
           provider: config.embedding.provider,
@@ -127,7 +150,7 @@ export class GraphContextBuilder {
     const missing = documents.filter((document) => !existing.has(document.key));
     const vectors = await embedder.embedBatch(missing.map((document) => document.text));
 
-    this.repository.insertGraphObjectEmbeddings(
+    repository.insertGraphObjectEmbeddings(
       missing.map((document, index) => ({
         repo_id: repoId,
         object_type: document.type,
@@ -147,29 +170,28 @@ export class GraphContextBuilder {
   }
 
   private rankDocuments(
-    repoId: string,
     query: string,
     queryEmbedding: number[],
     documents: ContextDocument[],
+    embeddings: Map<string, Float32Array>,
     config: GraphContextConfig,
   ): RankedContextDocument[] {
-    const semantic = this.scoreSemantic(repoId, documents, queryEmbedding, config);
+    const semantic = this.scoreSemantic(documents, queryEmbedding, embeddings);
     const bm25 = scoreBm25(query, documents, config);
     return rankContextDocuments(documents, semantic, bm25, config);
   }
 
   private scoreSemantic(
-    repoId: string,
     documents: ContextDocument[],
     queryEmbedding: number[],
-    config: GraphContextConfig,
+    embeddings: Map<string, Float32Array>,
   ): SemanticScoreEntry[] {
     const documentKeys = new Set(documents.map((document) => document.key));
-    const embeddings = this.loadEmbeddings(repoId, config).filter((embedding) => documentKeys.has(embedding.key));
-    const scored = embeddings
-      .map((embedding) => ({
-        id: embedding.key,
-        score: cosineSimilarity(queryEmbedding, embedding.vector),
+    const scored = [...embeddings.entries()]
+      .filter(([key]) => documentKeys.has(key))
+      .map(([key, vector]) => ({
+        id: key,
+        score: cosineSimilarity(queryEmbedding, vector),
       }))
       .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
     const maxScore = scored[0]?.score ?? 1;
@@ -182,18 +204,23 @@ export class GraphContextBuilder {
     }));
   }
 
-  private loadEmbeddings(repoId: string, config: GraphContextConfig): ExistingEmbedding[] {
-    return this.repository
+  private loadEmbeddings(repoId: string, config: GraphContextConfig): Map<string, Float32Array> {
+    return new Map(this.requireRepository()
       .listGraphObjectEmbeddings({
         repo_id: repoId,
         provider: config.embedding.provider,
         model: config.embedding.model,
         dimensions: config.embedding.dimensions,
       })
-      .map((record) => ({
-        key: contextDocumentKey(record.object_type, record.object_id),
-        vector: bufferToFloat32Array(record.embedding),
-      }));
+      .map((record) => [
+        contextDocumentKey(record.object_type, record.object_id),
+        bufferToFloat32Array(record.embedding),
+      ] as const));
+  }
+
+  private requireRepository(): SqliteRepository {
+    if (this.repository === undefined) throw new Error("This graph context operation requires a storage repository.");
+    return this.repository;
   }
 }
 
@@ -227,10 +254,11 @@ function selectClaims(
   config: GraphContextConfig,
   resolver: CodeAnchorResolver,
   repoRoot: string | undefined,
+  resolveAnchors: boolean,
 ): Promise<ClaimContextResult[]> {
   return Promise.all(selectRankedDocuments(ranked, config, { minimumSelected: config.ranking.minimumSelectedClaims })
     .sort((left, right) => right.score - left.score || left.document.key.localeCompare(right.document.key))
-    .map((document, index) => toClaimResult(document, index, evidenceByClaim, resolver, repoRoot)));
+    .map((document, index) => toClaimResult(document, index, evidenceByClaim, resolver, repoRoot, resolveAnchors)));
 }
 
 async function toClaimResult(
@@ -239,6 +267,7 @@ async function toClaimResult(
   evidenceByClaim: Map<string, ClaimEvidenceResult[]>,
   resolver: CodeAnchorResolver,
   repoRoot: string | undefined,
+  resolveAnchors: boolean,
 ): Promise<ClaimContextResult> {
   const claim = document.document.object as Claim;
   return {
@@ -248,7 +277,7 @@ async function toClaimResult(
     object: claim,
     about: document.document.about,
     evidence: evidenceByClaim.get(document.document.id) ?? [],
-    code_anchors: await resolveCodeAnchors(resolver, repoRoot, claim),
+    code_anchors: resolveAnchors ? await resolveCodeAnchors(resolver, repoRoot, claim) : [],
   };
 }
 

--- a/libs/knowledge-graph/graph-view/build-graph-view.ts
+++ b/libs/knowledge-graph/graph-view/build-graph-view.ts
@@ -5,7 +5,7 @@ import type { Claim } from "../claim.js";
 import type { Edge } from "../edge.js";
 import type { GraphReadResult } from "../service.js";
 import type { Component, Flow, Source } from "../schema.js";
-import type { ClaimProvenanceRecord } from "../../storage/sqlite/repository.js";
+import type { ClaimProvenanceRecord } from "../repository.js";
 
 const require = createRequire(import.meta.url);
 
@@ -179,6 +179,13 @@ export function buildGraphViewHtml(
   options: BuildGraphViewOptions = {},
 ): string {
   const data = buildGraphViewData(graph, provenance, supersededClaims);
+  return buildGraphViewHtmlFromData(data, options);
+}
+
+export function buildGraphViewHtmlFromData(
+  data: GraphViewData,
+  options: BuildGraphViewOptions = {},
+): string {
   const title = options.repoName ? `Greplica graph view — ${options.repoName}` : "Greplica graph view";
   return renderHtml(data, title);
 }

--- a/libs/knowledge-graph/local-provider.ts
+++ b/libs/knowledge-graph/local-provider.ts
@@ -1,0 +1,52 @@
+import type Database from "better-sqlite3";
+import type { RepoInstallation } from "../install/repo-installation-store.js";
+import type { RepoRef } from "./service.js";
+import { KnowledgeGraphService } from "./service.js";
+import type { GraphMemoryProvider } from "./provider.js";
+
+export class LocalGraphMemoryProvider implements GraphMemoryProvider {
+  readonly mode = "local" as const;
+
+  constructor(
+    readonly installation: RepoInstallation,
+    private readonly repo: RepoRef,
+    private readonly service: KnowledgeGraphService,
+    private readonly db: Database.Database,
+  ) {
+    if (installation.activeMode !== "local") throw new Error("Local provider requires a local repository installation.");
+    const initialized = service.requireRepo(repo);
+    if (initialized.repo_id !== installation.id) throw new Error("Resolved repository installation does not match its local graph.");
+  }
+
+  async readGraph() {
+    return this.service.readGraph(this.repo);
+  }
+
+  async contextGraph(query: string) {
+    return this.service.contextGraph(this.repo, query);
+  }
+
+  async viewData() {
+    return this.service.graphViewData(this.repo);
+  }
+
+  async buildGraphView() {
+    return this.service.buildGraphView(this.repo);
+  }
+
+  async auditCodeAnchors() {
+    return this.service.auditCodeAnchors(this.repo);
+  }
+
+  async reviewProposal(proposal: unknown) {
+    return this.service.validateProposal(this.repo, proposal);
+  }
+
+  async applyProposal(proposal: unknown) {
+    return this.service.applyProposal(this.repo, proposal);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/libs/knowledge-graph/managed-client.ts
+++ b/libs/knowledge-graph/managed-client.ts
@@ -1,0 +1,247 @@
+import type { Claim } from "./claim.js";
+import { execFileSync } from "node:child_process";
+import { auditClaimCodeAnchors } from "./code-anchors/audit.js";
+import { fingerprintClaimAnchors } from "./code-anchors/fingerprint.js";
+import { CodeAnchorResolver } from "./code-anchors/resolver.js";
+import type { ClaimAnchorAuditResult } from "./code-anchors/types.js";
+import {
+  readManagedCredentials,
+  writeManagedCredentials,
+  type ManagedCredentials,
+} from "../config/managed-credentials.js";
+import type { RepoInstallation } from "../install/repo-installation-store.js";
+import { RepoInstallationStore } from "../install/repo-installation-store.js";
+import { openDatabase } from "../storage/sqlite/db.js";
+import { buildGraphViewHtmlFromData, type GraphViewData } from "./graph-view/build-graph-view.js";
+import { normalizeProposal } from "./proposal.js";
+import type { GraphMemoryProvider, ManagedProposalReviewResult } from "./provider.js";
+import type { ApplyProposalResult, GraphReadResult, RepoRef } from "./service.js";
+import type { GraphContextResult } from "./graph-context/types.js";
+
+export interface ManagedGraphClientOptions {
+  apiUrl: string;
+  token: string;
+  credentials?: ManagedCredentials;
+  fetchImpl?: typeof fetch;
+}
+
+interface AnchorDataResponse {
+  claims: Claim[];
+  fingerprints: Record<string, Record<string, string>>;
+}
+
+interface ApplyRequest {
+  proposal: unknown;
+  working_head: string;
+  anchor_audit: ProposalAnchorAudit;
+  commit?: { git_head?: string; branch?: string; dirty?: boolean };
+}
+
+interface ProposalAnchorAudit {
+  result: ClaimAnchorAuditResult;
+  fingerprints: Record<string, Record<string, string>>;
+}
+
+export class ManagedGraphMemoryClient implements GraphMemoryProvider {
+  readonly mode = "managed" as const;
+  private readonly apiUrl: string;
+  private token: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(
+    readonly installation: RepoInstallation,
+    private readonly repo: RepoRef,
+    options: ManagedGraphClientOptions,
+  ) {
+    if (installation.activeMode !== "managed" || installation.managedRepoId === undefined) {
+      throw new Error("Managed provider requires a managed repository binding.");
+    }
+    this.apiUrl = options.apiUrl.replace(/\/+$/, "");
+    this.token = options.token;
+    this.credentials = options.credentials;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  private readonly credentials?: ManagedCredentials;
+
+  readGraph(): Promise<GraphReadResult> {
+    return this.request("/graph", { method: "GET" });
+  }
+
+  async contextGraph(query: string): Promise<GraphContextResult> {
+    const result = await this.request<GraphContextResult>("/graph/context", { method: "POST", body: { query } });
+    const resolver = new CodeAnchorResolver();
+    const resolved = new Map<string, Awaited<ReturnType<CodeAnchorResolver["resolveMany"]>>>();
+    for (const claim of result.claims) {
+      const anchors = await resolver.resolveMany(this.repo.repo_root, claim.object.code_anchors);
+      claim.code_anchors = anchors;
+      resolved.set(claim.object.id, anchors);
+    }
+    for (const item of result.ranked_results) {
+      if (item.type === "claim") item.code_anchors = resolved.get(item.object.id) ?? [];
+    }
+    return result;
+  }
+
+  viewData(): Promise<GraphViewData> {
+    return this.request("/graph/view-data", { method: "GET" });
+  }
+
+  async buildGraphView(): Promise<string> {
+    return buildGraphViewHtmlFromData(await this.viewData(), { repoName: this.repo.repo_name });
+  }
+
+  async auditCodeAnchors(): Promise<ClaimAnchorAuditResult> {
+    const data = await this.request<AnchorDataResponse>("/graph/anchor-data", { method: "GET" });
+    return auditClaimCodeAnchors(
+      this.repo.repo_root,
+      data.claims,
+      undefined,
+      new Map(Object.entries(data.fingerprints)),
+    );
+  }
+
+  async reviewProposal(proposal: unknown): Promise<ManagedProposalReviewResult> {
+    const anchorAudit = await this.proposalAnchorAudit(proposal);
+    if (anchorAudit.result.missing_anchors.length > 0 ||
+        anchorAudit.result.missing_files.length > 0 ||
+        anchorAudit.result.missing_symbols.length > 0 ||
+        anchorAudit.result.ambiguous_symbols.length > 0 ||
+        anchorAudit.result.unsupported_languages.length > 0) {
+      return {
+        valid: false,
+        errors: anchorAuditErrors(anchorAudit.result),
+        duplicate_warnings: {},
+      };
+    }
+    return this.request("/proposals/review", { method: "POST", body: { proposal, anchor_audit: anchorAudit } });
+  }
+
+  async applyProposal(proposal: unknown): Promise<ApplyProposalResult> {
+    const anchorAudit = await this.proposalAnchorAudit(proposal);
+    const review = await this.request<ManagedProposalReviewResult>("/proposals/review", {
+      method: "POST",
+      body: { proposal, anchor_audit: anchorAudit },
+    });
+    if (!review.valid) {
+      throw new Error(`Proposal is invalid:\n${review.errors.map((error) => `- ${error}`).join("\n")}`);
+    }
+    if (review.working_head === undefined) throw new Error("Managed proposal review did not return a working head.");
+    const body: ApplyRequest = {
+      proposal,
+      working_head: review.working_head,
+      anchor_audit: anchorAudit,
+      commit: localGitState(this.repo.repo_root),
+    };
+    return this.request("/proposals/apply", { method: "POST", body });
+  }
+
+  close(): void {}
+
+  private async proposalAnchorAudit(proposal: unknown): Promise<ProposalAnchorAudit> {
+    const normalized = normalizeProposal(proposal);
+    const claims = normalized.creates.claims ?? [];
+    const result = await auditClaimCodeAnchors(this.repo.repo_root, claims);
+    const fingerprints: Record<string, Record<string, string>> = {};
+    for (const claim of claims) {
+      if (claim.code_anchors === undefined || claim.code_anchors.length === 0) continue;
+      const values = await fingerprintClaimAnchors(this.repo.repo_root, claim.code_anchors);
+      if (Object.keys(values).length > 0) fingerprints[claim.id] = values;
+    }
+    return { result, fingerprints };
+  }
+
+  private async request<T>(
+    path: string,
+    input: { method: "GET" | "POST"; body?: unknown },
+  ): Promise<T> {
+    const managedRepoId = this.installation.managedRepoId as string;
+    const response = await this.fetchImpl(`${this.apiUrl}/v1/repos/${encodeURIComponent(managedRepoId)}${path}`, {
+      method: input.method,
+      headers: {
+        authorization: `Bearer ${this.token}`,
+        accept: "application/json",
+        ...(input.body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      body: input.body === undefined ? undefined : JSON.stringify(input.body),
+    });
+    await this.captureResponseMetadata(response, managedRepoId);
+    const payload = await readJson(response);
+    if (!response.ok) {
+      const message = isRecord(payload) && typeof payload.message === "string"
+        ? payload.message
+        : `Managed Greplica request failed (${response.status}).`;
+      const error = new Error(message) as Error & { status?: number; code?: string };
+      error.status = response.status;
+      if (isRecord(payload) && typeof payload.code === "string") error.code = payload.code;
+      throw error;
+    }
+    return payload as T;
+  }
+
+  private async captureResponseMetadata(response: Response, managedRepoId: string): Promise<void> {
+    const renewedToken = response.headers.get("x-greplica-token");
+    if (renewedToken !== null && renewedToken.length > 0) {
+      this.token = renewedToken;
+      if (this.credentials !== undefined) {
+        this.credentials.token = renewedToken;
+        writeManagedCredentials(this.credentials);
+      }
+    }
+    const role = response.headers.get("x-greplica-repo-role");
+    const access = response.headers.get("x-greplica-access-status");
+    if ((role === "reader" || role === "memory_admin") &&
+        (access === "active" || access === "pending" || access === "suspended" || access === "revoked")) {
+      const db = openDatabase();
+      try {
+        new RepoInstallationStore(db).updateManagedAccess(managedRepoId, role, access);
+      } finally {
+        db.close();
+      }
+    }
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error(`Managed Greplica returned invalid JSON (${response.status}).`);
+  }
+}
+
+function anchorAuditErrors(result: ClaimAnchorAuditResult): string[] {
+  return [
+    ...result.missing_anchors.map((issue) => `${issue.claim_id} is code_verified but has no code anchors`),
+    ...result.missing_files.map((issue) => `${issue.claim_id} references a missing file`),
+    ...result.missing_symbols.map((issue) => `${issue.claim_id} references a missing symbol`),
+    ...result.ambiguous_symbols.map((issue) => `${issue.claim_id} references an ambiguous symbol`),
+    ...result.unsupported_languages.map((issue) => `${issue.claim_id} uses an unsupported anchor language`),
+  ];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function localGitState(repoRoot: string | undefined): ApplyRequest["commit"] {
+  if (repoRoot === undefined) return undefined;
+  const git = (args: string[]): string | undefined => {
+    try {
+      const value = execFileSync("git", ["-C", repoRoot, ...args], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      return value.length === 0 ? undefined : value;
+    } catch {
+      return undefined;
+    }
+  };
+  const gitHead = git(["rev-parse", "HEAD"]);
+  const branch = git(["branch", "--show-current"]);
+  const dirtyOutput = git(["status", "--porcelain"]);
+  if (gitHead === undefined && branch === undefined && dirtyOutput === undefined) return undefined;
+  return { git_head: gitHead, branch, dirty: dirtyOutput !== undefined };
+}

--- a/libs/knowledge-graph/provider-factory.ts
+++ b/libs/knowledge-graph/provider-factory.ts
@@ -1,0 +1,36 @@
+import type { GreplicaConfig } from "../config/greplica-config.js";
+import { managedApiUrl } from "../config/greplica-config.js";
+import { managedToken, readManagedCredentials } from "../config/managed-credentials.js";
+import { RepoInstallationStore } from "../install/repo-installation-store.js";
+import { openDatabase } from "../storage/sqlite/db.js";
+import { SqliteRepository } from "../storage/sqlite/repository.js";
+import { graphContextConfigFromGreplicaConfig } from "./graph-context/config.js";
+import { LocalGraphMemoryProvider } from "./local-provider.js";
+import { ManagedGraphMemoryClient } from "./managed-client.js";
+import type { GraphMemoryProvider } from "./provider.js";
+import { KnowledgeGraphService, type RepoRef } from "./service.js";
+
+export function createGraphMemoryProvider(repo: RepoRef, config: GreplicaConfig): GraphMemoryProvider {
+  const db = openDatabase();
+  const installation = new RepoInstallationStore(db).require(repo);
+  if (installation.activeMode === "local") {
+    return new LocalGraphMemoryProvider(
+      installation,
+      repo,
+      new KnowledgeGraphService(new SqliteRepository(db), graphContextConfigFromGreplicaConfig(config)),
+      db,
+    );
+  }
+
+  db.close();
+  const credentials = readManagedCredentials();
+  const token = managedToken(credentials);
+  if (token === undefined) throw new Error("Managed Greplica is not authenticated. Run 'greplica login'.");
+  return new ManagedGraphMemoryClient(installation, repo, {
+    apiUrl: managedApiUrl(config),
+    token,
+    credentials,
+  });
+}
+
+export const createKnowledgeGraphProvider = createGraphMemoryProvider;

--- a/libs/knowledge-graph/provider.ts
+++ b/libs/knowledge-graph/provider.ts
@@ -1,0 +1,31 @@
+import type { RepoInstallation } from "../install/repo-installation-store.js";
+import type { ClaimAnchorAuditResult } from "./code-anchors/types.js";
+import type { GraphContextResult } from "./graph-context/types.js";
+import type { GraphViewData } from "./graph-view/build-graph-view.js";
+import type {
+  ApplyProposalResult,
+  GraphReadResult,
+  ProposalReviewResult,
+} from "./service.js";
+
+export type GraphMemoryProviderMode = "local" | "managed";
+
+export interface ManagedProposalReviewResult extends ProposalReviewResult {
+  working_head?: string;
+}
+
+export interface GraphMemoryProvider {
+  readonly mode: GraphMemoryProviderMode;
+  readonly installation: RepoInstallation;
+
+  readGraph(): Promise<GraphReadResult>;
+  contextGraph(query: string): Promise<GraphContextResult>;
+  viewData(): Promise<GraphViewData>;
+  buildGraphView(): Promise<string>;
+  auditCodeAnchors(): Promise<ClaimAnchorAuditResult>;
+  reviewProposal(proposal: unknown): Promise<ManagedProposalReviewResult>;
+  applyProposal(proposal: unknown): Promise<ApplyProposalResult>;
+  close(): void;
+}
+
+export type KnowledgeGraphProvider = GraphMemoryProvider;

--- a/libs/knowledge-graph/repository.ts
+++ b/libs/knowledge-graph/repository.ts
@@ -1,0 +1,24 @@
+import type { Claim } from "./claim.js";
+import type { GraphReadResult } from "./service.js";
+
+export type MaybePromise<T> = T | Promise<T>;
+
+export interface ClaimProvenanceRecord {
+  claim_id: string;
+  created_at: string;
+  memory_commit_id: string;
+}
+
+export interface GraphReadRepository {
+  readGraphView(repoId: string): MaybePromise<GraphReadResult>;
+  readSupersededClaims(repoId: string): MaybePromise<Claim[]>;
+  readClaimProvenance(repoId: string): MaybePromise<ClaimProvenanceRecord[]>;
+  readClaimAnchorFingerprints(repoId: string, ids: string[]): MaybePromise<Map<string, Record<string, string>>>;
+}
+
+export interface ManagedGraphWriteMetadata {
+  actorUserId?: string;
+  gitHead?: string;
+  branch?: string;
+  dirty?: boolean;
+}

--- a/libs/knowledge-graph/service.ts
+++ b/libs/knowledge-graph/service.ts
@@ -6,7 +6,7 @@ import type { Component, Flow, GraphObjectType, Source } from "./schema.js";
 import { GraphContextBuilder } from "./graph-context/context-builder.js";
 import { graphContextConfig, type GraphContextConfig } from "./graph-context/config.js";
 import type { EmbeddingStatus, GraphContextResult } from "./graph-context/types.js";
-import { buildGraphViewHtml } from "./graph-view/build-graph-view.js";
+import { buildGraphViewData, buildGraphViewHtml, type GraphViewData } from "./graph-view/build-graph-view.js";
 import { auditClaimCodeAnchors } from "./code-anchors/audit.js";
 import { CodeAnchorResolver } from "./code-anchors/resolver.js";
 import { fingerprintClaimAnchors } from "./code-anchors/fingerprint.js";
@@ -123,6 +123,14 @@ export class KnowledgeGraphService {
     const provenance = this.repository.readClaimProvenance(initialized.repo_id);
     const supersededClaims = this.repository.readSupersededClaims(initialized.repo_id);
     return buildGraphViewHtml(graph, provenance, supersededClaims, { repoName: input.repo_name });
+  }
+
+  graphViewData(input: RepoRef): GraphViewData {
+    const initialized = this.requireRepo(input);
+    const graph = this.repository.readGraphView(initialized.repo_id);
+    const provenance = this.repository.readClaimProvenance(initialized.repo_id);
+    const supersededClaims = this.repository.readSupersededClaims(initialized.repo_id);
+    return buildGraphViewData(graph, provenance, supersededClaims);
   }
 
   async contextGraph(input: RepoRef, query: string): Promise<GraphContextResult> {

--- a/libs/managed/control-client.ts
+++ b/libs/managed/control-client.ts
@@ -1,0 +1,309 @@
+import {
+  managedToken,
+  readManagedCredentials,
+  writeManagedCredentials,
+  type ManagedCredentials,
+} from "../config/managed-credentials.js";
+import type { GreplicaConfig } from "../config/greplica-config.js";
+import { managedApiUrl } from "../config/greplica-config.js";
+import { RepoInstallationStore } from "../install/repo-installation-store.js";
+import { openDatabase } from "../storage/sqlite/db.js";
+import type {
+  ManagedAccessRequest,
+  ManagedInvitation,
+  ManagedOrganization,
+  ManagedOrgMembership,
+  ManagedRepository,
+  ManagedRepoGrant,
+  ManagedUser,
+} from "./protocol.js";
+
+export interface DeviceLoginStart {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+export type DeviceLoginPoll =
+  | { status: "pending"; interval: number }
+  | { status: "complete"; token: string; user: ManagedUser };
+
+export class ManagedControlClient {
+  private token?: string;
+  private credentials?: ManagedCredentials;
+  private readonly apiUrl: string;
+
+  constructor(
+    config: GreplicaConfig,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {
+    this.apiUrl = managedApiUrl(config);
+    this.credentials = readManagedCredentials();
+    this.token = managedToken(this.credentials);
+  }
+
+  startDeviceLogin(): Promise<DeviceLoginStart> {
+    return this.request("POST", "/v1/auth/github/device/start", {}, false);
+  }
+
+  pollDeviceLogin(deviceCode: string): Promise<DeviceLoginPoll> {
+    return this.request("POST", "/v1/auth/github/device/poll", { device_code: deviceCode }, false);
+  }
+
+  whoami(): Promise<{ user: ManagedUser }> {
+    return this.request("GET", "/v1/auth/me");
+  }
+
+  createOrg(name: string, slug?: string): Promise<ManagedOrganization> {
+    return this.request("POST", "/v1/orgs", { name, slug });
+  }
+
+  listOrgs(): Promise<ManagedOrganization[]> {
+    return this.request("GET", "/v1/orgs");
+  }
+
+  inviteOrgMember(orgId: string, githubUser: string): Promise<ManagedInvitation> {
+    return this.request("POST", `/v1/orgs/${encodeURIComponent(orgId)}/invitations`, { github_user: githubUser });
+  }
+
+  listOrgMembers(orgId: string): Promise<ManagedOrgMembership[]> {
+    return this.request("GET", `/v1/orgs/${encodeURIComponent(orgId)}/members`);
+  }
+
+  updateOrgRole(orgId: string, userId: string, role: "admin" | "member" | "guest"): Promise<ManagedOrgMembership> {
+    return this.request("PATCH", `/v1/orgs/${encodeURIComponent(orgId)}/members/${encodeURIComponent(userId)}/role`, {
+      user_id: userId,
+      role,
+    });
+  }
+
+  removeOrgMember(orgId: string, userId: string): Promise<{ removed: boolean }> {
+    return this.request("DELETE", `/v1/orgs/${encodeURIComponent(orgId)}/members/${encodeURIComponent(userId)}`);
+  }
+
+  leaveOrg(orgId: string): Promise<{ removed: boolean }> {
+    return this.request("DELETE", `/v1/orgs/${encodeURIComponent(orgId)}/members/me`);
+  }
+
+  listInvites(): Promise<ManagedInvitation[]> {
+    return this.request("GET", "/v1/invites");
+  }
+
+  acceptInvite(inviteId: string): Promise<ManagedInvitation> {
+    return this.request("POST", `/v1/invites/${encodeURIComponent(inviteId)}/accept`);
+  }
+
+  revokeInvite(inviteId: string): Promise<ManagedInvitation> {
+    return this.request("POST", `/v1/invites/${encodeURIComponent(inviteId)}/revoke`);
+  }
+
+  createGenericRepo(orgId: string, name: string): Promise<ManagedRepository> {
+    return this.request("POST", "/v1/repos", { org_id: orgId, name });
+  }
+
+  async listRepos(): Promise<ManagedRepository[]> {
+    const repositories = await this.request<ManagedRepository[]>("GET", "/v1/repos");
+    const byId = new Map(repositories.map((repository) => [repository.id, repository]));
+    const db = openDatabase();
+    try {
+      const store = new RepoInstallationStore(db);
+      for (const installation of store.list()) {
+        if (installation.managedRepoId === undefined) continue;
+        const repository = byId.get(installation.managedRepoId);
+        store.updateManagedAccess(
+          installation.managedRepoId,
+          repository?.effective_role,
+          repository?.access_status ?? "revoked",
+        );
+      }
+    } finally {
+      db.close();
+    }
+    return repositories;
+  }
+
+  connectRepos(githubRepositoryId?: string, upstreamGithubRepositoryId?: string): Promise<ManagedRepository[]> {
+    return this.request("POST", "/v1/repos/connect", {
+      github_repository_id: githubRepositoryId,
+      upstream_github_repository_id: upstreamGithubRepositoryId,
+    });
+  }
+
+  enrollGithubRepo(orgId: string, installationId: string, githubRepositoryId: string, name?: string): Promise<ManagedRepository> {
+    return this.request("POST", "/v1/repos/enroll/github", {
+      org_id: orgId,
+      installation_id: installationId,
+      github_repository_id: githubRepositoryId,
+      name,
+    });
+  }
+
+  linkGithubRepo(repoId: string, installationId: string, githubRepositoryId: string): Promise<ManagedRepository> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/link/github`, {
+      installation_id: installationId,
+      github_repository_id: githubRepositoryId,
+    }, true, repoId);
+  }
+
+  archiveRepo(repoId: string): Promise<ManagedRepository> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/archive`, undefined, true, repoId);
+  }
+
+  restoreRepo(repoId: string): Promise<ManagedRepository> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/restore`, undefined, true, repoId);
+  }
+
+  setDiscovery(repoId: string, discovery: "listed" | "unlisted"): Promise<ManagedRepository> {
+    return this.request("PATCH", `/v1/repos/${encodeURIComponent(repoId)}/discovery`, { discovery }, true, repoId);
+  }
+
+  inviteRepoReader(repoId: string, githubUser: string): Promise<ManagedInvitation> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/invites`, { github_user: githubUser }, true, repoId);
+  }
+
+  grantRepoRole(repoId: string, userId: string, role: "reader" | "memory_admin"): Promise<ManagedRepoGrant> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/grants`, { user_id: userId, role }, true, repoId);
+  }
+
+  revokeRepoRole(repoId: string, userId: string, role: "reader" | "memory_admin"): Promise<{ revoked: boolean }> {
+    return this.request("DELETE", `/v1/repos/${encodeURIComponent(repoId)}/grants`, { user_id: userId, role }, true, repoId);
+  }
+
+  requestAccess(repoId: string): Promise<ManagedAccessRequest> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/access-requests`, undefined, true, repoId);
+  }
+
+  listAccessRequests(repoId: string): Promise<ManagedAccessRequest[]> {
+    return this.request("GET", `/v1/repos/${encodeURIComponent(repoId)}/access-requests`, undefined, true, repoId);
+  }
+
+  decideAccessRequest(repoId: string, requestId: string, decision: "approve" | "deny"): Promise<ManagedAccessRequest> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/access-requests/${encodeURIComponent(requestId)}/decision`, {
+      decision,
+    }, true, repoId);
+  }
+
+  startGithubInstallation(): Promise<{ setup_id: string; url: string; state: string }> {
+    return this.request("POST", "/v1/github/installations/start");
+  }
+
+  pollGithubInstallation(setupId: string): Promise<
+    { status: "pending" } | { status: "complete"; installation_id: string }
+  > {
+    return this.request("POST", "/v1/github/installations/poll", { setup_id: setupId });
+  }
+
+  importLocalGraph(
+    repoId: string,
+    graph: unknown,
+    anchorAudit: {
+      result: unknown;
+      fingerprints: Record<string, Record<string, string>>;
+    },
+    commit?: { git_head?: string; branch?: string; dirty?: boolean },
+  ): Promise<unknown> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/import`, {
+      graph,
+      anchor_audit: anchorAudit,
+      commit,
+    }, true, repoId);
+  }
+
+  setAuthenticatedUser(result: Extract<DeviceLoginPoll, { status: "complete" }>): void {
+    this.token = result.token;
+    this.credentials = {
+      version: 1,
+      token: result.token,
+      user: {
+        id: result.user.id,
+        githubLogin: result.user.github_login,
+        githubUserId: result.user.github_user_id,
+      },
+    };
+    writeManagedCredentials(this.credentials);
+  }
+
+  private async request<T>(
+    method: "GET" | "POST" | "PATCH" | "DELETE",
+    path: string,
+    body?: unknown,
+    authenticated = true,
+    managedRepoId?: string,
+  ): Promise<T> {
+    if (authenticated && this.token === undefined) throw new Error("Managed Greplica is not authenticated. Run 'greplica login'.");
+    const response = await this.fetchImpl(`${this.apiUrl}${path}`, {
+      method,
+      headers: {
+        accept: "application/json",
+        ...(authenticated ? { authorization: `Bearer ${this.token}` } : {}),
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    this.captureRenewedToken(response);
+    if (managedRepoId !== undefined) this.captureRepoAccess(response, managedRepoId);
+    const payload = await response.text();
+    const parsed = payload.length === 0 ? {} : JSON.parse(payload) as unknown;
+    if (!response.ok) {
+      const message = isRecord(parsed) && typeof parsed.message === "string"
+        ? parsed.message
+        : `Managed Greplica request failed (${response.status}).`;
+      const error = new Error(message) as Error & { status?: number; code?: string; details?: unknown };
+      error.status = response.status;
+      if (isRecord(parsed) && typeof parsed.code === "string") error.code = parsed.code;
+      if (isRecord(parsed)) error.details = parsed.details;
+      throw error;
+    }
+    if (managedRepoId !== undefined && isRepositoryAccessPayload(parsed, managedRepoId)) {
+      this.updateRepoAccess(managedRepoId, parsed.effective_role, parsed.access_status);
+    }
+    return parsed as T;
+  }
+
+  private captureRenewedToken(response: Response): void {
+    const token = response.headers.get("x-greplica-token");
+    if (token === null || token.length === 0) return;
+    this.token = token;
+    if (this.credentials !== undefined) {
+      this.credentials.token = token;
+      writeManagedCredentials(this.credentials);
+    }
+  }
+
+  private captureRepoAccess(response: Response, managedRepoId: string): void {
+    const role = response.headers.get("x-greplica-repo-role");
+    const status = response.headers.get("x-greplica-access-status");
+    if ((role !== "reader" && role !== "memory_admin") ||
+        (status !== "active" && status !== "pending" && status !== "suspended" && status !== "revoked")) return;
+    this.updateRepoAccess(managedRepoId, role, status);
+  }
+
+  private updateRepoAccess(
+    managedRepoId: string,
+    role: "reader" | "memory_admin" | undefined,
+    status: "active" | "pending" | "suspended" | "revoked",
+  ): void {
+    const db = openDatabase();
+    try {
+      new RepoInstallationStore(db).updateManagedAccess(managedRepoId, role, status);
+    } finally {
+      db.close();
+    }
+  }
+}
+
+function isRepositoryAccessPayload(
+  value: unknown,
+  managedRepoId: string,
+): value is { id: string; effective_role: "reader" | "memory_admin"; access_status: "active" | "pending" | "suspended" | "revoked" } {
+  if (!isRecord(value) || value.id !== managedRepoId) return false;
+  return (value.effective_role === "reader" || value.effective_role === "memory_admin") &&
+    (value.access_status === "active" || value.access_status === "pending" ||
+      value.access_status === "suspended" || value.access_status === "revoked");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/libs/managed/protocol.ts
+++ b/libs/managed/protocol.ts
@@ -1,0 +1,493 @@
+import { Type, type Static, type TSchema } from "@sinclair/typebox";
+
+export const managedErrorCodes = [
+  "invalid_request",
+  "authentication_required",
+  "forbidden",
+  "not_found",
+  "conflict",
+  "github_pending",
+  "github_denied",
+  "access_pending",
+  "source_suspended",
+  "stale_working_head",
+  "embedding_failed",
+  "validation_failed",
+] as const;
+
+export type ManagedErrorCode = (typeof managedErrorCodes)[number];
+
+export const ManagedErrorSchema = Type.Object({
+  code: Type.Union(managedErrorCodes.map((code) => Type.Literal(code))),
+  message: Type.String(),
+  details: Type.Optional(Type.Unknown()),
+});
+
+export const UserSchema = Type.Object({
+  id: Type.String({ format: "uuid" }),
+  github_user_id: Type.String(),
+  github_login: Type.String(),
+  created_at: Type.String({ format: "date-time" }),
+});
+
+export const OrgRoleSchema = Type.Union([
+  Type.Literal("admin"),
+  Type.Literal("member"),
+  Type.Literal("guest"),
+]);
+export const RepoRoleSchema = Type.Union([Type.Literal("reader"), Type.Literal("memory_admin")]);
+export const AccessStatusSchema = Type.Union([
+  Type.Literal("active"),
+  Type.Literal("pending"),
+  Type.Literal("suspended"),
+  Type.Literal("revoked"),
+]);
+
+export const OrganizationSchema = Type.Object({
+  id: Type.String({ format: "uuid" }),
+  slug: Type.String(),
+  name: Type.String(),
+  role: OrgRoleSchema,
+  created_at: Type.String({ format: "date-time" }),
+  updated_at: Type.String({ format: "date-time" }),
+});
+
+export const OrgMembershipSchema = Type.Object({
+  org_id: Type.String({ format: "uuid" }),
+  user: UserSchema,
+  role: OrgRoleSchema,
+  created_at: Type.String({ format: "date-time" }),
+  updated_at: Type.String({ format: "date-time" }),
+});
+
+export const InvitationKindSchema = Type.Union([Type.Literal("org_member"), Type.Literal("repo_reader")]);
+export const InvitationSchema = Type.Object({
+  id: Type.String({ format: "uuid" }),
+  kind: InvitationKindSchema,
+  org_id: Type.String({ format: "uuid" }),
+  repo_id: Type.Optional(Type.String({ format: "uuid" })),
+  target_github_user_id: Type.String(),
+  target_github_login: Type.String(),
+  status: Type.Union([Type.Literal("pending"), Type.Literal("accepted"), Type.Literal("revoked")]),
+  created_by: Type.String({ format: "uuid" }),
+  created_at: Type.String({ format: "date-time" }),
+  accepted_at: Type.Optional(Type.String({ format: "date-time" })),
+  revoked_at: Type.Optional(Type.String({ format: "date-time" })),
+});
+
+export const GithubSourceSchema = Type.Object({
+  repository_id: Type.String(),
+  owner: Type.String(),
+  name: Type.String(),
+  full_name: Type.String(),
+  visibility: Type.Union([Type.Literal("public"), Type.Literal("private")]),
+  installation_id: Type.String(),
+  status: Type.Union([Type.Literal("active"), Type.Literal("suspended"), Type.Literal("deleted")]),
+  html_url: Type.Optional(Type.String()),
+});
+
+export const ManagedRepositorySchema = Type.Object({
+  id: Type.String({ format: "uuid" }),
+  org_id: Type.String({ format: "uuid" }),
+  name: Type.String(),
+  source_type: Type.Union([Type.Literal("generic"), Type.Literal("github")]),
+  github_source: Type.Optional(GithubSourceSchema),
+  discovery: Type.Union([Type.Literal("listed"), Type.Literal("unlisted")]),
+  archived_at: Type.Optional(Type.String({ format: "date-time" })),
+  effective_role: RepoRoleSchema,
+  access_status: AccessStatusSchema,
+  created_at: Type.String({ format: "date-time" }),
+  updated_at: Type.String({ format: "date-time" }),
+});
+
+export const RepoGrantSchema = Type.Object({
+  repo_id: Type.String({ format: "uuid" }),
+  user: UserSchema,
+  role: RepoRoleSchema,
+  created_at: Type.String({ format: "date-time" }),
+  updated_at: Type.String({ format: "date-time" }),
+});
+
+export const AccessRequestSchema = Type.Object({
+  id: Type.String({ format: "uuid" }),
+  repo_id: Type.String({ format: "uuid" }),
+  user: UserSchema,
+  status: Type.Union([Type.Literal("pending"), Type.Literal("approved"), Type.Literal("denied"), Type.Literal("closed")]),
+  created_at: Type.String({ format: "date-time" }),
+  decided_at: Type.Optional(Type.String({ format: "date-time" })),
+});
+
+export const CodeAnchorSchema = Type.Object({
+  file: Type.String(),
+  symbol: Type.Optional(Type.String()),
+});
+export const ComponentSchema = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  code_anchor: Type.Optional(Type.String()),
+});
+export const FlowSchema = Type.Object({ id: Type.String(), name: Type.String() });
+export const ClaimSchema = Type.Object({
+  id: Type.String(),
+  kind: Type.Union([
+    Type.Literal("fact"),
+    Type.Literal("requirement"),
+    Type.Literal("decision"),
+    Type.Literal("task"),
+    Type.Literal("question"),
+    Type.Literal("risk"),
+  ]),
+  text: Type.String(),
+  truth: Type.Union([Type.Literal("code_verified"), Type.Literal("source_verified"), Type.Literal("unknown")]),
+  intent: Type.Union([Type.Literal("intended"), Type.Literal("accidental"), Type.Literal("unknown")]),
+  code_anchors: Type.Optional(Type.Array(CodeAnchorSchema)),
+});
+export const SourceSchema = Type.Object({
+  id: Type.String(),
+  kind: Type.Literal("session"),
+  ref: Type.String(),
+  title: Type.Optional(Type.String()),
+});
+export const GraphObjectTypeSchema = Type.Union([
+  Type.Literal("component"),
+  Type.Literal("flow"),
+  Type.Literal("claim"),
+  Type.Literal("edge"),
+  Type.Literal("source"),
+]);
+export const EdgeSchema = Type.Object({
+  id: Type.String(),
+  from_id: Type.String(),
+  from_type: GraphObjectTypeSchema,
+  to_id: Type.String(),
+  to_type: GraphObjectTypeSchema,
+  kind: Type.Union([
+    Type.Literal("about"),
+    Type.Literal("contains"),
+    Type.Literal("touches"),
+    Type.Literal("supersedes"),
+    Type.Literal("evidenced_by"),
+  ]),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+export const GraphReadSchema = Type.Object({
+  components: Type.Array(ComponentSchema),
+  flows: Type.Array(FlowSchema),
+  claims: Type.Array(ClaimSchema),
+  sources: Type.Array(SourceSchema),
+  edges: Type.Array(EdgeSchema),
+});
+
+export const MemoryProposalSchema = Type.Object({}, { additionalProperties: true });
+
+export const AnchorAuditIssueSchema = Type.Object({
+  claim_id: Type.String(),
+  anchor: Type.Optional(CodeAnchorSchema),
+  status: Type.Union([
+    Type.Literal("missing_anchors"),
+    Type.Literal("missing_file"),
+    Type.Literal("missing_symbol"),
+    Type.Literal("ambiguous_symbol"),
+    Type.Literal("unsupported_language"),
+    Type.Literal("drifted"),
+  ]),
+});
+export const AnchorAuditSchema = Type.Object({
+  missing_anchors: Type.Array(AnchorAuditIssueSchema),
+  missing_files: Type.Array(AnchorAuditIssueSchema),
+  missing_symbols: Type.Array(AnchorAuditIssueSchema),
+  ambiguous_symbols: Type.Array(AnchorAuditIssueSchema),
+  unsupported_languages: Type.Array(AnchorAuditIssueSchema),
+  drifted: Type.Array(AnchorAuditIssueSchema),
+});
+export const ProposalAnchorAuditSchema = Type.Object({
+  result: AnchorAuditSchema,
+  fingerprints: Type.Record(Type.String(), Type.Record(Type.String(), Type.String())),
+});
+
+export const ProposalReviewSchema = Type.Object({
+  valid: Type.Boolean(),
+  errors: Type.Array(Type.String()),
+  duplicate_warnings: Type.Record(
+    Type.String(),
+    Type.Array(Type.Object({ claim_id: Type.String(), similarity: Type.Number() })),
+  ),
+  working_head: Type.String(),
+});
+
+export const ApplyProposalResultSchema = Type.Object({
+  memory_commit_id: Type.String(),
+  scope_id: Type.String(),
+  embedding_status: Type.Object({
+    checked_objects: Type.Integer({ minimum: 0 }),
+    created: Type.Integer({ minimum: 0 }),
+    reused: Type.Integer({ minimum: 0 }),
+  }),
+  created: Type.Object({
+    components: Type.Integer({ minimum: 0 }),
+    flows: Type.Integer({ minimum: 0 }),
+    claims: Type.Integer({ minimum: 0 }),
+    sources: Type.Integer({ minimum: 0 }),
+    edges: Type.Integer({ minimum: 0 }),
+  }),
+});
+
+export const EmbeddingStatusSchema = Type.Object({
+  checked_objects: Type.Integer({ minimum: 0 }),
+  created: Type.Integer({ minimum: 0 }),
+  reused: Type.Integer({ minimum: 0 }),
+});
+
+export const GraphContextSourceSchema = Type.Object({
+  id: Type.String(),
+  edge_kind: Type.String(),
+  weight: Type.Number(),
+  score: Type.Number(),
+  raw_score: Type.Number(),
+});
+
+export const ContextSignalsSchema = Type.Object({
+  semantic_score: Type.Number(),
+  semantic_raw_score: Type.Number(),
+  semantic_rank: Type.Union([Type.Integer(), Type.Null()]),
+  bm25_score: Type.Number(),
+  bm25_raw_score: Type.Number(),
+  bm25_rank: Type.Union([Type.Integer(), Type.Null()]),
+  weighted_score: Type.Number(),
+  weighted_raw_score: Type.Number(),
+  pre_coherence_score: Type.Number(),
+  graph_score: Type.Number(),
+  graph_raw_score: Type.Number(),
+  graph_sources: Type.Array(GraphContextSourceSchema),
+  coherence_score: Type.Number(),
+  coherence_raw_score: Type.Number(),
+  coherence_sources: Type.Array(GraphContextSourceSchema),
+});
+
+export const GraphAboutSchema = Type.Object({
+  type: Type.Union([Type.Literal("component"), Type.Literal("flow")]),
+  id: Type.String(),
+});
+
+export const ResolvedCodeAnchorSchema = Type.Object({
+  file: Type.String(),
+  symbol: Type.Optional(Type.String()),
+  start_line: Type.Optional(Type.Integer({ minimum: 1 })),
+  end_line: Type.Optional(Type.Integer({ minimum: 1 })),
+  status: Type.Union([
+    Type.Literal("resolved"),
+    Type.Literal("file_only"),
+    Type.Literal("missing_file"),
+    Type.Literal("missing_symbol"),
+    Type.Literal("ambiguous_symbol"),
+    Type.Literal("unsupported_language"),
+  ]),
+});
+
+export const ClaimContextSchema = Type.Object({
+  rank: Type.Integer({ minimum: 1 }),
+  score: Type.Number(),
+  signals: ContextSignalsSchema,
+  object: ClaimSchema,
+  about: Type.Array(GraphAboutSchema),
+  evidence: Type.Array(Type.Object({ source: SourceSchema, reason: Type.String() })),
+  code_anchors: Type.Array(ResolvedCodeAnchorSchema),
+});
+
+function graphObjectContextSchema<TObject extends TSchema>(object: TObject) {
+  return Type.Object({
+    rank: Type.Integer({ minimum: 1 }),
+    score: Type.Number(),
+    context_relation: Type.Union([Type.Literal("primary"), Type.Literal("additional")]),
+    direct_score: Type.Number(),
+    direct_raw_score: Type.Number(),
+    claim_support_score: Type.Number(),
+    claim_support_raw_score: Type.Number(),
+    signals: ContextSignalsSchema,
+    object,
+    matched_claim_ids: Type.Array(Type.String()),
+  });
+}
+
+export const ComponentContextSchema = graphObjectContextSchema(ComponentSchema);
+export const FlowContextSchema = graphObjectContextSchema(FlowSchema);
+export const RankedGraphContextSchema = Type.Union([
+  Type.Intersect([Type.Object({ type: Type.Literal("component") }), ComponentContextSchema]),
+  Type.Intersect([Type.Object({ type: Type.Literal("flow") }), FlowContextSchema]),
+  Type.Intersect([Type.Object({ type: Type.Literal("claim") }), ClaimContextSchema]),
+]);
+
+function rankedContextDebugSchema<TObject extends TSchema>(object: TObject) {
+  return Type.Object({
+    rank: Type.Integer({ minimum: 1 }),
+    score: Type.Number(),
+    signals: ContextSignalsSchema,
+    object,
+    about: Type.Array(GraphAboutSchema),
+  });
+}
+
+export const GraphContextSchema = Type.Object({
+  query: Type.String(),
+  search_config_version: Type.String(),
+  embedding_status: EmbeddingStatusSchema,
+  claims: Type.Array(ClaimContextSchema),
+  components: Type.Array(ComponentContextSchema),
+  flows: Type.Array(FlowContextSchema),
+  ranked_results: Type.Array(RankedGraphContextSchema),
+  sources: Type.Array(SourceSchema),
+  debug: Type.Optional(Type.Object({
+    ranked_results: Type.Array(RankedGraphContextSchema),
+    base_ranked_claims: Type.Optional(Type.Array(rankedContextDebugSchema(ClaimSchema))),
+    base_ranked_components: Type.Optional(Type.Array(rankedContextDebugSchema(ComponentSchema))),
+    base_ranked_flows: Type.Optional(Type.Array(rankedContextDebugSchema(FlowSchema))),
+    ranked_claims: Type.Array(rankedContextDebugSchema(ClaimSchema)),
+    ranked_components: Type.Array(rankedContextDebugSchema(ComponentSchema)),
+    ranked_flows: Type.Array(rankedContextDebugSchema(FlowSchema)),
+  })),
+});
+
+export const GraphViewClaimRowSchema = Type.Object({
+  id: Type.String(),
+  text: Type.String(),
+  kind: Type.String(),
+  session: Type.String(),
+  source: Type.Union([Type.Literal("code"), Type.Literal("session")]),
+  freshness: Type.Union([Type.Literal("active"), Type.Literal("superseded")]),
+  componentIds: Type.Array(Type.String()),
+  flowIds: Type.Array(Type.String()),
+  createdAt: Type.Union([Type.String({ format: "date-time" }), Type.Null()]),
+  memoryCommitId: Type.Union([Type.String(), Type.Null()]),
+});
+
+export const GraphViewDataSchema = Type.Object({
+  generatedAt: Type.String({ format: "date-time" }),
+  counts: Type.Object({
+    components: Type.Integer({ minimum: 0 }),
+    flows: Type.Integer({ minimum: 0 }),
+    claims: Type.Integer({ minimum: 0 }),
+    superseded: Type.Integer({ minimum: 0 }),
+  }),
+  components: Type.Array(Type.Object({
+    id: Type.String(),
+    name: Type.String(),
+    folder: Type.String(),
+    anchors: Type.Array(Type.String()),
+    flowCount: Type.Integer({ minimum: 0 }),
+    claimCount: Type.Integer({ minimum: 0 }),
+    subcomponentCount: Type.Integer({ minimum: 0 }),
+  })),
+  flows: Type.Array(Type.Object({
+    id: Type.String(),
+    name: Type.String(),
+    folder: Type.String(),
+    touchedComponentFolders: Type.Array(Type.String()),
+    claimCount: Type.Integer({ minimum: 0 }),
+  })),
+  claims: Type.Array(GraphViewClaimRowSchema),
+  supersededClaims: Type.Array(GraphViewClaimRowSchema),
+  claimsTimeline: Type.Object({
+    summary: Type.Object({ total: Type.Integer({ minimum: 0 }), sessionPct: Type.Number(), codePct: Type.Number() }),
+    events: Type.Array(Type.Object({
+      memoryCommitId: Type.Union([Type.String(), Type.Null()]),
+      createdAt: Type.Union([Type.String({ format: "date-time" }), Type.Null()]),
+      added: Type.Integer({ minimum: 0 }),
+      sessionPct: Type.Number(),
+      codePct: Type.Number(),
+    })),
+  }),
+});
+
+export const MemoryCommitMetadataSchema = Type.Object({
+  git_head: Type.Optional(Type.String()),
+  branch: Type.Optional(Type.String()),
+  dirty: Type.Optional(Type.Boolean()),
+});
+
+export const routeSchemas = {
+  authDeviceStart: route(Type.Object({}), Type.Object({
+    device_code: Type.String(),
+    user_code: Type.String(),
+    verification_uri: Type.String(),
+    expires_in: Type.Integer(),
+    interval: Type.Integer(),
+  })),
+  authDevicePoll: route(Type.Object({ device_code: Type.String() }), Type.Union([
+    Type.Object({ status: Type.Literal("pending"), interval: Type.Integer() }),
+    Type.Object({ status: Type.Literal("complete"), token: Type.String(), user: UserSchema }),
+  ])),
+  authMe: route(Type.Object({}), Type.Object({ user: UserSchema })),
+  orgCreate: route(Type.Object({ name: Type.String({ minLength: 1 }), slug: Type.Optional(Type.String()) }), OrganizationSchema),
+  orgList: route(Type.Object({}), Type.Array(OrganizationSchema)),
+  orgInvite: route(Type.Object({ github_user: Type.String({ minLength: 1 }) }), InvitationSchema),
+  orgMembers: route(Type.Object({}), Type.Array(OrgMembershipSchema)),
+  orgRole: route(Type.Object({ user_id: Type.String({ format: "uuid" }), role: OrgRoleSchema }), OrgMembershipSchema),
+  orgRemoveMember: route(Type.Object({ user_id: Type.String({ format: "uuid" }) }), Type.Object({ removed: Type.Boolean() })),
+  orgLeave: route(Type.Object({}), Type.Object({ removed: Type.Boolean() })),
+  inviteList: route(Type.Object({}), Type.Array(InvitationSchema)),
+  inviteAccept: route(Type.Object({}), InvitationSchema),
+  inviteRevoke: route(Type.Object({}), InvitationSchema),
+  githubInstallStart: route(Type.Object({}), Type.Object({ setup_id: Type.String({ format: "uuid" }), url: Type.String(), state: Type.String() })),
+  githubInstallPoll: route(Type.Object({ setup_id: Type.String({ format: "uuid" }) }), Type.Union([
+    Type.Object({ status: Type.Literal("pending") }),
+    Type.Object({ status: Type.Literal("complete"), installation_id: Type.String() }),
+  ])),
+  repoCreate: route(Type.Object({ org_id: Type.String({ format: "uuid" }), name: Type.String({ minLength: 1 }) }), ManagedRepositorySchema),
+  repoList: route(Type.Object({}), Type.Array(ManagedRepositorySchema)),
+  repoConnect: route(Type.Object({
+    repo_key: Type.Optional(Type.String()),
+    github_repository_id: Type.Optional(Type.String()),
+    upstream_github_repository_id: Type.Optional(Type.String()),
+  }), Type.Array(ManagedRepositorySchema)),
+  repoEnrollGithub: route(Type.Object({
+    org_id: Type.String({ format: "uuid" }),
+    installation_id: Type.String(),
+    github_repository_id: Type.String(),
+    name: Type.Optional(Type.String()),
+  }), ManagedRepositorySchema),
+  repoLinkGithub: route(Type.Object({ installation_id: Type.String(), github_repository_id: Type.String() }), ManagedRepositorySchema),
+  repoArchive: route(Type.Object({}), ManagedRepositorySchema),
+  repoRestore: route(Type.Object({}), ManagedRepositorySchema),
+  repoInvite: route(Type.Object({ github_user: Type.String({ minLength: 1 }) }), InvitationSchema),
+  repoGrant: route(Type.Object({ user_id: Type.String({ format: "uuid" }), role: RepoRoleSchema }), RepoGrantSchema),
+  repoRevokeGrant: route(Type.Object({ user_id: Type.String({ format: "uuid" }), role: RepoRoleSchema }), Type.Object({ revoked: Type.Boolean() })),
+  accessRequestCreate: route(Type.Object({}), AccessRequestSchema),
+  accessRequestList: route(Type.Object({}), Type.Array(AccessRequestSchema)),
+  accessRequestDecision: route(Type.Object({ decision: Type.Union([Type.Literal("approve"), Type.Literal("deny")]) }), AccessRequestSchema),
+  graphRead: route(Type.Object({}), GraphReadSchema),
+  graphContext: route(Type.Object({ query: Type.String({ minLength: 1 }) }), GraphContextSchema),
+  graphViewData: route(Type.Object({}), GraphViewDataSchema),
+  graphAnchorData: route(Type.Object({}), Type.Object({
+    claims: Type.Array(ClaimSchema),
+    fingerprints: Type.Record(Type.String(), Type.Record(Type.String(), Type.String())),
+  })),
+  proposalReview: route(Type.Object({ proposal: MemoryProposalSchema, anchor_audit: ProposalAnchorAuditSchema }), ProposalReviewSchema),
+  proposalApply: route(Type.Object({
+    proposal: MemoryProposalSchema,
+    working_head: Type.String(),
+    anchor_audit: ProposalAnchorAuditSchema,
+    commit: Type.Optional(MemoryCommitMetadataSchema),
+  }), ApplyProposalResultSchema),
+  repoImport: route(Type.Object({
+    graph: GraphReadSchema,
+    anchor_audit: ProposalAnchorAuditSchema,
+    commit: Type.Optional(MemoryCommitMetadataSchema),
+  }), ApplyProposalResultSchema),
+} as const;
+
+export type ManagedUser = Static<typeof UserSchema>;
+export type ManagedOrganization = Static<typeof OrganizationSchema>;
+export type ManagedOrgMembership = Static<typeof OrgMembershipSchema>;
+export type ManagedInvitation = Static<typeof InvitationSchema>;
+export type ManagedRepository = Static<typeof ManagedRepositorySchema>;
+export type ManagedRepoGrant = Static<typeof RepoGrantSchema>;
+export type ManagedAccessRequest = Static<typeof AccessRequestSchema>;
+export type ManagedGraphRead = Static<typeof GraphReadSchema>;
+export type ManagedGraphContext = Static<typeof GraphContextSchema>;
+export type ManagedGraphViewData = Static<typeof GraphViewDataSchema>;
+export type ManagedProposalReview = Static<typeof ProposalReviewSchema>;
+
+function route<TRequest extends TSchema, TResponse extends TSchema>(request: TRequest, response: TResponse) {
+  return { request, response, error: ManagedErrorSchema } as const;
+}

--- a/libs/storage/sqlite/db.ts
+++ b/libs/storage/sqlite/db.ts
@@ -11,6 +11,8 @@ export function defaultDatabasePath(): string {
 export function openDatabase(path = defaultDatabasePath()): Database.Database {
   mkdirSync(dirname(path), { recursive: true });
   const db = new Database(path);
+  db.pragma("journal_mode = WAL");
+  db.pragma("busy_timeout = 5000");
   db.pragma("foreign_keys = ON");
   migrate(db);
   return db;

--- a/libs/storage/sqlite/migrate.ts
+++ b/libs/storage/sqlite/migrate.ts
@@ -1,13 +1,77 @@
 import type Database from "better-sqlite3";
+import { canonicalRepoKey } from "../../install/repo-identity.js";
 import { schemaSql } from "./schema.js";
 
 export function migrate(db: Database.Database): void {
   db.exec(schemaSql);
   migrateReposTable(db);
+  migrateRepoInstallationState(db);
   migrateClaimsTable(db);
   migrateGraphObjectTables(db);
   migrateSourceMemberships(db);
   migrateClaimAnchorFingerprints(db);
+}
+
+function migrateRepoInstallationState(db: Database.Database): void {
+  const columns = new Set(
+    (db.prepare("PRAGMA table_info(repos)").all() as Array<{ name: string }>).map((column) => column.name),
+  );
+  const isLegacyInstallationState = !columns.has("repo_key");
+  const additions = [
+    ["repo_key", "TEXT"],
+    ["status", "TEXT NOT NULL DEFAULT 'inactive'"],
+    ["active_mode", "TEXT NOT NULL DEFAULT 'local'"],
+    ["managed_repo_id", "TEXT"],
+    ["managed_role", "TEXT"],
+    ["managed_access_status", "TEXT"],
+    ["managed_access_refreshed_at", "TEXT"],
+    ["hooks_enabled", "INTEGER NOT NULL DEFAULT 1"],
+    ["auto_memory_updates", "INTEGER NOT NULL DEFAULT 1"],
+    ["created_at", "TEXT"],
+    ["updated_at", "TEXT"],
+  ] as const;
+
+  for (const [name, definition] of additions) {
+    if (!columns.has(name)) db.exec(`ALTER TABLE repos ADD COLUMN ${name} ${definition}`);
+  }
+
+  const now = new Date().toISOString();
+  const rows = db.prepare("SELECT id, remote_url, root_path, repo_key FROM repos ORDER BY id").all() as Array<{
+    id: string;
+    remote_url: string | null;
+    root_path: string | null;
+    repo_key: string | null;
+  }>;
+  const usedKeys = new Set<string>();
+  const update = db.prepare(
+    `UPDATE repos
+     SET repo_key = ?,
+         status = CASE
+           WHEN ? = 1 AND EXISTS (SELECT 1 FROM graph_scopes WHERE graph_scopes.repo_id = repos.id) THEN 'active'
+           ELSE COALESCE(status, 'inactive')
+         END,
+         active_mode = COALESCE(active_mode, 'local'),
+         hooks_enabled = COALESCE(hooks_enabled, 1),
+         auto_memory_updates = COALESCE(auto_memory_updates, 1),
+         created_at = COALESCE(created_at, ?),
+         updated_at = COALESCE(updated_at, ?)
+     WHERE id = ?`,
+  );
+  const write = db.transaction(() => {
+    for (const row of rows) {
+      let key = row.repo_key ?? canonicalRepoKey({
+        remote_url: row.remote_url ?? undefined,
+        repo_root: row.root_path ?? undefined,
+      });
+      if (usedKeys.has(key)) key = `${key}:legacy:${row.id}`;
+      usedKeys.add(key);
+      update.run(key, Number(isLegacyInstallationState), now, now, row.id);
+    }
+  });
+  write();
+  db.exec("CREATE UNIQUE INDEX IF NOT EXISTS repos_repo_key_idx ON repos(repo_key) WHERE repo_key IS NOT NULL");
+  db.exec("CREATE INDEX IF NOT EXISTS repos_managed_repo_idx ON repos(managed_repo_id)");
+  db.exec("CREATE INDEX IF NOT EXISTS repos_status_idx ON repos(status, active_mode)");
 }
 
 function migrateReposTable(db: Database.Database): void {
@@ -29,10 +93,21 @@ function migrateReposTable(db: Database.Database): void {
       ALTER TABLE repos RENAME TO repos_old;
       CREATE TABLE repos (
         id TEXT PRIMARY KEY,
+        repo_key TEXT UNIQUE,
         remote_url TEXT UNIQUE,
         root_path TEXT UNIQUE,
         repo_name TEXT NOT NULL,
-        default_branch TEXT NOT NULL
+        default_branch TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'inactive',
+        active_mode TEXT NOT NULL DEFAULT 'local',
+        managed_repo_id TEXT,
+        managed_role TEXT,
+        managed_access_status TEXT,
+        managed_access_refreshed_at TEXT,
+        hooks_enabled INTEGER NOT NULL DEFAULT 1,
+        auto_memory_updates INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT,
+        updated_at TEXT
       );
       INSERT INTO repos (id, remote_url, root_path, repo_name, default_branch)
       SELECT
@@ -50,6 +125,11 @@ function migrateReposTable(db: Database.Database): void {
         repo_name,
         default_branch
       FROM repos_old;
+      UPDATE repos
+      SET status = CASE
+        WHEN EXISTS (SELECT 1 FROM graph_scopes WHERE graph_scopes.repo_id = repos.id) THEN 'active'
+        ELSE 'inactive'
+      END;
       DROP TABLE repos_old;
       COMMIT;
     `);

--- a/libs/storage/sqlite/repository.ts
+++ b/libs/storage/sqlite/repository.ts
@@ -7,13 +7,31 @@ import type { Component, Flow, GraphObjectType, MembershipSubjectType, Source } 
 import type { Claim } from "../../knowledge-graph/claim.js";
 import type { GraphScope, GraphScopeKind } from "../../knowledge-graph/scope.js";
 import { installCommandSuggestion } from "../../install/paths.js";
+import { canonicalRepoKey, canonicalRepoPath } from "../../install/repo-identity.js";
+import type { ClaimProvenanceRecord, GraphReadRepository } from "../../knowledge-graph/repository.js";
+
+export type RepoStatus = "active" | "inactive";
+export type RepoMode = "local" | "managed";
+export type ManagedRepoRole = "reader" | "memory_admin";
+export type ManagedAccessStatus = "active" | "pending" | "suspended" | "revoked";
 
 export interface RepoRecord {
   id: string;
+  repo_key: string;
   remote_url: string | null;
   root_path: string | null;
   repo_name: string;
   default_branch: string;
+  status: RepoStatus;
+  active_mode: RepoMode;
+  managed_repo_id: string | null;
+  managed_role: ManagedRepoRole | null;
+  managed_access_status: ManagedAccessStatus | null;
+  managed_access_refreshed_at: string | null;
+  hooks_enabled: 0 | 1;
+  auto_memory_updates: 0 | 1;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface UpsertRepoInput {
@@ -73,13 +91,9 @@ export interface InsertGraphObjectEmbeddingInput {
   embedding: Buffer;
 }
 
-export interface ClaimProvenanceRecord {
-  claim_id: string;
-  created_at: string;
-  memory_commit_id: string;
-}
+export type { ClaimProvenanceRecord } from "../../knowledge-graph/repository.js";
 
-export class SqliteRepository {
+export class SqliteRepository implements GraphReadRepository {
   constructor(private readonly db: Database.Database) {}
 
   close(): void {
@@ -90,18 +104,37 @@ export class SqliteRepository {
     const existing = this.findRepo(input);
     if (existing) return { repo: this.updateRepo(existing.repo, input, existing.matchedBy), created: false };
 
+    const timestamp = now();
     const repo: RepoRecord = {
-      id: makeId("repo", identityKey(input)),
+      id: makeId("repo", canonicalRepoKey(input)),
+      repo_key: canonicalRepoKey(input),
       remote_url: input.remote_url ?? null,
-      root_path: input.repo_root ?? null,
+      root_path: input.repo_root === undefined ? null : canonicalRepoPath(input.repo_root),
       repo_name: input.repo_name,
       default_branch: input.default_branch,
+      status: "inactive",
+      active_mode: "local",
+      managed_repo_id: null,
+      managed_role: null,
+      managed_access_status: null,
+      managed_access_refreshed_at: null,
+      hooks_enabled: 1,
+      auto_memory_updates: 1,
+      created_at: timestamp,
+      updated_at: timestamp,
     };
 
     this.db
       .prepare(
-        `INSERT INTO repos (id, remote_url, root_path, repo_name, default_branch)
-         VALUES (@id, @remote_url, @root_path, @repo_name, @default_branch)`,
+        `INSERT INTO repos (
+           id, repo_key, remote_url, root_path, repo_name, default_branch,
+           status, active_mode, managed_repo_id, managed_role, managed_access_status,
+           managed_access_refreshed_at, hooks_enabled, auto_memory_updates, created_at, updated_at
+         ) VALUES (
+           @id, @repo_key, @remote_url, @root_path, @repo_name, @default_branch,
+           @status, @active_mode, @managed_repo_id, @managed_role, @managed_access_status,
+           @managed_access_refreshed_at, @hooks_enabled, @auto_memory_updates, @created_at, @updated_at
+         )`,
       )
       .run(repo);
 
@@ -110,6 +143,10 @@ export class SqliteRepository {
 
   getRepoByRemote(remoteUrl: string): RepoRecord | undefined {
     return this.db.prepare("SELECT * FROM repos WHERE remote_url = ?").get(remoteUrl) as RepoRecord | undefined;
+  }
+
+  getRepoByKey(repoKey: string): RepoRecord | undefined {
+    return this.db.prepare("SELECT * FROM repos WHERE repo_key = ?").get(repoKey) as RepoRecord | undefined;
   }
 
   getRepoByRootPath(rootPath: string): RepoRecord | undefined {
@@ -129,6 +166,8 @@ export class SqliteRepository {
   }
 
   private findRepo(input: UpsertRepoInput): RepoMatch | undefined {
+    const byKey = this.getRepoByKey(canonicalRepoKey(input));
+    if (byKey !== undefined) return { repo: byKey, matchedBy: input.remote_url === undefined ? "root" : "remote" };
     if (input.remote_url !== undefined) {
       const byRemote = this.getRepoByRemote(input.remote_url);
       if (byRemote !== undefined) return { repo: byRemote, matchedBy: "remote" };
@@ -147,19 +186,36 @@ export class SqliteRepository {
       matchedBy === "root" || existing.root_path === null || existing.root_path === input.repo_root;
     const repo: RepoRecord = {
       id: existing.id,
+      repo_key: matchedBy === "root" && input.remote_url !== undefined
+        ? canonicalRepoKey(input)
+        : existing.repo_key,
       remote_url: input.remote_url ?? existing.remote_url,
-      root_path: shouldUpdateRootPath ? (input.repo_root ?? existing.root_path) : existing.root_path,
+      root_path: shouldUpdateRootPath
+        ? (input.repo_root === undefined ? existing.root_path : canonicalRepoPath(input.repo_root))
+        : existing.root_path,
       repo_name: input.repo_name,
       default_branch: input.default_branch,
+      status: existing.status,
+      active_mode: existing.active_mode,
+      managed_repo_id: existing.managed_repo_id,
+      managed_role: existing.managed_role,
+      managed_access_status: existing.managed_access_status,
+      managed_access_refreshed_at: existing.managed_access_refreshed_at,
+      hooks_enabled: existing.hooks_enabled,
+      auto_memory_updates: existing.auto_memory_updates,
+      created_at: existing.created_at,
+      updated_at: now(),
     };
 
     this.db
       .prepare(
         `UPDATE repos
-         SET remote_url = @remote_url,
+         SET repo_key = @repo_key,
+             remote_url = @remote_url,
              root_path = @root_path,
              repo_name = @repo_name,
-             default_branch = @default_branch
+             default_branch = @default_branch,
+             updated_at = @updated_at
          WHERE id = @id`,
       )
       .run(repo);
@@ -547,16 +603,11 @@ function makeId(prefix: string, value: string): string {
   return `${prefix}_${hash}`;
 }
 
-function identityKey(input: UpsertRepoInput): string {
-  if (input.remote_url !== undefined) return input.remote_url;
-  if (input.repo_root !== undefined) return `root:${input.repo_root}`;
-  throw new Error("Repo memory needs either a remote URL or a root path.");
-}
-
 function rootPathCandidates(rootPath: string): string[] {
-  const candidates = [rootPath];
-  if (rootPath.startsWith("/private/var/")) candidates.push(rootPath.slice("/private".length));
-  if (rootPath.startsWith("/var/")) candidates.push(`/private${rootPath}`);
+  const canonical = canonicalRepoPath(rootPath);
+  const candidates = [canonical];
+  if (canonical.startsWith("/private/var/")) candidates.push(canonical.slice("/private".length));
+  if (canonical.startsWith("/var/")) candidates.push(`/private${canonical}`);
   return candidates;
 }
 

--- a/libs/storage/sqlite/schema.ts
+++ b/libs/storage/sqlite/schema.ts
@@ -1,10 +1,21 @@
 export const schemaSql = `
 CREATE TABLE IF NOT EXISTS repos (
   id TEXT PRIMARY KEY,
+  repo_key TEXT UNIQUE,
   remote_url TEXT UNIQUE,
   root_path TEXT UNIQUE,
   repo_name TEXT NOT NULL,
-  default_branch TEXT NOT NULL
+  default_branch TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'inactive' CHECK(status IN ('active', 'inactive')),
+  active_mode TEXT NOT NULL DEFAULT 'local' CHECK(active_mode IN ('local', 'managed')),
+  managed_repo_id TEXT,
+  managed_role TEXT CHECK(managed_role IN ('reader', 'memory_admin')),
+  managed_access_status TEXT CHECK(managed_access_status IN ('active', 'pending', 'suspended', 'revoked')),
+  managed_access_refreshed_at TEXT,
+  hooks_enabled INTEGER NOT NULL DEFAULT 1 CHECK(hooks_enabled IN (0, 1)),
+  auto_memory_updates INTEGER NOT NULL DEFAULT 1 CHECK(auto_memory_updates IN (0, 1)),
+  created_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z',
+  updated_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z'
 );
 
 CREATE TABLE IF NOT EXISTS graph_scopes (
@@ -113,6 +124,12 @@ CREATE TABLE IF NOT EXISTS agent_worker_locks (
   name TEXT PRIMARY KEY,
   owner TEXT NOT NULL,
   locked_until_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS platform_integrations (
+  platform TEXT PRIMARY KEY,
+  installed_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
+        "@sinclair/typebox": "^0.34.38",
         "better-sqlite3": "^12.11.1",
         "chart.js": "4.4.7",
         "chartjs-plugin-datalabels": "2.2.0",
@@ -577,12 +578,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -600,6 +595,12 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "license": "MIT"
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -621,12 +622,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/base64-js": {
@@ -1151,9 +1152,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1163,7 +1164,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "smoke:copilot": "npm run build && node scripts/smoke-copilot-install.mjs",
     "smoke:opencode": "npm run build && node scripts/smoke-opencode-install.mjs",
     "smoke:cursor": "npm run build && node scripts/smoke-cursor-install.mjs",
-    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-graph-view.js && node scripts/check-graph-view-offline-browser.js && node scripts/check-source-memberships.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js && node scripts/check-find-similar-claims.js && node scripts/check-apply-proposal-dedupe.js && node scripts/check-opencode-sqlite-transcript.js",
+    "test": "npm run build && node scripts/check-transcript-bundle.js && node scripts/check-repo-context.js && node scripts/check-install-options.js && node scripts/check-repo-installations.js && node scripts/check-managed-cli.js && node scripts/check-graph-view.js && node scripts/check-graph-view-offline-browser.js && node scripts/check-source-memberships.js && node scripts/check-proposal-validate.js && node scripts/check-bm25-tokenizer.js && node scripts/check-anchor-drift.js && node scripts/check-find-similar-claims.js && node scripts/check-apply-proposal-dedupe.js && node scripts/check-opencode-sqlite-transcript.js",
+    "test:repo-installations": "npm run build && node scripts/check-repo-installations.js",
     "test:transcript-bundle": "npm run build && node scripts/check-transcript-bundle.js",
     "test:repo-context": "npm run build && node scripts/check-repo-context.js",
     "test:source-memberships": "npm run build && node scripts/check-source-memberships.js",
@@ -65,6 +66,7 @@
   ],
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
+    "@sinclair/typebox": "^0.34.38",
     "better-sqlite3": "^12.11.1",
     "chart.js": "4.4.7",
     "chartjs-plugin-datalabels": "2.2.0",
@@ -75,5 +77,9 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.15.3",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "adm-zip": "0.6.0",
+    "protobufjs": "^7.6.5"
   }
 }

--- a/scripts/check-install-options.js
+++ b/scripts/check-install-options.js
@@ -4,12 +4,12 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
 
 const root = new URL("..", import.meta.url);
 const cliPath = fileURLToPath(new URL("dist/apps/cli/main.js", root));
 const { installCommandSuggestion, installPlatformUsage } = await import(new URL("dist/libs/install/paths.js", root));
 const { greplicaHookGuidance } = await import(new URL("dist/libs/hooks/guidance.js", root));
-const { shouldRunAutoMemoryUpdates } = await import(new URL("dist/libs/hooks/worker.js", root));
 
 const tmp = mkdtempSync(join(tmpdir(), "greplica-install-options-test-"));
 
@@ -17,15 +17,13 @@ const autoSave = installInTempRepo("auto-save", ["--hooks", "enabled", "--auto-m
 assert.match(autoSave.output, /Hooks: installed for UserPromptSubmit, Stop\./);
 assert.match(autoSave.output, /Automatic memory updates: enabled\./);
 assert.ok(existsSync(join(autoSave.codexHome, "hooks.json")));
-assert.equal(readConfig(autoSave.greplicaHome).session.autoMemoryUpdates, true);
-assert.equal(shouldRunAutoMemoryUpdates(readConfig(autoSave.greplicaHome)), true);
+assert.equal(readRepoInstall(autoSave.greplicaHome).auto_memory_updates, 1);
 
 const guidanceOnly = installInTempRepo("guidance-only", ["--hooks", "enabled", "--auto-memory", "disabled"]);
 assert.match(guidanceOnly.output, /Hooks: installed for UserPromptSubmit, Stop\./);
 assert.match(guidanceOnly.output, /Automatic memory updates: disabled\./);
 assert.ok(existsSync(join(guidanceOnly.codexHome, "hooks.json")));
-assert.equal(readConfig(guidanceOnly.greplicaHome).session.autoMemoryUpdates, false);
-assert.equal(shouldRunAutoMemoryUpdates(readConfig(guidanceOnly.greplicaHome)), false);
+assert.equal(readRepoInstall(guidanceOnly.greplicaHome).auto_memory_updates, 0);
 
 const hookOutput = execFileSync(
   process.execPath,
@@ -50,21 +48,21 @@ assert.match(noHooks.output, /Automatic memory updates: disabled\./);
 assert.match(noHooks.output, /To give future agents Greplica guidance without hooks/);
 assert.ok(noHooks.output.includes(greplicaHookGuidance));
 assert.equal(existsSync(join(noHooks.codexHome, "hooks.json")), false);
-assert.equal(readConfig(noHooks.greplicaHome).session.autoMemoryUpdates, false);
+assert.equal(readRepoInstall(noHooks.greplicaHome).auto_memory_updates, 0);
 
 const opencodeHooks = installInTempRepo("opencode-hooks", ["--hooks", "enabled", "--auto-memory", "enabled"], "opencode");
 assert.match(opencodeHooks.output, /Installed Greplica for OpenCode\./);
 assert.match(opencodeHooks.output, /Hooks: installed for UserPromptSubmit, Stop\./);
 assert.match(opencodeHooks.output, /Automatic memory updates: enabled\./);
 assert.ok(existsSync(join(opencodeHooks.xdgConfigHome, "opencode", "hooks.json")));
-assert.equal(readConfig(opencodeHooks.greplicaHome).session.autoMemoryUpdates, true);
+assert.equal(readRepoInstall(opencodeHooks.greplicaHome).auto_memory_updates, 1);
 
 const copilotHooks = installInTempRepo("copilot-hooks", ["--hooks", "enabled", "--auto-memory", "enabled"], "copilot");
 assert.match(copilotHooks.output, /Installed Greplica for GitHub Copilot CLI\./);
 assert.match(copilotHooks.output, /Hooks: installed for SessionStart, Stop\./);
 assert.match(copilotHooks.output, /Automatic memory updates: enabled\./);
 assert.ok(existsSync(join(copilotHooks.copilotHome, "hooks", "greplica.json")));
-assert.equal(readConfig(copilotHooks.greplicaHome).session.autoMemoryUpdates, true);
+assert.equal(readRepoInstall(copilotHooks.greplicaHome).auto_memory_updates, 1);
 
 const cursorHooks = installInTempRepo("cursor-hooks", ["--hooks", "enabled", "--auto-memory", "enabled"], "cursor");
 assert.match(cursorHooks.output, /Installed Greplica for Cursor\./);
@@ -74,7 +72,7 @@ assert.match(cursorHooks.output, /Automatic memory updates: enabled\./);
 assert.doesNotMatch(cursorHooks.output, /automatic memory updates are not supported yet/);
 assert.ok(existsSync(join(cursorHooks.cursorHome, "hooks.json")));
 assert.ok(existsSync(join(cursorHooks.repo, ".cursor", "rules", "greplica.mdc")));
-assert.equal(readConfig(cursorHooks.greplicaHome).session.autoMemoryUpdates, true);
+assert.equal(readRepoInstall(cursorHooks.greplicaHome).auto_memory_updates, 1);
 
 const invalid = spawnSync(
   process.execPath,
@@ -171,4 +169,13 @@ function installInTempRepo(name, flags, platform = "codex") {
 
 function readConfig(greplicaHome) {
   return JSON.parse(readFileSync(join(greplicaHome, "config.json"), "utf8"));
+}
+
+function readRepoInstall(greplicaHome) {
+  const db = new Database(join(greplicaHome, "graph.db"), { readonly: true });
+  try {
+    return db.prepare("SELECT * FROM repos").get();
+  } finally {
+    db.close();
+  }
 }

--- a/scripts/check-managed-cli.js
+++ b/scripts/check-managed-cli.js
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+
+const root = new URL("..", import.meta.url);
+const cliPath = fileURLToPath(new URL("dist/apps/cli/main.js", root));
+const temporary = mkdtempSync(join(tmpdir(), "greplica-managed-cli-"));
+const managedRepoId = "11111111-1111-4111-8111-111111111111";
+const orgId = "22222222-2222-4222-8222-222222222222";
+const now = "2026-07-21T00:00:00.000Z";
+const managedRepository = {
+  id: managedRepoId,
+  org_id: orgId,
+  name: "shared-memory",
+  source_type: "generic",
+  discovery: "unlisted",
+  effective_role: "reader",
+  access_status: "active",
+  created_at: now,
+  updated_at: now,
+};
+let deviceStarts = 0;
+let requestCount = 0;
+let importedSnapshot;
+
+const server = createServer(async (request, response) => {
+  requestCount += 1;
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  const body = chunks.length === 0 ? undefined : JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  const send = (status, value, headers = {}) => {
+    response.writeHead(status, { "content-type": "application/json", ...headers });
+    response.end(JSON.stringify(value));
+  };
+
+  if (request.method === "POST" && request.url === "/v1/auth/github/device/start") {
+    deviceStarts += 1;
+    send(200, {
+      device_code: `device-${deviceStarts}`,
+      user_code: `CODE-${deviceStarts}`,
+      verification_uri: "https://github.com/login/device",
+      expires_in: 30,
+      interval: 0.01,
+    });
+    return;
+  }
+  if (request.method === "POST" && request.url === "/v1/auth/github/device/poll") {
+    const userNumber = body.device_code === "device-2" ? 2 : 1;
+    send(200, {
+      status: "complete",
+      token: `token-${userNumber}`,
+      user: {
+        id: `${userNumber}0000000-0000-4000-8000-000000000000`,
+        github_user_id: String(userNumber),
+        github_login: `contributor-${userNumber}`,
+        created_at: now,
+        updated_at: now,
+      },
+    });
+    return;
+  }
+  if (request.method === "GET" && request.url === "/v1/auth/me") {
+    const userNumber = request.headers.authorization === "Bearer token-2" ? 2 : 1;
+    send(200, {
+      user: {
+        id: `${userNumber}0000000-0000-4000-8000-000000000000`,
+        github_user_id: String(userNumber),
+        github_login: `contributor-${userNumber}`,
+        created_at: now,
+        updated_at: now,
+      },
+    });
+    return;
+  }
+  if (request.method === "GET" && request.url === "/v1/repos") {
+    send(200, [managedRepository], { "x-greplica-token": "renewed-token" });
+    return;
+  }
+  if (request.method === "GET" && request.url === `/v1/repos/${managedRepoId}/graph`) {
+    send(200, { components: [], flows: [], claims: [], sources: [], edges: [] }, {
+      "x-greplica-repo-role": managedRepository.effective_role,
+      "x-greplica-access-status": "active",
+    });
+    return;
+  }
+  if (request.method === "POST" && request.url === `/v1/repos/${managedRepoId}/import`) {
+    importedSnapshot = body;
+    send(200, {
+      memory_commit_id: "memory-commit-1",
+      scope_id: "main-scope-1",
+      embedding_status: { checked_objects: 0, created: 0, reused: 0 },
+      created: { components: 0, flows: 0, claims: 0, sources: 0, edges: 0 },
+    }, { "x-greplica-repo-role": "memory_admin", "x-greplica-access-status": "active" });
+    return;
+  }
+  send(404, { message: `Unexpected ${request.method} ${request.url}` });
+});
+
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", resolve);
+});
+
+try {
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const apiUrl = `http://127.0.0.1:${address.port}`;
+  const greplicaHome = join(temporary, "greplica-home");
+  const codexHome = join(temporary, "codex-home");
+  const fakeBin = join(temporary, "bin");
+  const managedRepo = join(temporary, "managed-repo");
+  const localRepo = join(temporary, "local-repo");
+  mkdirSync(fakeBin, { recursive: true });
+  mkdirSync(managedRepo, { recursive: true });
+  mkdirSync(localRepo, { recursive: true });
+  writeFileSync(join(fakeBin, "open"), "#!/bin/sh\nexit 0\n");
+  chmodSync(join(fakeBin, "open"), 0o755);
+  await run("git", ["init", "--quiet"], managedRepo);
+  await run("git", ["init", "--quiet"], localRepo);
+
+  const env = {
+    ...process.env,
+    GREPLICA_HOME: greplicaHome,
+    CODEX_HOME: codexHome,
+    GREPLICA_INSTALL_SKIP_PREWARM: "1",
+    PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+  };
+
+  const login = await run(process.execPath, [cliPath, "login", "--api-url", apiUrl], managedRepo, env);
+  assert.match(login.stdout, /Logged in as contributor-1/);
+  const credentialsPath = join(greplicaHome, "credentials.json");
+  assert.equal(statSync(credentialsPath).mode & 0o777, 0o600);
+
+  const install = await run(process.execPath, [
+    cliPath,
+    "install",
+    "--mode",
+    "managed",
+    "--platform",
+    "codex",
+    "--managed-repo",
+    managedRepoId,
+    "--hooks",
+    "enabled",
+    "--auto-memory",
+    "enabled",
+  ], managedRepo, env);
+  assert.match(install.stdout, /Mode: managed/);
+  assert.match(install.stdout, /reader access records session guidance but does not schedule memory updates/);
+  assert.equal(JSON.parse(readFileSync(credentialsPath, "utf8")).token, "renewed-token");
+
+  const dbPath = join(greplicaHome, "graph.db");
+  let db = new Database(dbPath);
+  let managedRow = db.prepare("SELECT * FROM repos WHERE managed_repo_id = ?").get(managedRepoId);
+  const managedLocalId = managedRow.id;
+  assert.equal(managedRow.active_mode, "managed");
+  assert.equal(managedRow.managed_role, "reader");
+  assert.equal(managedRow.auto_memory_updates, 1);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM graph_scopes WHERE repo_id = ?").get(managedRow.id).count, 0);
+  db.close();
+  const managedGraph = await run(process.execPath, [cliPath, "graph", "read"], managedRepo, env);
+  assert.match(managedGraph.stdout, /Current graph view: main \+ working/);
+
+  const requestsBeforeHook = requestCount;
+  const hook = await run(process.execPath, [cliPath, "hook", "ingest", "--platform", "codex"], managedRepo, env, JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    session_id: "managed-reader-session",
+    transcript_path: join(temporary, "transcript.jsonl"),
+    cwd: managedRepo,
+  }));
+  assert.match(hook.stdout, /Greplica hook guidance/);
+  assert.equal(requestCount, requestsBeforeHook, "foreground hooks must not call the managed API");
+  db = new Database(dbPath);
+  const session = db.prepare("SELECT * FROM agent_sessions WHERE session_id = 'managed-reader-session'").get();
+  assert.equal(session.cwd, managedRepo);
+  assert.equal(session.transcript_path, join(temporary, "transcript.jsonl"));
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM agent_sessions").get().count, 1);
+  db.close();
+
+  const localInstall = await run(process.execPath, [
+    cliPath,
+    "install",
+    "--mode",
+    "local",
+    "--hooks",
+    "disabled",
+  ], localRepo, env);
+  assert.match(localInstall.stdout, /Installed Greplica for Codex/);
+  db = new Database(dbPath);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM repos WHERE active_mode = 'local'").get().count, 1);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM repos WHERE active_mode = 'managed'").get().count, 1);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM graph_scopes").get().count, 2);
+  db.close();
+  const requestsBeforeLocalRead = requestCount;
+  const localGraph = await run(process.execPath, [cliPath, "graph", "read"], localRepo, env);
+  assert.match(localGraph.stdout, /Current graph view: main \+ working/);
+  assert.equal(requestCount, requestsBeforeLocalRead, "local graph commands must not call the managed API");
+
+  managedRepository.effective_role = "memory_admin";
+  const connected = await run(process.execPath, [
+    cliPath,
+    "repo",
+    "connect",
+    "--managed-repo",
+    managedRepoId,
+    "--confirm-mode-switch",
+  ], localRepo, env);
+  assert.match(connected.stdout, /Connected/);
+  const published = await run(process.execPath, [cliPath, "repo", "publish", "--from-local"], localRepo, env);
+  assert.match(published.stdout, /Published one local memory snapshot/);
+  assert.ok(importedSnapshot);
+  assert.deepEqual(importedSnapshot.anchor_audit.result, {
+    missing_anchors: [], missing_files: [], missing_symbols: [], ambiguous_symbols: [], unsupported_languages: [], drifted: [],
+  });
+  assert.deepEqual(importedSnapshot.anchor_audit.fingerprints, {});
+  assert.equal("repo" in importedSnapshot, false);
+  assert.equal("cwd" in importedSnapshot, false);
+  assert.equal("remote_url" in importedSnapshot, false);
+
+  const secondLogin = await run(process.execPath, [cliPath, "login"], managedRepo, env);
+  assert.match(secondLogin.stdout, /Logged in as contributor-2/);
+  db = new Database(dbPath);
+  managedRow = db.prepare("SELECT * FROM repos WHERE id = ?").get(managedLocalId);
+  assert.equal(managedRow.managed_role, null);
+  assert.equal(managedRow.managed_access_status, null);
+  assert.equal(managedRow.auto_memory_updates, 1);
+  db.close();
+
+  await run(process.execPath, [cliPath, "logout"], managedRepo, env);
+  assert.equal(existsSync(credentialsPath), false);
+  console.log("Managed CLI checks passed.");
+} finally {
+  await new Promise((resolve) => server.close(resolve));
+}
+
+function run(command, args, cwd, env = process.env, input = "") {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolve({ stdout, stderr });
+      else reject(new Error(`${command} ${args.join(" ")} failed (${code})\n${stderr}`));
+    });
+    child.stdin.end(input);
+  });
+}

--- a/scripts/check-opencode-sqlite-transcript.js
+++ b/scripts/check-opencode-sqlite-transcript.js
@@ -162,6 +162,9 @@ process.stdout.write('{"type":"done"}\\n');
   });
   runOrThrow([process.execPath, cli, "hook", "ingest", "--platform", "opencode"], workspace, hookInput);
   assert.equal(existsSync(runnerMarker), false, "disabled automatic updates should not spawn a worker");
+  const graphDb = new Database(join(greplicaHome, "graph.db"));
+  graphDb.prepare("UPDATE repos SET auto_memory_updates = 1").run();
+  graphDb.close();
   runOrThrow([process.execPath, cli, "hook", "worker"], workspace);
 
   const args = JSON.parse(readFileSync(runnerMarker, "utf8"));

--- a/scripts/check-repo-installations.js
+++ b/scripts/check-repo-installations.js
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+
+const root = new URL("..", import.meta.url);
+const temporary = mkdtempSync(join(tmpdir(), "greplica-repo-installations-"));
+process.env.GREPLICA_HOME = join(temporary, "home");
+
+const { canonicalRepoKey } = await import(new URL("dist/libs/install/repo-identity.js", root));
+const { RepoInstallationStore } = await import(new URL("dist/libs/install/repo-installation-store.js", root));
+const { LocalAgentRuntimeStore } = await import(new URL("dist/libs/hooks/runtime-store.js", root));
+const { installGreplica } = await import(new URL("dist/libs/install/install.js", root));
+const { ensureGreplicaConfig } = await import(new URL("dist/libs/config/greplica-config.js", root));
+const { openDatabase } = await import(new URL("dist/libs/storage/sqlite/db.js", root));
+const {
+  managedCredentialsPath,
+  managedToken,
+  writeManagedCredentials,
+} = await import(new URL("dist/libs/config/managed-credentials.js", root));
+
+const ssh = canonicalRepoKey({ remote_url: "git@github.com:Autoloops/greplica.git" });
+const https = canonicalRepoKey({ remote_url: "https://github.com/autoloops/greplica.git" });
+const sshUrl = canonicalRepoKey({ remote_url: "ssh://git@github.com/Autoloops/greplica.git" });
+assert.equal(ssh, https);
+assert.equal(https, sshUrl);
+
+const localRepo = repo("local", "git@github.com:Autoloops/greplica.git");
+const sameRemoteClone = repo("clone", "https://github.com/autoloops/greplica.git");
+const managedRepo = repo("managed", "https://github.com/example/managed.git");
+const absentRepo = repo("absent", "https://github.com/example/absent.git");
+const db = openDatabase();
+const installations = new RepoInstallationStore(db);
+const local = installations.activateLocal(localRepo, {
+  hooksEnabled: true,
+  autoMemoryUpdates: true,
+});
+const clone = installations.activateLocal(sameRemoteClone, {
+  hooksEnabled: true,
+  autoMemoryUpdates: true,
+});
+assert.equal(local.id, clone.id, "equivalent remotes must share one installation row");
+
+const managed = installations.activateManaged(managedRepo, {
+  managedRepoId: "managed_repo_1",
+  managedRole: "reader",
+  hooksEnabled: true,
+  autoMemoryUpdates: true,
+});
+assert.equal(managed.activeMode, "managed");
+assert.equal(managed.autoMemoryUpdates, true, "reader installs retain the update preference for later promotion");
+await assert.rejects(installGreplica({
+  mode: "local",
+  platform: "codex",
+  embedding: "local",
+  hooks: false,
+  autoMemoryUpdates: false,
+  repo: managedRepo,
+}), /mode-switch confirmation/);
+assert.equal(db.prepare("SELECT COUNT(*) AS count FROM graph_scopes WHERE repo_id = ?").get(managed.id).count, 0,
+  "a refused mode switch must not create local graph scopes");
+assert.equal(db.prepare("SELECT COUNT(*) AS count FROM repos").get().count, 2);
+assert.equal(db.pragma("journal_mode", { simple: true }), "wal");
+assert.equal(db.pragma("busy_timeout", { simple: true }), 5000);
+
+const runtime = new LocalAgentRuntimeStore(db, {
+  stopThreshold: 1,
+  timeThresholdMinutes: 40,
+  currentGraceMinutes: 5,
+});
+assert.equal(runtime.recordHook({
+  repo: absentRepo,
+  platform: "codex",
+  sessionId: "absent",
+  eventName: "Stop",
+}), undefined);
+assert.equal(db.prepare("SELECT COUNT(*) AS count FROM repos").get().count, 2, "hooks must not create repo rows");
+
+const readerHook = runtime.recordHook({
+  repo: managedRepo,
+  platform: "codex",
+  sessionId: "reader-session",
+  cwd: managedRepo.repo_root,
+  eventName: "Stop",
+});
+assert.ok(readerHook);
+assert.equal(runtime.claimDueMemoryUpdateAttempts().length, 0);
+
+const promotionAt = new Date("2026-07-21T00:00:00.000Z");
+installations.updateManagedAccess("managed_repo_1", "memory_admin", "active", promotionAt);
+const promoted = installations.find(managedRepo);
+assert.equal(promoted.managedRole, "memory_admin");
+assert.equal(runtime.claimDueMemoryUpdateAttempts(promotionAt).length, 0, "promotion starts prior reader sessions fresh");
+assert.equal(
+  db.prepare("SELECT stops_since_memory_current FROM agent_sessions WHERE session_id = 'reader-session'").get().stops_since_memory_current,
+  0,
+  "promotion must start fresh",
+);
+
+assert.throws(
+  () => installations.activateLocal(managedRepo, { hooksEnabled: true, autoMemoryUpdates: true }),
+  /mode-switch confirmation/,
+);
+const switched = installations.activateLocal(managedRepo, {
+  hooksEnabled: true,
+  autoMemoryUpdates: true,
+  allowModeSwitch: true,
+});
+assert.equal(switched.managedRepoId, "managed_repo_1", "mode switches retain managed binding");
+assert.equal(installations.deactivate(managedRepo).status, "inactive");
+db.close();
+
+writeManagedCredentials({
+  version: 1,
+  token: "stored-token",
+  user: { id: "user_1", githubLogin: "octocat", githubUserId: "1" },
+});
+assert.equal(statSync(managedCredentialsPath()).mode & 0o777, 0o600);
+process.env.GREPLICA_MANAGED_TOKEN = "environment-token";
+assert.equal(managedToken(), "environment-token");
+delete process.env.GREPLICA_MANAGED_TOKEN;
+
+checkLegacyActivationMigration();
+checkOldestLegacyActivationMigration();
+checkLegacyConfigMigration();
+console.log("Repository installation checks passed.");
+
+function repo(name, remoteUrl) {
+  const repoRoot = join(temporary, name);
+  mkdirSync(repoRoot, { recursive: true });
+  return { repo_root: repoRoot, remote_url: remoteUrl, repo_name: name, default_branch: "main" };
+}
+
+function checkLegacyActivationMigration() {
+  const path = join(temporary, "legacy.db");
+  const legacy = new Database(path);
+  legacy.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE repos (
+      id TEXT PRIMARY KEY,
+      remote_url TEXT UNIQUE,
+      root_path TEXT UNIQUE,
+      repo_name TEXT NOT NULL,
+      default_branch TEXT NOT NULL
+    );
+    CREATE TABLE graph_scopes (
+      id TEXT PRIMARY KEY,
+      repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+      kind TEXT NOT NULL,
+      name TEXT NOT NULL,
+      parent_scope_id TEXT,
+      ref TEXT,
+      created_at TEXT NOT NULL,
+      UNIQUE(repo_id, kind, name)
+    );
+    INSERT INTO repos VALUES ('repo_active', 'https://github.com/example/active.git', NULL, 'active', 'main');
+    INSERT INTO repos VALUES ('repo_inactive', 'https://github.com/example/inactive.git', NULL, 'inactive', 'main');
+    INSERT INTO graph_scopes VALUES ('scope_active', 'repo_active', 'main', 'main', NULL, 'main', '2026-01-01T00:00:00.000Z');
+  `);
+  legacy.close();
+  const migrated = openDatabase(path);
+  assert.equal(migrated.prepare("SELECT status FROM repos WHERE id = 'repo_active'").get().status, "active");
+  assert.equal(migrated.prepare("SELECT status FROM repos WHERE id = 'repo_inactive'").get().status, "inactive");
+  migrated.close();
+}
+
+function checkOldestLegacyActivationMigration() {
+  const path = join(temporary, "oldest-legacy.db");
+  const legacy = new Database(path);
+  legacy.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE repos (
+      id TEXT PRIMARY KEY,
+      remote_url TEXT NOT NULL UNIQUE,
+      repo_name TEXT NOT NULL,
+      default_branch TEXT NOT NULL
+    );
+    CREATE TABLE graph_scopes (
+      id TEXT PRIMARY KEY,
+      repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+      kind TEXT NOT NULL,
+      name TEXT NOT NULL,
+      parent_scope_id TEXT,
+      ref TEXT,
+      created_at TEXT NOT NULL,
+      UNIQUE(repo_id, kind, name)
+    );
+    INSERT INTO repos VALUES ('repo_active', 'https://github.com/example/oldest.git', 'oldest', 'main');
+    INSERT INTO graph_scopes VALUES ('scope_active', 'repo_active', 'main', 'main', NULL, 'main', '2026-01-01T00:00:00.000Z');
+  `);
+  legacy.close();
+  const migrated = openDatabase(path);
+  assert.equal(migrated.prepare("SELECT status FROM repos WHERE id = 'repo_active'").get().status, "active");
+  migrated.close();
+}
+
+function checkLegacyConfigMigration() {
+  const path = join(temporary, "legacy-config.json");
+  writeFileSync(path, JSON.stringify({
+    version: 1,
+    mode: "managed",
+    embedding: { provider: "openai", model: "text-embedding-3-small", dimensions: 1536, batchSize: 100 },
+    session: { stopThreshold: 9, timeThresholdMinutes: 50, currentGraceMinutes: 6 },
+  }));
+  const config = ensureGreplicaConfig(path);
+  assert.equal(config.version, 2);
+  assert.equal(config.embedding.provider, "openai");
+  assert.equal(config.session.stopThreshold, 9);
+  assert.equal(config.managed.apiUrl, "https://api.greplica.com");
+  const rewritten = JSON.parse(readFileSync(path, "utf8"));
+  assert.equal("mode" in rewritten, false, "global mode is removed during config migration");
+}


### PR DESCRIPTION
## Summary
- make installation mode, status, hooks, and managed bindings repository-scoped in the existing SQLite runtime
- add GitHub-backed managed authentication, organization/repository administration, invitation, publication, and provider routing CLI commands
- add storage-neutral provider/repository contracts, managed wire schemas, strict offline hooks, role caching, and mixed local/managed tests

## Validation
- `npm test`
- `npm audit --omit=dev --audit-level=high`
- live AWS acceptance with local + managed repositories and a read-only guest contributor