### PR TITLE
docs: sync README Commands with managed CLI help (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,13 @@ Current showcase rows:
 
 ## Commands
 
+This Commands list is a curated user-facing subset; the full CLI surface is `greplica --help`.
+
 ```bash
 greplica install --mode local --platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
-greplica login [--api-url https://memory.autoloops.ai]
 greplica install --mode managed [--platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity] [--managed-repo <uuid>] [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica uninstall
+greplica login [--api-url https://memory.autoloops.ai]
 greplica logout
 greplica whoami
 greplica repo status
@@ -159,10 +162,45 @@ greplica graph context "<query>" [--debug]
 greplica graph audit anchors
 greplica graph view [--out <file>] [--no-open]
 greplica graph export <dir>
-greplica proposal validate <proposal.json>
-greplica proposal apply <proposal.json>
+greplica proposal validate <file>
+greplica proposal apply <file>
 greplica session mark-memory-current --session-ref <ref>
 greplica transcript bundle --platform codex|claude|copilot|opencode --file <path> [--file <path>...] --out <bundle.md>
+```
+
+### Managed administration
+
+Organization, invitation, and remaining repository administration commands from top-level CLI help:
+
+```bash
+greplica org create --name <name> [--slug <slug>]
+greplica org list
+greplica org invite --org <id> --github-user <login>
+greplica org members --org <id>
+greplica org role --org <id> --user <id> --role admin|member|guest
+greplica org remove-member --org <id> --user <id>
+greplica org leave --org <id>
+greplica invite list
+greplica invite accept <id>
+greplica invite revoke <id>
+greplica repo create --org <id> --name <name>
+greplica repo list
+greplica repo connect --managed-repo <id> [--confirm-mode-switch] [--confirm-rebind]
+greplica repo rebind --managed-repo <id> --confirm-rebind
+greplica repo github-install
+greplica repo enroll-github --org <id> --installation <id> --github-repo <id> [--name <name>]
+greplica repo link-github --installation <id> --github-repo <id>
+greplica repo archive
+greplica repo restore
+greplica repo discovery --discovery listed|unlisted
+greplica repo invite-reader --github-user <login>
+greplica repo grant-memory-admin --user <id>
+greplica repo revoke-memory-admin --user <id>
+greplica repo request-access --managed-repo <id>
+greplica repo access-requests
+greplica repo approve-access --request <id>
+greplica repo deny-access --request <id>
+greplica repo publish --from-local
 ```
 
 - `greplica graph context "<query>"` - returns Markdown for agent use. Add `--debug` for the full retrieval payload with ranking signals.


### PR DESCRIPTION
## Summary

- Sync README Commands with current top-level CLI help for managed-CLI drift beyond #130 (refs #129).
- Add `greplica uninstall`, a **Managed administration** block covering every top-level `org *`, `invite *`, and remaining `repo *` usage string, and a curated-subset note pointing to `greplica --help`.
- Align proposal placeholders with CLI help (`<proposal.json>` → `<file>`). Keep #130 items: `embeddings prewarm`, `session mark-memory-current`, OpenCode in `transcript bundle`.

## Test plan / dry-run evidence

Gates cleared on commit `2ca657c` before opening this PR (iterate-until-green).

### Build + CLI help

```bash
npm ci && npm run build
node dist/apps/cli/main.js --help
```

Transcript:

```
Usage:
  main.js install --mode local|managed [--platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity] [--embedding local|openai] [--managed-repo <id>] [--hooks enabled|disabled] [--auto-memory enabled|disabled]
  main.js uninstall
  main.js repo status
  main.js login [--api-url <url>]
  main.js logout
  main.js whoami
  main.js org create --name <name> [--slug <slug>]
  main.js org list
  main.js org invite --org <id> --github-user <login>
  main.js org members --org <id>
  main.js org role --org <id> --user <id> --role admin|member|guest
  main.js org remove-member --org <id> --user <id>
  main.js org leave --org <id>
  main.js invite list
  main.js invite accept <id>
  main.js invite revoke <id>
  main.js repo create --org <id> --name <name>
  main.js repo list
  main.js repo connect --managed-repo <id> [--confirm-mode-switch] [--confirm-rebind]
  main.js repo rebind --managed-repo <id> --confirm-rebind
  main.js repo github-install
  main.js repo enroll-github --org <id> --installation <id> --github-repo <id> [--name <name>]
  main.js repo link-github --installation <id> --github-repo <id>
  main.js repo archive
  main.js repo restore
  main.js repo discovery --discovery listed|unlisted
  main.js repo invite-reader --github-user <login>
  main.js repo grant-memory-admin --user <id>
  main.js repo revoke-memory-admin --user <id>
  main.js repo request-access --managed-repo <id>
  main.js repo access-requests
  main.js repo approve-access --request <id>
  main.js repo deny-access --request <id>
  main.js repo publish --from-local
  main.js config
  main.js doctor [--check-embeddings]
  main.js embeddings prewarm
  main.js graph read
  main.js graph context <query> [--debug]
  main.js graph audit anchors
  main.js graph export <dir>
  main.js graph view [--out <file>] [--no-open]
  main.js proposal validate <file>
  main.js proposal apply <file>
  main.js session mark-memory-current --session-ref <ref>
  main.js transcript bundle --platform codex|claude|copilot|opencode --file <path> [--file <path>...] --out <bundle.md>
```

### Reviewer checklist (PASS)

| Check | Result |
| --- | --- |
| Every top-level `--help` usage appears in README Commands **or** Managed administration (curated-subset note covers intentional subset framing) | PASS |
| Managed administration block complete (all `org *`, `invite *`, remaining `repo *`) | PASS (28 usage lines) |
| #130 items still present (`embeddings prewarm`, `session mark-memory-current`, OpenCode in transcript bundle) | PASS |
| Proposal placeholders use `<file>`; curated-subset note present | PASS |

## Refs

Closes / addresses managed-CLI docs drift for #129 (original #130 gaps already fixed).

Made with [Cursor](https://cursor.com)