### PR TITLE
Add reusable managed memory invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ greplica repo status
 greplica graph context "What should I know before changing this subsystem?"
 ```
 
+An organization admin can instead create one reusable, repository-scoped reader link from a folder already connected to the memory:
+
+```bash
+greplica repo invite-link create
+```
+
+Give the printed link or command to an agent. It logs in when needed, claims access, installs Greplica, and upgrades local memory to the invited managed memory:
+
+```bash
+greplica install --invite-link <invite-url> --platform codex
+```
+
+The link works for multiple GitHub users until an admin revokes it. Greplica never creates a new managed-memory namespace through this link. When ordinary managed discovery finds no access or invite, creation requires the user to type `create managed memory`; an agent must ask rather than supply that confirmation itself.
+
 Replace `codex` with your agent platform. Login uses GitHub's browser device flow; do not share GitHub credentials or Greplica tokens. Interactive install can accept a matching invitation and automatically map a public fork to its upstream namespace. The GitHub App therefore does not need access to each contributor fork.
 
 Organization admins and members inherit read access to every organization repository. Guests can read only explicitly granted repositories. Repository writes always require an explicit `memory_admin` grant; ordinary contributors remain read-only. Managed graph data stays on the server, while local SQLite stores only the repository binding, role cache, hook policy, and runtime session metadata.
@@ -148,6 +162,9 @@ Current showcase rows:
 greplica install --mode local --platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity --embedding local|openai [--hooks enabled|disabled] [--auto-memory enabled|disabled]
 greplica login [--api-url https://memory.autoloops.ai]
 greplica install --mode managed [--platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity] [--managed-repo <uuid>] [--hooks enabled|disabled] [--auto-memory enabled|disabled]
+greplica install --invite-link <url> --platform codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity
+greplica repo invite-link create|list
+greplica repo invite-link revoke --link <uuid>
 greplica logout
 greplica whoami
 greplica repo status

--- a/apps/cli/main.ts
+++ b/apps/cli/main.ts
@@ -55,6 +55,9 @@ import {
   runRepoGithubInstall,
   runRepoGrantMemoryAdmin,
   runRepoInviteReader,
+  runRepoInviteLinkCreate,
+  runRepoInviteLinkList,
+  runRepoInviteLinkRevoke,
   runRepoLinkGithub,
   runRepoList,
   runRepoPublish,
@@ -93,7 +96,7 @@ const cliCommands = [
   {
     key: "install",
     path: ["install"],
-    usage: `install --mode local|managed [--platform ${installPlatformUsage}] [--embedding local|openai] [--managed-repo <id>] [--hooks enabled|disabled] [--auto-memory enabled|disabled]`,
+    usage: `install [--mode local|managed] [--platform ${installPlatformUsage}] [--embedding local|openai] [--managed-repo <id> | --invite-link <url>] [--hooks enabled|disabled] [--auto-memory enabled|disabled]`,
     handler: runInstallCommand,
     showInTopLevelHelp: true,
   },
@@ -135,6 +138,9 @@ const cliCommands = [
   { key: "repoRestore", path: ["repo", "restore"], usage: "repo restore", handler: runRepoRestore, showInTopLevelHelp: true },
   { key: "repoDiscovery", path: ["repo", "discovery"], usage: "repo discovery --discovery listed|unlisted", handler: runRepoDiscovery, showInTopLevelHelp: true },
   { key: "repoInviteReader", path: ["repo", "invite-reader"], usage: "repo invite-reader --github-user <login>", handler: runRepoInviteReader, showInTopLevelHelp: true },
+  { key: "repoInviteLinkCreate", path: ["repo", "invite-link", "create"], usage: "repo invite-link create", handler: runRepoInviteLinkCreate, showInTopLevelHelp: true },
+  { key: "repoInviteLinkList", path: ["repo", "invite-link", "list"], usage: "repo invite-link list", handler: runRepoInviteLinkList, showInTopLevelHelp: true },
+  { key: "repoInviteLinkRevoke", path: ["repo", "invite-link", "revoke"], usage: "repo invite-link revoke --link <id>", handler: runRepoInviteLinkRevoke, showInTopLevelHelp: true },
   { key: "repoGrantMemoryAdmin", path: ["repo", "grant-memory-admin"], usage: "repo grant-memory-admin --user <id>", handler: runRepoGrantMemoryAdmin, showInTopLevelHelp: true },
   { key: "repoRevokeMemoryAdmin", path: ["repo", "revoke-memory-admin"], usage: "repo revoke-memory-admin --user <id>", handler: runRepoRevokeMemoryAdmin, showInTopLevelHelp: true },
   { key: "repoAccessRequest", path: ["repo", "request-access"], usage: "repo request-access --managed-repo <id>", handler: runRepoAccessRequest, showInTopLevelHelp: true },
@@ -323,7 +329,7 @@ async function runInstallCommand(args: string[]): Promise<void> {
   const options = parseInstallArgs(args);
   const repo = detectRepoContext();
   const managed = options.mode === "managed"
-    ? await resolveManagedInstall(repo, options.managedRepoId)
+    ? await resolveManagedInstall(repo, options.managedRepoId, options.inviteLink)
     : undefined;
   if (managed?.pending === true) return;
   if (options.mode === "managed" && managed?.repository === undefined) {
@@ -778,6 +784,7 @@ function parseInstallArgs(args: string[]): {
   platform?: InstallPlatform;
   embedding?: InstallEmbedding;
   managedRepoId?: string;
+  inviteLink?: string;
   hooks: boolean;
   autoMemoryUpdates: boolean;
   allowModeSwitch: boolean;
@@ -788,6 +795,7 @@ function parseInstallArgs(args: string[]): {
   let platform: InstallPlatform | undefined;
   let embedding: InstallEmbedding | undefined;
   let managedRepoId: string | undefined;
+  let inviteLink: string | undefined;
   let hooks: boolean | undefined;
   let autoMemoryUpdates: boolean | undefined;
   let allowModeSwitch = false;
@@ -834,6 +842,14 @@ function parseInstallArgs(args: string[]): {
       if (arg === "--managed-repo") index += 1;
       continue;
     }
+    if (arg === "--invite-link" || arg.startsWith("--invite-link=")) {
+      if (inviteLink !== undefined) throw new Error(`Specify --invite-link only once.\n${usage("install")}`);
+      inviteLink = arg === "--invite-link"
+        ? requireFlagValue(args, index, "--invite-link")
+        : arg.slice("--invite-link=".length);
+      if (arg === "--invite-link") index += 1;
+      continue;
+    }
     if (arg === "--confirm-mode-switch") {
       allowModeSwitch = true;
       continue;
@@ -867,6 +883,13 @@ function parseInstallArgs(args: string[]): {
     throw new Error(usage("install"));
   }
 
+  if (inviteLink !== undefined && modeSeen && mode === "local") {
+    throw new Error(`--invite-link cannot be used with --mode local.\n${usage("install")}`);
+  }
+  if (inviteLink !== undefined) mode = "managed";
+  if (managedRepoId !== undefined && inviteLink !== undefined) {
+    throw new Error(`--invite-link and --managed-repo are mutually exclusive.\n${usage("install")}`);
+  }
   if (mode === "managed" && embedding !== undefined) {
     throw new Error(`Managed installations do not accept --embedding.\n${usage("install")}`);
   }
@@ -881,9 +904,10 @@ function parseInstallArgs(args: string[]): {
     platform,
     embedding: mode === "local" ? (embedding ?? "local") : undefined,
     managedRepoId,
+    inviteLink,
     hooks: hooks ?? true,
     autoMemoryUpdates: hooks === false ? false : autoMemoryUpdates ?? true,
-    allowModeSwitch,
+    allowModeSwitch: allowModeSwitch || inviteLink !== undefined,
     allowRebind,
   };
 }

--- a/apps/cli/managed-cli.ts
+++ b/apps/cli/managed-cli.ts
@@ -7,6 +7,7 @@ import {
 } from "../../libs/config/managed-credentials.js";
 import {
   ensureGreplicaConfig,
+  managedApiUrl,
   updateManagedApiUrl,
   type GreplicaConfig,
 } from "../../libs/config/greplica-config.js";
@@ -42,7 +43,7 @@ export async function runLogin(args: string[]): Promise<void> {
       interval = poll.interval;
       continue;
     }
-    const previous = readManagedCredentials();
+    const previous = readManagedCredentials(managedApiUrl(config));
     if (previous !== undefined && previous.user.id !== poll.user.id) invalidateRoleCache();
     client.setAuthenticatedUser(poll);
     console.log(`Logged in as ${poll.user.github_login}.`);
@@ -212,6 +213,30 @@ export async function runRepoInviteReader(args: string[]): Promise<void> {
   console.log(`Reader invitation ${invite.id} targets ${invite.target_github_login}.`);
 }
 
+export async function runRepoInviteLinkCreate(args: string[]): Promise<void> {
+  requireNoArgs(args, "Usage: greplica repo invite-link create");
+  const created = await controlClient().createRepoInviteLink(repoBinding().managedRepoId);
+  console.log(`Invite link ${created.link.id}: ${created.claim_url}`);
+  console.log("Give an agent these commands:");
+  console.log("npm install --global greplica@latest");
+  console.log(`greplica install --invite-link ${created.claim_url} --platform codex`);
+}
+
+export async function runRepoInviteLinkList(args: string[]): Promise<void> {
+  requireNoArgs(args, "Usage: greplica repo invite-link list");
+  for (const link of await controlClient().listRepoInviteLinks(repoBinding().managedRepoId)) {
+    console.log(`${link.id}\t${link.status}\t${link.claim_count}\t${link.created_at}`);
+  }
+}
+
+export async function runRepoInviteLinkRevoke(args: string[]): Promise<void> {
+  const link = await controlClient().revokeRepoInviteLink(
+    repoBinding().managedRepoId,
+    required(args, "--link"),
+  );
+  console.log(`Invite link ${link.id} is ${link.status}.`);
+}
+
 export async function runRepoGrantMemoryAdmin(args: string[]): Promise<void> {
   const grant = await controlClient().grantRepoRole(repoBinding().managedRepoId, required(args, "--user"), "memory_admin");
   console.log(`${grant.user.github_login} is now memory_admin for this memory.`);
@@ -276,7 +301,13 @@ export async function runRepoPublish(args: string[]): Promise<void> {
 export async function resolveManagedInstall(
   repo: RepoRef,
   requestedId?: string,
+  inviteLink?: string,
 ): Promise<ManagedInstallResolution> {
+  if (inviteLink !== undefined) {
+    const token = configureInviteLinkApi(inviteLink);
+    await ensureAuthenticated();
+    return { repository: await controlClient().claimRepoInviteLink(token), pending: false };
+  }
   await ensureAuthenticated();
   const client = controlClient();
   const accessible = await client.listRepos();
@@ -295,7 +326,7 @@ export async function resolveManagedInstall(
     throw new Error("Requested managed repository is not accessible.");
   }
 
-  if (!stdin.isTTY) throw new Error("Non-interactive managed installation requires --managed-repo.");
+  if (!stdin.isTTY) throw new Error("Non-interactive managed installation requires --managed-repo or --invite-link.");
   const github = await publicGithubIdentity(repo.remote_url);
   if (github !== undefined) {
     const matches = await client.connectRepos(github.id, github.parentId);
@@ -335,6 +366,13 @@ export async function resolveManagedInstall(
     if (selected !== undefined) return { repository: selected, pending: false };
   }
 
+  console.log("No existing managed memory was selected. An administrator may still provide an invite link later.");
+  console.log("Creating a managed memory makes a new, separate shared namespace; it does not connect to a future invite.");
+  const creationConfirmation = await prompt('Type "create managed memory" only if the user explicitly wants a new memory: ');
+  if (creationConfirmation.toLowerCase() !== "create managed memory") {
+    throw new Error("Managed memory creation was not explicitly confirmed. Ask an administrator for an invite link or invitation.");
+  }
+
   const coordinates = githubCoordinates(repo.remote_url);
   if (coordinates !== undefined && await confirm(`Enroll GitHub memory for ${coordinates.owner}/${coordinates.repo}?`)) {
     const organization = await chooseOrCreateAdminOrganization(client);
@@ -353,6 +391,39 @@ export async function resolveManagedInstall(
     return { repository: await client.createGenericRepo(organization.id, name), pending: false };
   }
   throw new Error("No accessible managed memory was found. Ask an org admin for an invite or enroll a repository.");
+}
+
+function configureInviteLinkApi(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("--invite-link must be a valid Greplica HTTPS invite URL.");
+  }
+  const isLoopback = url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopback)) {
+    throw new Error("--invite-link must use HTTPS; HTTP is allowed only for a loopback development server.");
+  }
+  if (url.username.length > 0 || url.password.length > 0 || url.search.length > 0 || url.hash.length > 0) {
+    throw new Error("--invite-link contains unsupported URL credentials, query parameters, or fragments.");
+  }
+  const match = /^\/join\/([A-Za-z0-9_-]{43})\/?$/.exec(url.pathname);
+  if (match === null) throw new Error("--invite-link is not a valid Greplica invite URL.");
+  const apiUrl = url.origin;
+  const config = ensureGreplicaConfig();
+  const currentApiUrl = managedApiUrl(config);
+  if (process.env.GREPLICA_MANAGED_API_URL !== undefined && currentApiUrl !== apiUrl) {
+    throw new Error(`--invite-link targets ${apiUrl}, but GREPLICA_MANAGED_API_URL is fixed to ${currentApiUrl}.`);
+  }
+  if ((process.env.GREPLICA_MANAGED_TOKEN !== undefined || process.env.GREPLICA_API_TOKEN !== undefined) &&
+      currentApiUrl !== apiUrl) {
+    throw new Error("Cannot switch invite-link origins while a managed API token is supplied through the environment.");
+  }
+  if (currentApiUrl !== apiUrl) {
+    deleteManagedCredentials();
+    updateManagedApiUrl(apiUrl);
+  }
+  return match[1];
 }
 
 function controlClient(config: GreplicaConfig = ensureGreplicaConfig()): ManagedControlClient {

--- a/docs/agent-install-prompt.md
+++ b/docs/agent-install-prompt.md
@@ -71,6 +71,14 @@ greplica repo status
 greplica graph context "What should I know before working in this repository?"
 ```
 
