### PR TITLE
Document onboarding and release managed CLI 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ greplica graph view
 
 ## Shared Managed Memory
 
-Managed mode lets contributors on different clones and forks query the same repository memory. It requires Greplica `0.1.53` or later and access to a managed Greplica server.
+Managed mode lets contributors on different clones and forks query the same repository memory. It requires Greplica `0.2.0` or later and access to a managed Greplica server.
 
 After an administrator invites your GitHub user to an organization or repository, run:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Does your coding agent spend 5 minutes just grepping around when you give it a c
 
 That's because it is re-learning context. Every new session, your agent wastes tokens and time building context on work it already did. And still misses important facts.
 
-**Greplica** explores your repo structure, code and session transcripts (fully local, no telemetry) to give your agent a persistent, maintained memory it can query before exploring.
+**Greplica** explores your repo structure, code and session transcripts to give your agent a persistent, maintained memory it can query before exploring. Local mode stays fully local with no telemetry; managed mode connects an authorized repository to shared team memory.
 
 ---
 
@@ -36,12 +36,39 @@ Install Greplica for this repo using https://raw.githubusercontent.com/Autoloops
 
 Full prompt: [docs/agent-install-prompt.md](https://raw.githubusercontent.com/Autoloops/greplica/refs/heads/main/docs/agent-install-prompt.md)
 
-That prompt asks a short setup questionnaire, installs Greplica with your chosen hook mode, creates the first saved context from the repo, and can optionally pull durable learnings from recent sessions.
+That prompt asks a short setup questionnaire, installs Greplica in local or managed mode, and either creates the first local context or connects to existing shared memory.
 
 To visualise your current memory in browser, run:
 
 ```bash
 greplica graph view
+```
+
+---
+
+## Shared Managed Memory
+
+Managed mode lets contributors on different clones and forks query the same repository memory. It requires Greplica `0.1.53` or later and access to a managed Greplica server.
+
+After an administrator invites your GitHub user to an organization or repository, run:
+
+```bash
+npm install -g greplica@latest
+cd /path/to/your/repository-or-fork
+greplica login --api-url https://memory.autoloops.ai
+greplica install --mode managed --platform codex
+greplica repo status
+greplica graph context "What should I know before changing this subsystem?"
+```
+
+Replace `codex` with your agent platform. Login uses GitHub's browser device flow; do not share GitHub credentials or Greplica tokens. Interactive install can accept a matching invitation and automatically map a public fork to its upstream namespace. The GitHub App therefore does not need access to each contributor fork.
+
+Organization admins and members inherit read access to every organization repository. Guests can read only explicitly granted repositories. Repository writes always require an explicit `memory_admin` grant; ordinary contributors remain read-only. Managed graph data stays on the server, while local SQLite stores only the repository binding, role cache, hook policy, and runtime session metadata.
+
+Local mode remains independent and does not require login or a server:
+
+```bash
+greplica install --mode local --platform codex --embedding local
 ```
 
 ---
@@ -118,7 +145,12 @@ Current showcase rows:
 ## Commands
 
 ```bash
-greplica install --platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica install --mode local --platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica login [--api-url https://memory.autoloops.ai]
+greplica install --mode managed [--platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity] [--managed-repo <uuid>] [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica logout
+greplica whoami
+greplica repo status
 greplica config
 greplica doctor [--check-embeddings]
 greplica embeddings prewarm
@@ -140,7 +172,8 @@ greplica transcript bundle --platform codex|claude|copilot|opencode --file <path
 - `greplica embeddings prewarm` - downloads and initializes the local embedding model ahead of the first query when local embeddings are configured.
 - `greplica session mark-memory-current` - marks a tracked agent session as already reflected in working memory.
 - `greplica doctor` - verifies installation and diagnoses configuration failures. Not a required preflight before every command.
-- `greplica install` prepares repo state, local storage, and agent integration; normal repo commands require install first.
+- `greplica install` prepares repo state, local storage, and agent integration; normal repo commands require install first. Local and managed mode are selected independently per repository.
+- `greplica login` authenticates managed mode through GitHub and stores the Greplica JWT separately in `~/.greplica/credentials.json`.
 
 For **OpenHands**, install is repo-local: skills are written to `.agents/skills/` and the `UserPromptSubmit`/`Stop` hooks to `.openhands/hooks.json` (Claude/Codex/Copilot install to the agent's home config instead). GitHub Copilot CLI installs personal skills under `~/.copilot/skills` (or `$COPILOT_HOME/skills`) and user hooks under `~/.copilot/hooks/greplica.json`. The hooks inject `graph context` guidance and trigger background working-memory updates; OpenHands must trust the repo hooks for the background save to run.
 

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -2,25 +2,35 @@
 
 `````txt
 Summary of what we are doing:
-- ask a short Greplica setup questionnaire before installing anything
-- install greplica with the selected guidance and memory-update mode
-- create initial memory from the codebase
-- optionally analyze previous sessions
+- ask whether this repository should use local or shared managed memory
+- ask a short Greplica guidance questionnaire before installing anything
+- install greplica with the selected mode and hook behavior
+- create initial memory and optionally analyze previous sessions only in local mode
+- connect read-only contributors to existing team memory in managed mode
 
-Before installing, ask me this short Greplica setup questionnaire. If this agent runtime supports native multiple-choice question UI, use it. Otherwise ask the same questions as plain multiple choice and wait for my answers. Do not run npm install, greplica install, bootstrap, or transcript search until I answer.
+Before installing, ask me this short Greplica setup questionnaire. If this agent runtime supports native multiple-choice question UI, use it. Otherwise ask the same questions as plain multiple choice and wait for my answers. Do not run npm install, greplica login, greplica install, bootstrap, or transcript search until I answer.
+
+Question 0:
+Where should this repository's memory live?
+
+Options:
+1. Local memory (Recommended for personal use)
+   Keep graph memory and embeddings in local SQLite. No login or managed server is required.
+2. Shared managed memory
+   Log in with GitHub and connect this checkout or fork to repository memory shared by an organization. This requires existing access, an invitation, or an accessible listed namespace.
 
 Question 1:
 How should Greplica help agents during future sessions in this repo?
 
 Options:
-1. Guidance + auto-save (Recommended)
-   Install hooks that remind agents to run `greplica graph context` before broad exploration, and automatically try to save useful memory after enough session activity.
+1. Guidance + auto-save when permitted (Recommended)
+   Install hooks that remind agents to run `greplica graph context` before broad exploration, and automatically try to save useful memory after enough session activity when the current repository role can write memory.
 2. Guidance only
    Install hooks only for in-session guidance. Agents get reminded to use `greplica graph context`, but Greplica will not automatically save memory after sessions.
 3. No hooks
    Do not install hooks. Greplica will install normally, but future agents will only use it if you manually add the guidance snippet shown at the end.
 
-Question 2:
+Question 2 (local memory only):
 Should I inspect recent prior sessions for this repo to seed useful Greplica memory?
 
 Options:
@@ -29,27 +39,47 @@ Options:
 2. No, fresh start
    Only create baseline memory from current repo files and skip transcript search.
 
-Map the first answer to install flags exactly:
+If I selected shared managed memory, skip Question 2 because ordinary managed contributors are read-only and should consume the existing shared memory rather than seed it from private sessions.
+
+Map the guidance answer to install flags exactly:
 - Guidance + auto-save: `--hooks enabled --auto-memory enabled`
 - Guidance only: `--hooks enabled --auto-memory disabled`
 - No hooks: `--hooks disabled --auto-memory disabled`
 
-Then run:
+Install the current CLI:
 
 ```bash
 npm install -g greplica
-greplica install --platform <codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity> --embedding local <mapped-hook-and-memory-flags>
 ```
 
 Use the platform matching this agent. Do not manually copy skills. After installation, do not echo the full installer output or repeat its next steps.
 
-Then bootstrap shallow memory for this repo:
+If I selected local memory, run:
+
+```bash
+greplica install --mode local --platform <codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity> --embedding local <mapped-hook-and-memory-flags>
+```
+
+Then follow the local bootstrap and optional transcript instructions below.
+
+If I selected shared managed memory, run:
+
+```bash
+greplica login --api-url https://memory.autoloops.ai
+greplica install --mode managed --platform <codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity> <mapped-hook-and-memory-flags>
+greplica repo status
+greplica graph context "What should I know before working in this repository?"
+```
+
+The login command uses GitHub's browser device flow. Never ask me to paste a password, GitHub token, or Greplica JWT. Let interactive managed installation accept a matching invitation, map a public fork to its upstream namespace, or ask me to select among accessible namespaces. Do not bootstrap, bundle transcripts, validate proposals, apply proposals, publish local memory, or attempt any other memory write unless `greplica repo status` shows an explicit `memory_admin` role and I separately ask for a write. After a successful managed install and context query, skip the local-only instructions below and follow the final answer rules.
+
+For local memory, bootstrap shallow memory for this repo:
 - Prefer using the `greplica-bootstrap` skill.
 - If the skill is not visible until restart, read the installed `greplica-bootstrap/SKILL.md` file and follow it directly.
 - Create, validate, and apply the bootstrap proposal.
 - Keep bootstrap output for the final answer to one line: `Greplica is installed and baseline memory was applied.`
 
-If I chose "Yes, recent sessions", analyze prior sessions:
+If I chose local memory and "Yes, recent sessions", analyze prior sessions:
 - Find recent prior sessions for this same repo and platform, preferring work from the last 1-2 days.
 - Candidate locations: Codex `~/.codex/sessions/**/*.jsonl`; Claude Code `~/.claude/projects/**/*.jsonl`; GitHub Copilot CLI paths from `Stop` hook `transcript_path` values or `$COPILOT_HOME/session-state`; OpenCode `~/.local/share/opencode/storage/session/*.json` with messages under `storage/message/<sessionId>/`.
 - Do not require transcript metadata `cwd` to equal the current checkout path. Users may use worktrees, renamed folders, or multiple checkouts of the same repo.
@@ -64,7 +94,7 @@ greplica transcript bundle --platform <codex-or-claude-or-copilot-or-opencode> -
 
 - Then use the `greplica-fast-session-bootstrap` skill on `<greplica-transcript-backfill.md>` and include its final value summary naturally in the final answer.
 
-If I chose "No, fresh start", skip transcript search entirely.
+If I chose local memory and "No, fresh start", skip transcript search entirely.
 
 If I chose "No hooks", do not edit `AGENTS.md`, `CLAUDE.md`, or any other agent instruction file. Instead, include this manual guidance snippet in the final answer and say I can add it to my agent instruction file if I want future sessions to use Greplica without hooks:
 
@@ -74,10 +104,13 @@ Greplica hook guidance: greplica is a repo-memory search tool for finding releva
 
 Final answer rules:
 - Write like you are updating a human, not filling a template.
-- Start by saying Greplica is installed and baseline memory is ready.
+- For local mode, start by saying Greplica is installed and baseline memory is ready.
+- For managed mode, start by saying Greplica is installed and connected to shared memory, then mention the effective repository role from `greplica repo status`.
+- Mention whether the repository uses local or shared managed memory.
 - Mention the selected guidance/memory-update mode: Guidance + auto-save, Guidance only, or No hooks.
-- If transcript backfill ran, include the `greplica-fast-session-bootstrap` final value summary naturally.
-- If transcript backfill was skipped, say it was skipped because I chose a fresh start.
+- In local mode, if transcript backfill ran, include the `greplica-fast-session-bootstrap` final value summary naturally.
+- In local mode, if transcript backfill was skipped, say it was skipped because I chose a fresh start.
+- In managed mode, do not mention transcript backfill or claim that baseline memory was created; state that the existing shared memory was queried successfully.
 - If hooks were installed, end with a short note that hooks and installed skills might need a restart or trust approval.
 - If hooks were not installed, include the manual guidance snippet and do not tell me to accept hooks.
 - Do not include installer output, selected transcript recap, proposal paths, apply counts, command lists, bundle paths, or a long usage guide unless I ask.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greplica",
-  "version": "0.1.12",
+  "version": "0.1.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greplica",
-      "version": "0.1.12",
+      "version": "0.1.53",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greplica",
-  "version": "0.1.53",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greplica",
-      "version": "0.1.53",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greplica",
-  "version": "0.1.53",
+  "version": "0.2.0",
   "description": "Long-term, searchable AGENTS.md for coding agents.",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greplica",
-  "version": "0.1.12",
+  "version": "0.1.53",
   "description": "Long-term, searchable AGENTS.md for coding agents.",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary
- document local versus shared managed memory onboarding
- teach the agent install prompt not to bootstrap or upload private sessions for managed readers
- prepare npm version 0.2.0, the first managed-enabled CLI release

## Validation
- npm run typecheck
- npm test
- npm pack --dry-run