### PR TITLE
fix(docs): Fix typos and grammar errors in docs and prompt templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Install Greplica for this repo using https://raw.githubusercontent.com/Autoloops
 
 Full prompt: [docs/agent-install-prompt.md](https://raw.githubusercontent.com/Autoloops/greplica/refs/heads/main/docs/agent-install-prompt.md)
 
-That prompt asks a short setup questionnaire, installs Greplica in local or managed mode, and either creates the first local context or connects to existing shared memory.
+That prompt runs a short setup questionnaire, installs Greplica in local or managed mode, and either creates the first local context or connects to existing shared memory.
 
-To visualise your current memory in browser, run:
+To visualize your current memory in a browser, run:
 
 ```bash
 greplica graph view
@@ -167,7 +167,7 @@ greplica transcript bundle --platform codex|claude|copilot|opencode --file <path
 
 - `greplica graph context "<query>"` - returns Markdown for agent use. Add `--debug` for the full retrieval payload with ranking signals.
 - `greplica graph read` - prints the current graph view: all components, flows, claims, sources, and edges in scope.
-- `greplica graph view` to visualise the current memory in a local HTML, opens in your default browser. Use `--out` to choose where the file is written; by default it goes to a temp path.
+- `greplica graph view` to visualize the current memory in a local HTML file, which opens in your default browser. Use `--out` to choose where the file is written; by default it goes to a temp path.
 - `greplica transcript bundle` - converts one or more Codex, Claude Code, GitHub Copilot CLI, or OpenCode transcripts into a sanitized Markdown bundle for `greplica-fast-session-bootstrap`.
 - `greplica embeddings prewarm` - downloads and initializes the local embedding model ahead of the first query when local embeddings are configured.
 - `greplica session mark-memory-current` - marks a tracked agent session as already reflected in working memory.

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -424,7 +424,7 @@ async function runGraphViewCommand(args: string[], getContext: CommandContextPro
   const { repo, service } = getContext();
   const graph = await service.readGraph();
   if (graph.components.length === 0) {
-    console.log("No components to visualise. Bootstrap memory first.");
+    console.log("No components to visualize. Bootstrap memory first.");
     process.exitCode = 1;
     return;
   }

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -3,12 +3,12 @@
 `````txt
 Summary of what we are doing:
 - ask whether this repository should use local or shared managed memory
-- ask a short Greplica guidance questionnaire before installing anything
+- run a short Greplica guidance questionnaire before installing anything
 - install greplica with the selected mode and hook behavior
 - create initial memory and optionally analyze previous sessions only in local mode
 - connect read-only contributors to existing team memory in managed mode
 
-Before installing, ask me this short Greplica setup questionnaire. If this agent runtime supports native multiple-choice question UI, use it. Otherwise ask the same questions as plain multiple choice and wait for my answers. Do not run npm install, greplica login, greplica install, bootstrap, or transcript search until I answer.
+Before installing, walk me through this short Greplica setup questionnaire. If this agent runtime supports native multiple-choice question UI, use it. Otherwise ask the same questions as plain multiple choice and wait for my answers. Do not run npm install, greplica login, greplica install, bootstrap, or transcript search until I answer.
 
 Question 0:
 Where should this repository's memory live?

--- a/scripts/memory-build/prompts/deep-bootstrap.md
+++ b/scripts/memory-build/prompts/deep-bootstrap.md
@@ -111,7 +111,7 @@ For claim `code_anchors`:
 
 - Prefer one anchor per code-verified claim: the stable symbol that best proves the claim.
 - Use two anchors when the claim is explicitly about a cross-boundary behavior.
-- Three anchors is the hard maximum and should be rare.
+- Three anchors are the hard maximum and should be rare.
 - A claim with four or more `code_anchors` is invalid; split it into narrower claims.
 - File-only anchors are acceptable for docs, config, schemas without stable symbols, generated artifacts, or tiny files whose whole content is the relevant unit.
 - Avoid file-only anchors for normal source files.

--- a/scripts/memory-build/prompts/deep-bootstrap.md
+++ b/scripts/memory-build/prompts/deep-bootstrap.md
@@ -111,7 +111,7 @@ For claim `code_anchors`:
 
 - Prefer one anchor per code-verified claim: the stable symbol that best proves the claim.
 - Use two anchors when the claim is explicitly about a cross-boundary behavior.
-- Three anchors are the hard maximum and should be rare.
+- The hard maximum is three anchors, and it should be rare.
 - A claim with four or more `code_anchors` is invalid; split it into narrower claims.
 - File-only anchors are acceptable for docs, config, schemas without stable symbols, generated artifacts, or tiny files whose whole content is the relevant unit.
 - Avoid file-only anchors for normal source files.

--- a/scripts/memory-build/prompts/github-packet-ingest.md
+++ b/scripts/memory-build/prompts/github-packet-ingest.md
@@ -164,7 +164,7 @@ For `code_verified` claims:
 
 - prefer one stable symbol per claim.
 - use two anchors for true cross-boundary facts.
-- three anchors is the hard maximum and should be rare.
+- three anchors are the hard maximum and should be rare.
 - a claim with four or more `code_anchors` is invalid; split it into narrower claims.
 - avoid file-only anchors for normal source files.
 - run `greplica graph audit anchors` after applying a packet when available.

--- a/scripts/memory-build/prompts/github-packet-ingest.md
+++ b/scripts/memory-build/prompts/github-packet-ingest.md
@@ -164,7 +164,7 @@ For `code_verified` claims:
 
 - prefer one stable symbol per claim.
 - use two anchors for true cross-boundary facts.
-- three anchors are the hard maximum and should be rare.
+- the hard maximum is three anchors, and it should be rare.
 - a claim with four or more `code_anchors` is invalid; split it into narrower claims.
 - avoid file-only anchors for normal source files.
 - run `greplica graph audit anchors` after applying a packet when available.

--- a/scripts/memory-build/prompts/layered-deep-bootstrap.md
+++ b/scripts/memory-build/prompts/layered-deep-bootstrap.md
@@ -45,7 +45,7 @@ Use **partial rewalk** when there is no changed-file list or the graph looks sta
 - re-inspect only the highest-value modules and their immediate neighbors
 - avoid creating a second full copy of the whole repo memory
 
-Use **full deep bootstrap** only when the user explicitly asks for a fresh first layer or the existing graph is unusable. That is handled by `greplica-deep-bootstrap`, not this skill.
+Use **full deep bootstrap** only when the user explicitly asks for a fresh first layer or the existing graph is unusable. That is handled by `greplica-deep-bootstrap`, not this prompt.
 
 ## Workflow
 
@@ -97,7 +97,7 @@ Write one proposal per changed module group or cross-cutting flow. Apply each pr
 
 Use existing component and flow IDs when they still represent the same concept. Create new IDs only for genuinely new concepts. When a previous claim is now too broad, incomplete, or stale, create a new claim with `supersedes[]` pointing to the old claim.
 
-Do not copy or recreate the parent graph. The proposal files from this skill should be small deltas that can be applied to the seeded parent graph. The harness may later materialize the current task by copying the parent runtime database and applying this task's proposal manifest.
+Do not copy or recreate the parent graph. The proposal files from this prompt should be small deltas that can be applied to the seeded parent graph. The harness may later materialize the current task by copying the parent runtime database and applying this task's proposal manifest.
 
 Use this proposal shape:
 
@@ -149,13 +149,13 @@ Allowed intent values: `intended`, `accidental`, `unknown`.
 Allowed source kinds: `session`.
 New `code_verified` claims require `code_anchors` with repo-relative `file` and optional `symbol`.
 
-For this skill, code inspection should normally produce source-free `code_verified` claims with `code_anchors`. Do not create session sources for source-code inspection.
+For this prompt, code inspection should normally produce source-free `code_verified` claims with `code_anchors`. Do not create session sources for source-code inspection.
 
 For claim `code_anchors`:
 
 - Prefer one stable symbol per code-verified claim.
 - Use two anchors for real cross-boundary behavior.
-- Three anchors is the hard maximum and should be rare.
+- Three anchors are the hard maximum and should be rare.
 - A claim with four or more `code_anchors` is invalid; split it into narrower claims.
 - File-only anchors are acceptable for docs, config, schemas without symbols, generated artifacts, and tiny whole-file units.
 - Avoid file-only anchors for normal source files.
@@ -191,9 +191,9 @@ When an output directory is available, write a small JSON or Markdown report wit
 
 ## Handoff To GitHub Packet Ingestion
 
-After this skill finishes, the graph should be ready for noisy historical packet ingestion. The packet workflow should then add only source-verified issue/PR context visible before the cutoff and should attach it to the refreshed code components/flows.
+After this prompt finishes, the graph should be ready for noisy historical packet ingestion. The packet workflow should then add only source-verified issue/PR context visible before the cutoff and should attach it to the refreshed code components/flows.
 
-Do not run packet ingestion from this skill unless the user explicitly asks for the separate ingestion step.
+Do not run packet ingestion from this prompt unless the user explicitly asks for the separate ingestion step.
 
 ## Quality Bar
 

--- a/scripts/memory-build/prompts/layered-deep-bootstrap.md
+++ b/scripts/memory-build/prompts/layered-deep-bootstrap.md
@@ -155,7 +155,7 @@ For claim `code_anchors`:
 
 - Prefer one stable symbol per code-verified claim.
 - Use two anchors for real cross-boundary behavior.
-- Three anchors are the hard maximum and should be rare.
+- The hard maximum is three anchors, and it should be rare.
 - A claim with four or more `code_anchors` is invalid; split it into narrower claims.
 - File-only anchors are acceptable for docs, config, schemas without symbols, generated artifacts, and tiny whole-file units.
 - Avoid file-only anchors for normal source files.


### PR DESCRIPTION
## Summary

Fixes #170 

What changes:
1. Unify "visualise" → "visualize" to match the codebase's consistent American spelling elsewhere (normalize, initialize, behavior, etc.), and fix an accompanying missing-article/awkward phrasing issue in README.md
2. Fix "ask a questionnaire" → "run"/"walk me through" a questionnaire in README.md and docs/agent-install-prompt.md
3. Fix subject-verb agreement ("Three anchors is" → "Three anchors are") duplicated verbatim across three scripts/memory-build/prompts/*.md files.
4. Fix layered-deep-bootstrap.md referring to itself as "this skill" (5×) despite stating on line 3 it is not an installable skill — changed to "this prompt"

## Test plan
- [x] Docs-only / string-literal changes, no logic affected

