### PR TITLE
docs: fix expired Discord invite in README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img alt="Agents" src="https://img.shields.io/badge/agents-Codex%20%7C%20Claude%20Code-2563eb">
   <img alt="Storage" src="https://img.shields.io/badge/storage-local%20SQLite-475569">
   <img alt="Embeddings" src="https://img.shields.io/badge/embeddings-local%20%7C%20OpenAI-16a34a">
-  <a href="https://discord.gg/q2R6AYXh9"><img alt="Discord" src="https://img.shields.io/badge/discord-join-5865F2"></a>
+  <a href="https://discord.gg/eNXJwHwYk8"><img alt="Discord" src="https://img.shields.io/badge/discord-join-5865F2"></a>
 </p>
 
 </div>


### PR DESCRIPTION
The Discord badge in the README links to `https://discord.gg/q2R6AYXh9`, which Discord reports as expired:

```
$ curl -s https://discord.com/api/v10/invites/q2R6AYXh9
{"message": "Invite is expired.", "code": 50270}   # HTTP 404
```

So anyone clicking through from GitHub lands on a dead invite.

This swaps in the invite currently published on autoloops.ai/greplica, which resolves to the same **Greplica** guild (`1514612226403864638`) and returns `"expires_at": null`, so it should not lapse again:

```
$ curl -s "https://discord.com/api/v10/invites/eNXJwHwYk8?with_counts=true"
{"code":"eNXJwHwYk8", ... "expires_at":null, "guild":{"name":"Greplica", ...}}   # HTTP 200
```

One-line README change, no code touched. Happy to use a different permanent invite if you would rather generate a fresh one.