+If I provide a managed-memory invite link, use it directly instead of the separate login and discovery commands:
+
+```bash
+greplica install --invite-link <provided-link> --platform <codex|claude|copilot|cursor|opencode|openhands|factory-droid|antigravity> <mapped-hook-and-memory-flags>
+```
+
+The invite-link command performs GitHub device login when needed, claims access to the existing memory, and upgrades an existing local installation to managed mode. Never substitute a newly created managed memory when an invite may be supplied later. If interactive discovery finds no existing access or invite and the CLI asks to create managed memory, stop and ask me whether I explicitly want a new, separate managed-memory namespace. Do not answer the `create managed memory` confirmation on my behalf.
+
 The login command uses GitHub's browser device flow. Never ask me to paste a password, GitHub token, or Greplica JWT. Let interactive managed installation accept a matching invitation, map a public fork to its upstream namespace, or ask me to select among accessible namespaces. Do not bootstrap, bundle transcripts, validate proposals, apply proposals, publish local memory, or attempt any other memory write unless `greplica repo status` shows an explicit `memory_admin` role and I separately ask for a write. After a successful managed install and context query, skip the local-only instructions below and follow the final answer rules.
 
 For local memory, bootstrap shallow memory for this repo:

--- a/libs/config/managed-credentials.ts
+++ b/libs/config/managed-credentials.ts
@@ -9,7 +9,8 @@ export interface ManagedUserIdentity {
 }
 
 export interface ManagedCredentials {
-  version: 1;
+  version: 2;
+  apiUrl: string;
   token: string;
   user: ManagedUserIdentity;
 }
