### PR TITLE
Enable scheduled managed memory reconciliation

### DIFF
--- a/.github/workflows/managed-memory.yml
+++ b/.github/workflows/managed-memory.yml
@@ -1,0 +1,23 @@
+name: Managed Greplica memory
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  reconcile-memory:
+    permissions:
+      contents: read
+      id-token: write
+    uses: Autoloops/greplica/.github/workflows/reconcile.yml@0725bf1e5094935ed8ae843e60d638ff40983767
+    with:
+      managed-repo: 9731ebad-16c5-403c-a28f-a68b0be0f774
+      merge-sha: ${{ github.sha }}


### PR DESCRIPTION
## What changed

Adds the repository-side caller for the already-merged immutable managed reconciliation workflow.

- runs on every push to main
- runs hourly for matching, retries, and freshness check-ins
- supports manual dispatch
- grants only contents read and GitHub OIDC token minting
- pins the reusable workflow to 0725bf1e5094935ed8ae843e60d638ff40983767
- binds the managed repository UUID and exact github.sha
- requires no repository or model secret

## Rollout gate

Do not merge this PR until the managed epoch-1 API is deployed. Its first main-branch run should target the new OIDC reconciliation endpoints, not the current epoch-0 service.