@@ -18,11 +19,13 @@ export function managedCredentialsPath(): string {
   return join(greplicaHome(), "credentials.json");
 }
 
-export function managedToken(credentials = readManagedCredentials()): string | undefined {
-  return process.env.GREPLICA_MANAGED_TOKEN ?? process.env.GREPLICA_API_TOKEN ?? credentials?.token;
+export function managedToken(apiUrl: string, credentials = readManagedCredentials(apiUrl)): string | undefined {
+  const environmentToken = process.env.GREPLICA_MANAGED_TOKEN ?? process.env.GREPLICA_API_TOKEN;
+  if (environmentToken !== undefined) return environmentToken;
+  return credentials?.apiUrl === normalizeApiUrl(apiUrl) ? credentials.token : undefined;
 }
 
-export function readManagedCredentials(path = managedCredentialsPath()): ManagedCredentials | undefined {
+export function readManagedCredentials(apiUrl?: string, path = managedCredentialsPath()): ManagedCredentials | undefined {
   if (!existsSync(path)) return undefined;
   let parsed: unknown;
   try {
@@ -30,7 +33,9 @@ export function readManagedCredentials(path = managedCredentialsPath()): Managed
   } catch (error: unknown) {
     throw new Error(`Invalid Greplica credentials at ${path}: ${error instanceof Error ? error.message : String(error)}`);
   }
-  if (!isRecord(parsed) || parsed.version !== 1 || typeof parsed.token !== "string" || !isRecord(parsed.user)) {
+  if (!isRecord(parsed) || (parsed.version !== 1 && parsed.version !== 2) ||
+      typeof parsed.token !== "string" || !isRecord(parsed.user) ||
+      (parsed.version === 2 && typeof parsed.apiUrl !== "string")) {
     throw new Error(`Invalid Greplica credentials at ${path}.`);
   }
   if (
@@ -41,7 +46,10 @@ export function readManagedCredentials(path = managedCredentialsPath()): Managed
     throw new Error(`Invalid Greplica credentials at ${path}.`);
   }
   return {
-    version: 1,
+    version: 2,
+    apiUrl: parsed.version === 2 && typeof parsed.apiUrl === "string"
+      ? normalizeApiUrl(parsed.apiUrl)
+      : normalizeApiUrl(apiUrl ?? ""),
     token: parsed.token,
     user: {
       id: parsed.user.id,
@@ -70,4 +78,8 @@ export function deleteManagedCredentials(path = managedCredentialsPath()): void 
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeApiUrl(apiUrl: string): string {
+  return apiUrl.trim().replace(/\/+$/, "");
 }

--- a/libs/knowledge-graph/provider-factory.ts
+++ b/libs/knowledge-graph/provider-factory.ts
@@ -23,11 +23,12 @@ export function createGraphMemoryProvider(repo: RepoRef, config: GreplicaConfig)
   }
 
   db.close();
-  const credentials = readManagedCredentials();
-  const token = managedToken(credentials);
+  const apiUrl = managedApiUrl(config);
+  const credentials = readManagedCredentials(apiUrl);
+  const token = managedToken(apiUrl, credentials);
   if (token === undefined) throw new Error("Managed Greplica is not authenticated. Run 'greplica login'.");
   return new ManagedGraphMemoryClient(installation, repo, {
-    apiUrl: managedApiUrl(config),
+    apiUrl,
     token,
     credentials,
   });

--- a/libs/managed/control-client.ts
+++ b/libs/managed/control-client.ts
@@ -14,6 +14,8 @@ import type {
   ManagedOrganization,
   ManagedOrgMembership,
   ManagedRepository,
+  ManagedRepoInviteLink,
+  ManagedRepoInviteLinkCreated,
   ManagedRepoGrant,
   ManagedUser,
 } from "./protocol.js";
@@ -40,8 +42,8 @@ export class ManagedControlClient {
     private readonly fetchImpl: typeof fetch = fetch,
   ) {
     this.apiUrl = managedApiUrl(config);
-    this.credentials = readManagedCredentials();
-    this.token = managedToken(this.credentials);
+    this.credentials = readManagedCredentials(this.apiUrl);
+    this.token = managedToken(this.apiUrl, this.credentials);
   }
 
   startDeviceLogin(): Promise<DeviceLoginStart> {
@@ -163,6 +165,28 @@ export class ManagedControlClient {
     return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/invites`, { github_user: githubUser }, true, repoId);
   }
 
+  createRepoInviteLink(repoId: string): Promise<ManagedRepoInviteLinkCreated> {
+    return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/invite-links`, {}, true, repoId);
+  }
+
+  listRepoInviteLinks(repoId: string): Promise<ManagedRepoInviteLink[]> {
+    return this.request("GET", `/v1/repos/${encodeURIComponent(repoId)}/invite-links`, undefined, true, repoId);
+  }
+
+  revokeRepoInviteLink(repoId: string, linkId: string): Promise<ManagedRepoInviteLink> {
+    return this.request(
+      "POST",
+      `/v1/repos/${encodeURIComponent(repoId)}/invite-links/${encodeURIComponent(linkId)}/revoke`,
+      {},
+      true,
+      repoId,
+    );
+  }
+
+  claimRepoInviteLink(token: string): Promise<ManagedRepository> {
+    return this.request("POST", "/v1/invite-links/claim", { token });
+  }
+
   grantRepoRole(repoId: string, userId: string, role: "reader" | "memory_admin"): Promise<ManagedRepoGrant> {
     return this.request("POST", `/v1/repos/${encodeURIComponent(repoId)}/grants`, { user_id: userId, role }, true, repoId);
   }
@@ -214,7 +238,8 @@ export class ManagedControlClient {
   setAuthenticatedUser(result: Extract<DeviceLoginPoll, { status: "complete" }>): void {
     this.token = result.token;
     this.credentials = {
-      version: 1,
+      version: 2,
+      apiUrl: this.apiUrl,
       token: result.token,
       user: {
         id: result.user.id,

--- a/libs/managed/protocol.ts
+++ b/libs/managed/protocol.ts
@@ -75,6 +75,21 @@ export const InvitationSchema = Type.Object({
   revoked_at: Type.Optional(Type.String({ format: "date-time" })),
 });
 
+export const RepoInviteLinkSchema = Type.Object({
+  id: Type.String({ format: "uuid" }),
+  repo_id: Type.String({ format: "uuid" }),
+  status: Type.Union([Type.Literal("active"), Type.Literal("revoked")]),
+  created_by: Type.String({ format: "uuid" }),
+  created_at: Type.String({ format: "date-time" }),
+  revoked_at: Type.Optional(Type.String({ format: "date-time" })),
+  claim_count: Type.Integer({ minimum: 0 }),
+});
+
+export const RepoInviteLinkCreatedSchema = Type.Object({
+  link: RepoInviteLinkSchema,
+  claim_url: Type.String(),
+});
+
 export const GithubSourceSchema = Type.Object({
   repository_id: Type.String(),
   owner: Type.String(),
@@ -450,6 +465,10 @@ export const routeSchemas = {
   repoArchive: route(Type.Object({}), ManagedRepositorySchema),
   repoRestore: route(Type.Object({}), ManagedRepositorySchema),
   repoInvite: route(Type.Object({ github_user: Type.String({ minLength: 1 }) }), InvitationSchema),
+  repoInviteLinkCreate: route(Type.Object({}), RepoInviteLinkCreatedSchema),
+  repoInviteLinkList: route(Type.Object({}), Type.Array(RepoInviteLinkSchema)),
+  repoInviteLinkRevoke: route(Type.Object({}), RepoInviteLinkSchema),
+  repoInviteLinkClaim: route(Type.Object({ token: Type.String({ minLength: 43, maxLength: 43 }) }), ManagedRepositorySchema),
   repoGrant: route(Type.Object({ user_id: Type.String({ format: "uuid" }), role: RepoRoleSchema }), RepoGrantSchema),
   repoRevokeGrant: route(Type.Object({ user_id: Type.String({ format: "uuid" }), role: RepoRoleSchema }), Type.Object({ revoked: Type.Boolean() })),
   accessRequestCreate: route(Type.Object({}), AccessRequestSchema),
@@ -480,6 +499,8 @@ export type ManagedUser = Static<typeof UserSchema>;
 export type ManagedOrganization = Static<typeof OrganizationSchema>;
 export type ManagedOrgMembership = Static<typeof OrgMembershipSchema>;
 export type ManagedInvitation = Static<typeof InvitationSchema>;
+export type ManagedRepoInviteLink = Static<typeof RepoInviteLinkSchema>;
+export type ManagedRepoInviteLinkCreated = Static<typeof RepoInviteLinkCreatedSchema>;
 export type ManagedRepository = Static<typeof ManagedRepositorySchema>;
 export type ManagedRepoGrant = Static<typeof RepoGrantSchema>;
 export type ManagedAccessRequest = Static<typeof AccessRequestSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "greplica",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "greplica",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -90,19 +90,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -112,19 +112,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -138,9 +157,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -154,9 +173,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -170,9 +189,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -186,9 +205,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -202,9 +221,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -218,9 +237,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -234,9 +253,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -250,9 +269,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -266,9 +285,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -282,9 +301,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -294,19 +313,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -316,19 +335,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -338,19 +357,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -360,19 +379,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -382,19 +401,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -404,19 +423,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -426,19 +445,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -448,38 +467,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -489,16 +524,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -508,16 +543,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -527,7 +562,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1251,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1284,47 +1319,52 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/simple-concat": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greplica",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Long-term, searchable AGENTS.md for coding agents.",
   "license": "MIT",
   "private": false,
@@ -80,6 +80,7 @@
   },
   "overrides": {
     "adm-zip": "0.6.0",
-    "protobufjs": "^7.6.5"
+    "protobufjs": "^7.6.5",
+    "sharp": "^0.35.3"
   }
 }

--- a/scripts/check-managed-cli.js
+++ b/scripts/check-managed-cli.js
@@ -12,6 +12,8 @@ const cliPath = fileURLToPath(new URL("dist/apps/cli/main.js", root));
 const temporary = mkdtempSync(join(tmpdir(), "greplica-managed-cli-"));
 const managedRepoId = "11111111-1111-4111-8111-111111111111";
 const orgId = "22222222-2222-4222-8222-222222222222";
+const inviteLinkId = "33333333-3333-4333-8333-333333333333";
+const inviteToken = "a".repeat(43);
 const now = "2026-07-21T00:00:00.000Z";
 const managedRepository = {
   id: managedRepoId,
@@ -81,6 +83,48 @@ const server = createServer(async (request, response) => {
     send(200, [managedRepository], { "x-greplica-token": "renewed-token" });
     return;
   }
+  if (request.method === "POST" && request.url === "/v1/invite-links/claim") {
+    assert.equal(body.token, inviteToken);
+    send(200, managedRepository);
+    return;
+  }
+  if (request.method === "POST" && request.url === `/v1/repos/${managedRepoId}/invite-links`) {
+    send(200, {
+      link: {
+        id: inviteLinkId,
+        repo_id: managedRepoId,
+        status: "active",
+        created_by: "10000000-0000-4000-8000-000000000000",
+        created_at: now,
+        claim_count: 0,
+      },
+      claim_url: `http://127.0.0.1:${server.address().port}/join/${inviteToken}`,
+    });
+    return;
+  }
+  if (request.method === "GET" && request.url === `/v1/repos/${managedRepoId}/invite-links`) {
+    send(200, [{
+      id: inviteLinkId,
+      repo_id: managedRepoId,
+      status: "active",
+      created_by: "10000000-0000-4000-8000-000000000000",
+      created_at: now,
+      claim_count: 1,
+    }]);
+    return;
+  }
+  if (request.method === "POST" && request.url === `/v1/repos/${managedRepoId}/invite-links/${inviteLinkId}/revoke`) {
+    send(200, {
+      id: inviteLinkId,
+      repo_id: managedRepoId,
+      status: "revoked",
+      created_by: "10000000-0000-4000-8000-000000000000",
+      created_at: now,
+      revoked_at: now,
+      claim_count: 1,
+    });
+    return;
+  }
   if (request.method === "GET" && request.url === `/v1/repos/${managedRepoId}/graph`) {
     send(200, { components: [], flows: [], claims: [], sources: [], edges: [] }, {
       "x-greplica-repo-role": managedRepository.effective_role,
@@ -115,13 +159,19 @@ try {
   const fakeBin = join(temporary, "bin");
   const managedRepo = join(temporary, "managed-repo");
   const localRepo = join(temporary, "local-repo");
+  const agentRepo = join(temporary, "agent-repo");
+  const upgradeRepo = join(temporary, "upgrade-repo");
   mkdirSync(fakeBin, { recursive: true });
   mkdirSync(managedRepo, { recursive: true });
   mkdirSync(localRepo, { recursive: true });
+  mkdirSync(agentRepo, { recursive: true });
+  mkdirSync(upgradeRepo, { recursive: true });
   writeFileSync(join(fakeBin, "open"), "#!/bin/sh\nexit 0\n");
   chmodSync(join(fakeBin, "open"), 0o755);
   await run("git", ["init", "--quiet"], managedRepo);
   await run("git", ["init", "--quiet"], localRepo);
+  await run("git", ["init", "--quiet"], agentRepo);
+  await run("git", ["init", "--quiet"], upgradeRepo);
 
   const env = {
     ...process.env,
@@ -134,7 +184,10 @@ try {
   const login = await run(process.execPath, [cliPath, "login", "--api-url", apiUrl], managedRepo, env);
   assert.match(login.stdout, /Logged in as contributor-1/);
   const credentialsPath = join(greplicaHome, "credentials.json");
+  const dbPath = join(greplicaHome, "graph.db");
+  let db;
   assert.equal(statSync(credentialsPath).mode & 0o777, 0o600);
+  assert.equal(JSON.parse(readFileSync(credentialsPath, "utf8")).apiUrl, apiUrl);
 
   const install = await run(process.execPath, [
     cliPath,
@@ -154,8 +207,31 @@ try {
   assert.match(install.stdout, /reader access records session guidance but does not schedule memory updates/);
   assert.equal(JSON.parse(readFileSync(credentialsPath, "utf8")).token, "renewed-token");
 
-  const dbPath = join(greplicaHome, "graph.db");
-  let db = new Database(dbPath);
+  const createdLink = await run(process.execPath, [cliPath, "repo", "invite-link", "create"], managedRepo, env);
+  assert.match(createdLink.stdout, /npm install --global greplica@latest/);
+  assert.match(createdLink.stdout, new RegExp(`greplica install --invite-link ${apiUrl}/join/${inviteToken} --platform codex`));
+  const listedLinks = await run(process.execPath, [cliPath, "repo", "invite-link", "list"], managedRepo, env);
+  assert.match(listedLinks.stdout, new RegExp(`${inviteLinkId}\\s+active\\s+1`));
+  assert.equal(listedLinks.stdout.includes(inviteToken), false, "list output must not expose the invite token");
+  const revokedLink = await run(process.execPath, [
+    cliPath, "repo", "invite-link", "revoke", "--link", inviteLinkId,
+  ], managedRepo, env);
+  assert.match(revokedLink.stdout, /is revoked/);
+
+  const agentInstall = await run(process.execPath, [
+    cliPath,
+    "install",
+    "--invite-link",
+    `${apiUrl}/join/${inviteToken}`,
+    "--platform",
+    "codex",
+  ], agentRepo, env);
+  assert.match(agentInstall.stdout, /Mode: managed/);
+  db = new Database(dbPath);
+  assert.equal(db.prepare("SELECT active_mode FROM repos WHERE repo_name = 'agent-repo'").get().active_mode, "managed");
+  db.close();
+
+  db = new Database(dbPath);
   let managedRow = db.prepare("SELECT * FROM repos WHERE managed_repo_id = ?").get(managedRepoId);
   const managedLocalId = managedRow.id;
   assert.equal(managedRow.active_mode, "managed");
@@ -193,13 +269,32 @@ try {
   assert.match(localInstall.stdout, /Installed Greplica for Codex/);
   db = new Database(dbPath);
   assert.equal(db.prepare("SELECT COUNT(*) AS count FROM repos WHERE active_mode = 'local'").get().count, 1);
-  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM repos WHERE active_mode = 'managed'").get().count, 1);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM repos WHERE active_mode = 'managed'").get().count, 2);
   assert.equal(db.prepare("SELECT COUNT(*) AS count FROM graph_scopes").get().count, 2);
   db.close();
   const requestsBeforeLocalRead = requestCount;
   const localGraph = await run(process.execPath, [cliPath, "graph", "read"], localRepo, env);
   assert.match(localGraph.stdout, /Current graph view: main \+ working/);
   assert.equal(requestCount, requestsBeforeLocalRead, "local graph commands must not call the managed API");
+
+  await run(process.execPath, [cliPath, "install", "--mode", "local", "--platform", "codex"], upgradeRepo, env);
+  const upgradedByInvite = await run(process.execPath, [
+    cliPath,
+    "install",
+    "--invite-link",
+    `${apiUrl}/join/${inviteToken}`,
+    "--platform",
+    "codex",
+  ], upgradeRepo, env);
+  assert.match(upgradedByInvite.stdout, /Mode: managed/);
+  db = new Database(dbPath);
+  assert.equal(db.prepare("SELECT active_mode FROM repos WHERE repo_name = 'upgrade-repo'").get().active_mode, "managed");
+  db.close();
+
+  const insecureInvite = await runFailure(process.execPath, [
+    cliPath, "install", "--invite-link", `http://memory.example.com/join/${inviteToken}`, "--platform", "codex",
+  ], agentRepo, env);
+  assert.match(insecureInvite.stderr, /must use HTTPS/);
 
   managedRepository.effective_role = "memory_admin";
   const connected = await run(process.execPath, [
@@ -231,6 +326,28 @@ try {
   assert.equal(managedRow.auto_memory_updates, 1);
   db.close();
 
+  const environmentTokenSwitch = await runFailure(process.execPath, [
+    cliPath,
+    "install",
+    "--invite-link",
+    `http://127.0.0.1:1/join/${inviteToken}`,
+    "--platform",
+    "codex",
+  ], agentRepo, { ...env, GREPLICA_MANAGED_TOKEN: "environment-token" });
+  assert.match(environmentTokenSwitch.stderr, /Cannot switch invite-link origins/);
+  assert.equal(existsSync(credentialsPath), true, "a rejected environment-token switch must not alter credentials");
+
+  const crossOrigin = await runFailure(process.execPath, [
+    cliPath,
+    "install",
+    "--invite-link",
+    `http://127.0.0.1:1/join/${inviteToken}`,
+    "--platform",
+    "codex",
+  ], agentRepo, env);
+  assert.match(crossOrigin.stderr, /fetch failed|connect/i);
+  assert.equal(existsSync(credentialsPath), false, "switching invite origins must discard credentials before network access");
+
   await run(process.execPath, [cliPath, "logout"], managedRepo, env);
   assert.equal(existsSync(credentialsPath), false);
   console.log("Managed CLI checks passed.");
@@ -251,6 +368,24 @@ function run(command, args, cwd, env = process.env, input = "") {
     child.once("close", (code) => {
       if (code === 0) resolve({ stdout, stderr });
       else reject(new Error(`${command} ${args.join(" ")} failed (${code})\n${stderr}`));
+    });
+    child.stdin.end(input);
+  });
+}
+
+function runFailure(command, args, cwd, env = process.env, input = "") {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code !== 0) resolve({ stdout, stderr, code });
+      else reject(new Error(`${command} ${args.join(" ")} unexpectedly succeeded`));
     });
     child.stdin.end(input);
   });


### PR DESCRIPTION
## Summary
- add reusable, revocable repository-scoped managed-memory invite links
- let agents install or upgrade with one invite-link command while preserving rebind safeguards
- bind saved credentials to API origins and require explicit user confirmation before creating new managed memory
- release as 0.2.1 and override sharp 0.35.3 to clear the current high-severity audit advisory

## Verification
- npm test
- npm audit --omit=dev --audit-level=high
- npm pack --dry-run